### PR TITLE
Fix url in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -771,7 +771,7 @@ func main() {
 	const azureOpenAIEndpoint = "https://<azure-openai-resource>.openai.azure.com"
 
 	// The latest API versions, including previews, can be found here:
-	// ttps://learn.microsoft.com/en-us/azure/ai-services/openai/reference#rest-api-versionng
+	// https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#rest-api-versionng
 	const azureOpenAIAPIVersion = "2024-06-01"
 
 	tokenCredential, err := azidentity.NewDefaultAzureCredential(nil)


### PR DESCRIPTION
This pull request includes a minor correction to the `README.md` file. The change fixes a typo in the URL for the latest API versions.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L774-R774): Corrected the URL for the latest API versions from "ttps" to "https".