### PR TITLE
Use interface for HTTP client

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,8 +635,8 @@ multiple times, for example first in the client then the method, the
 middleware in the client will run first and the middleware given in the method
 will run next.
 
-You may also replace the default `http.Client` with
-`option.WithHTTPClient(client)`. Only one http client is
+You may also replace the default HTTP client with
+`option.WithHTTPClient(client)`. Only one HTTP client is
 accepted (this overwrites any previous client) and receives requests after any
 middleware has been applied.
 

--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -183,7 +183,7 @@ type RequestConfig struct {
 	Context        context.Context
 	Request        *http.Request
 	BaseURL        *url.URL
-	HTTPClient     *http.Client
+	HTTPClient     httpclient
 	Middlewares    []middleware
 	APIKey         string
 	Organization   string
@@ -196,6 +196,12 @@ type RequestConfig struct {
 	// given address
 	ResponseInto **http.Response
 	Body         io.Reader
+}
+
+// httpclient is exactly the same type as the HTTPClient type found in the [option] package,
+// but it is redeclared here for circular dependency issues.
+type httpclient interface {
+	Do(*http.Request) (*http.Response, error)
 }
 
 // middleware is exactly the same type as the Middleware type found in the [option] package,

--- a/option/requestoption.go
+++ b/option/requestoption.go
@@ -34,9 +34,13 @@ func WithBaseURL(base string) RequestOption {
 	}
 }
 
-// WithHTTPClient returns a RequestOption that changes the underlying [http.Client] used to make this
+type HTTPClient interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+// WithHTTPClient returns a RequestOption that changes the underlying [HTTPClient] used to make this
 // request, which by default is [http.DefaultClient].
-func WithHTTPClient(client *http.Client) RequestOption {
+func WithHTTPClient(client HTTPClient) RequestOption {
 	return func(r *requestconfig.RequestConfig) error {
 		r.HTTPClient = client
 		return nil


### PR DESCRIPTION
This allows users to pass in their own HTTP client implementations that satisfy the SDK's `HTTPClient` interface.
Closes #233.