### PR TITLE
fix(client): resolve ToParams regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ if stream.Err() != nil {
 _ = acc.Choices[0].Message.Content
 ```
 
-> See the [full streaming and accumulation example]./examples/chat-completion-accumulating/main.go)
+> See the [full streaming and accumulation example](./examples/chat-completion-accumulating/main.go)
 
 </details>
 
@@ -202,7 +202,7 @@ for _, toolCall := range toolCalls {
 // ... continue the conversation with the information provided by the tool
 ```
 
-> See the [full tool calling example]./examples/chat-completion-tool-calling/main.go)
+> See the [full tool calling example](./examples/chat-completion-tool-calling/main.go)
 
 </details>
 
@@ -751,7 +751,8 @@ middleware has been applied.
 
 ## Microsoft Azure OpenAI
 
-To use this library with [Azure OpenAI]https://learn.microsoft.com/azure/ai-services/openai/overview), use the ption.RequestOption functions in the `azure` package.
+To use this library with [Azure OpenAI]https://learn.microsoft.com/azure/ai-services/openai/overview),
+use the option.RequestOption functions in the `azure` package.
 
 ```go
 package main

--- a/chatcompletion.go
+++ b/chatcompletion.go
@@ -1265,17 +1265,24 @@ func (r ChatCompletionMessage) ToParam() ChatCompletionMessageParamUnion {
 
 func (r ChatCompletionMessage) ToAssistantMessageParam() ChatCompletionAssistantMessageParam {
 	var p ChatCompletionAssistantMessageParam
-	p.Content.OfString = toParam(r.Content, r.JSON.Content)
-	p.Refusal = toParam(r.Refusal, r.JSON.Refusal)
+	if r.JSON.Content.IsPresent() {
+		p.Content.OfString.Value = r.Content
+	}
+	if r.JSON.Refusal.IsPresent() {
+		p.Refusal = String(r.Refusal)
+	}
 	p.Audio.ID = r.Audio.ID
 	p.Role = r.Role
 	p.FunctionCall.Arguments = r.FunctionCall.Arguments
 	p.FunctionCall.Name = r.FunctionCall.Name
-	p.ToolCalls = make([]ChatCompletionMessageToolCallParam, len(r.ToolCalls))
-	for i, v := range r.ToolCalls {
-		p.ToolCalls[i].ID = v.ID
-		p.ToolCalls[i].Function.Arguments = v.Function.Arguments
-		p.ToolCalls[i].Function.Name = v.Function.Name
+
+	if len(r.ToolCalls) > 0 {
+		p.ToolCalls = make([]ChatCompletionMessageToolCallParam, len(r.ToolCalls))
+		for i, v := range r.ToolCalls {
+			p.ToolCalls[i].ID = v.ID
+			p.ToolCalls[i].Function.Arguments = v.Function.Arguments
+			p.ToolCalls[i].Function.Name = v.Function.Name
+		}
 	}
 	return p
 }


### PR DESCRIPTION
Elide `null` in the ChatCompletionMessage.ToParams() function
Elide empty ToolCalls.

Also fixes some documentation links. 