### PR TITLE
Adding ID support for FinishedChatCompletionToolCall

### DIFF
--- a/streamaccumulator.go
+++ b/streamaccumulator.go
@@ -11,6 +11,7 @@ type ChatCompletionAccumulator struct {
 type FinishedChatCompletionToolCall struct {
 	ChatCompletionMessageToolCallFunction
 	Index int
+	ID    string
 }
 
 type chatCompletionResponseState struct {
@@ -80,9 +81,11 @@ func (acc *ChatCompletionAccumulator) JustFinishedRefusal() (refusal string, ok 
 // You cannot rely on this with a stream that has ParallelToolCalls enabled.
 func (acc *ChatCompletionAccumulator) JustFinishedToolCall() (toolcall FinishedChatCompletionToolCall, ok bool) {
 	if acc.justFinished.state == toolResponseState {
-		f := acc.Choices[0].Message.ToolCalls[acc.justFinished.index].Function
+		t := acc.Choices[0].Message.ToolCalls[acc.justFinished.index]
+		f := t.Function
 		return FinishedChatCompletionToolCall{
 			Index: acc.justFinished.index,
+			ID:    t.ID,
 			ChatCompletionMessageToolCallFunction: ChatCompletionMessageToolCallFunction{
 				Name:      f.Name,
 				Arguments: f.Arguments,

--- a/streamaccumulator_test.go
+++ b/streamaccumulator_test.go
@@ -22,9 +22,13 @@ func getWeather(_ string) string {
 }
 
 // Since the streamed response is hardcoded, we can hardcode the expected tool call
-var expectedToolCall openai.ChatCompletionMessageToolCallFunction = openai.ChatCompletionMessageToolCallFunction{
-	Arguments: `{"location":"Santorini, Greece"}`,
-	Name:      "get_weather",
+var expectedToolCall openai.FinishedChatCompletionToolCall = openai.FinishedChatCompletionToolCall{
+	ID:    "call_FXoAjBUMcVv1k40fficJ9cSs",
+	Index: 0,
+	ChatCompletionMessageToolCallFunction: openai.ChatCompletionMessageToolCallFunction{
+		Arguments: `{"location":"Santorini, Greece"}`,
+		Name:      "get_weather",
+	},
 }
 
 var expectedContents string = `Let's take a journey to the beautiful island of Santorini in Greece.
@@ -129,7 +133,7 @@ func TestStreamingAccumulatorWithToolCalls(t *testing.T) {
 		t.Fatalf("Found unexpected content")
 	}
 
-	if expectedToolCall.Arguments != acc.Choices[0].Message.ToolCalls[0].Function.Arguments || expectedToolCall.Name != acc.Choices[0].Message.ToolCalls[0].Function.Name {
+	if expectedToolCall.Arguments != acc.Choices[0].Message.ToolCalls[0].Function.Arguments || expectedToolCall.Name != acc.Choices[0].Message.ToolCalls[0].Function.Name || expectedToolCall.ID != acc.Choices[0].Message.ToolCalls[0].ID {
 		t.Fatalf("Found unexpected tool call %v %v", acc.Choices[0].Message.ToolCalls[0].Function.Arguments, acc.Choices[0].Message.ToolCalls[0].Function.Name)
 	}
 


### PR DESCRIPTION
This PR adds ID field support to the **FinishedChatCompletionToolCall** struct, enabling it to capture and return the unique identifier for tool calls. This ensures tool calls can be accurately tracked and referenced in streaming responses.

### Changes
Added ID field to FinishedChatCompletionToolCall struct
Refactored JustFinishedToolCall() method to properly retrieve and return tool call IDs
Updated test cases to validate ID field handling

### Impact
This change allows API clients to access complete tool call metadata, particularly in streaming scenarios, enabling reliable tracking and management of tool call lifecycles.