### PR TITLE
Minor text change: Update readme to say beta instead of alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <a href="https://pkg.go.dev/github.com/openai/openai-go"><img src="https://pkg.go.dev/badge/github.com/openai/openai-go.svg" alt="Go Reference"></a>
 
 > [!WARNING]
-> **This release is currently in alpha**. Minor breaking changes may occur.
+> **This release is currently in beta**. Minor breaking changes may occur.
 
 The OpenAI Go library provides convenient access to [the OpenAI REST
 API](https://platform.openai.com/docs) from applications written in Go. The full API of this library can be found in [api.md](api.md).


### PR DESCRIPTION
Readme currently says this library is in alpha while beta was announced in December in the official OpenAI guidance [here](https://platform.openai.com/docs/libraries#official-rest-api-libraries)