### PR TITLE
streaming: fix reading the last empty chunk

### DIFF
--- a/packages/ssestream/streaming.go
+++ b/packages/ssestream/streaming.go
@@ -143,7 +143,7 @@ func (s *Stream[T]) Next() bool {
 
 		if bytes.HasPrefix(s.decoder.Event().Data, []byte("[DONE]")) {
 			s.done = true
-			return false
+			continue
 		}
 
 		if s.decoder.Event().Type == "" {


### PR DESCRIPTION
Hello! We built a small, straightforward LLM benchmarking tool in Go that sends a large number of concurrent requests through a single openai client. 

**Issue:**

We noticed that connections were repeatedly being re-created instead of reused. By limiting the client to a single connection per host, we discovered that the connection was hanging because the final chunk in a chunked response `"0\r\n\r\n"` was never read. 


Returning false at that moment prevents the last chunk from being processed properly, causing the body to not be properly closed. This fix corrects that typo, ensuring the final chunk is consumed and allowing connections to be reused as intended.