### PR TITLE
Set the 'Include Usage' parameter under 'Stream Options' to true in the 'chat-completion-accumulating' example

### DIFF
--- a/examples/chat-completion-accumulating/main.go
+++ b/examples/chat-completion-accumulating/main.go
@@ -28,6 +28,9 @@ func main() {
 		Seed:     openai.Int(0),
 		Model:    openai.ChatModelGPT4o,
 		Tools:    tools,
+		StreamOptions: openai.ChatCompletionStreamOptionsParam{
+			IncludeUsage: openai.Bool(true),
+		},
 	}
 
 	stream := client.Chat.Completions.NewStreaming(ctx, params)


### PR DESCRIPTION
### Summary
This pull request adds the missing`StreamOptions.IncludeUsage` option in the example code that should be set to `true` to retrieve accurate token usage information from the API. Without this parameter, the example currently returns a token usage of 0.

### Changes Made
- Updated the relevant example request options to include the missing parameter with a value of `true`.

### Issue Reference
Fixes #124 

### Testing
- Ran the example after adding the parameter and confirmed that token usage is now reported accurately.

### Additional Context
This change ensures users get accurate usage data when using the example code.