### PR TITLE
fix(example): use correct model

### DIFF
--- a/examples/audio-text-to-speech/main.go
+++ b/examples/audio-text-to-speech/main.go
@@ -13,7 +13,7 @@ func main() {
 	ctx := context.Background()
 
 	res, err := client.Audio.Speech.New(ctx, openai.AudioSpeechNewParams{
-		Model:          openai.F(openai.AudioModelWhisper1),
+		Model:          openai.F(openai.SpeechModelTTS1),
 		Input:          openai.String(`Why did the chicken cross the road? To get to the other side.`),
 		ResponseFormat: openai.F(openai.AudioSpeechNewParamsResponseFormatPCM),
 		Voice:          openai.F(openai.AudioSpeechNewParamsVoiceAlloy),


### PR DESCRIPTION
Correct example to fix #85
