### PR TITLE
Correctly set Accept header to text/event-stream for completion streaming

### DIFF
--- a/completion.go
+++ b/completion.go
@@ -47,7 +47,12 @@ func (r *CompletionService) NewStreaming(ctx context.Context, body CompletionNew
 		err error
 	)
 	opts = append(r.Options[:], opts...)
-	opts = append([]option.RequestOption{option.WithJSONSet("stream", true)}, opts...)
+	opts = append(opts,
+		option.WithJSONSet("stream", true),
+		// Streaming response returns a text/event-stream content type. To comply with
+		// the SSE spec, we need to set the Accept header to text/event-stream explicitly.
+		option.WithHeader("Accept", "text/event-stream"),
+	)
 	path := "completions"
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &raw, opts...)
 	return ssestream.NewStream[Completion](ssestream.NewDecoder(raw), err)


### PR DESCRIPTION
Previously, the standard Accept header was set to `application/json` unconditionally.
However, streaming response returns `content-type: text/event-stream` following
the specification of server-sent-events.

This correctly sets the Accept header to it accordingly in order to comply with the
standard. The exact same problem exists in other SDKS (e.g. https://github.com/openai/openai-node/issues/375, https://github.com/openai/openai-python/pull/1815)