### PR TITLE
fix(stream): ensure .Close() doesn't panic

### DIFF
--- a/packages/ssestream/ssestream.go
+++ b/packages/ssestream/ssestream.go
@@ -171,5 +171,8 @@ func (s *Stream[T]) Err() error {
 }
 
 func (s *Stream[T]) Close() error {
+	if s.decoder == nil {
+		return nil
+	}
 	return s.decoder.Close()
 }


### PR DESCRIPTION
If a network anomaly occurs,directly calling the Close method will panic. Therefore,it is necessary to add a check in the Close method to determine whether the decoder is nil.