### PR TITLE
fix: correct accumulation in ChatCompletionAccumulator

### DIFF
--- a/streamaccumulator.go
+++ b/streamaccumulator.go
@@ -141,6 +141,14 @@ func (cc *ChatCompletion) accumulateDelta(chunk ChatCompletionChunk) bool {
 	cc.Usage.PromptTokens += chunk.Usage.PromptTokens
 	cc.Usage.TotalTokens += chunk.Usage.TotalTokens
 
+	cc.Usage.CompletionTokensDetails.AcceptedPredictionTokens += chunk.Usage.CompletionTokensDetails.AcceptedPredictionTokens
+	cc.Usage.CompletionTokensDetails.RejectedPredictionTokens += chunk.Usage.CompletionTokensDetails.RejectedPredictionTokens
+	cc.Usage.CompletionTokensDetails.ReasoningTokens += chunk.Usage.CompletionTokensDetails.ReasoningTokens
+	cc.Usage.CompletionTokensDetails.AudioTokens += chunk.Usage.CompletionTokensDetails.AudioTokens
+
+	cc.Usage.PromptTokensDetails.CachedTokens += chunk.Usage.PromptTokensDetails.CachedTokens
+	cc.Usage.PromptTokensDetails.AudioTokens += chunk.Usage.PromptTokensDetails.AudioTokens
+
 	cc.Model = chunk.Model
 	cc.Created = chunk.Created
 	cc.SystemFingerprint = chunk.SystemFingerprint


### PR DESCRIPTION
The ChatCompletionAccumulator doesn’t correctly accumulate CompletionTokensDetails and PromptTokensDetails. This PR fixes the bug.