### PR TITLE
handle missing case properly

### DIFF
--- a/internal/apijson/field.go
+++ b/internal/apijson/field.go
@@ -14,7 +14,7 @@ type Field struct {
 	status status
 }
 
-// Returns true if the field is explicitly `null` _or_ if it is not present at all (ie, missing).
+// IsNull returns true if the field is explicitly `null` _or_ if it is not present at all (ie, missing).
 // To check if the field's key is present in the JSON with an explicit null value,
 // you must check `f.IsNull() && !f.IsMissing()`.
 func (j Field) IsNull() bool    { return j.status <= null }

--- a/internal/apijson/subfield.go
+++ b/internal/apijson/subfield.go
@@ -1,8 +1,9 @@
 package apijson
 
 import (
-	"github.com/openai/openai-go/packages/resp"
 	"reflect"
+
+	"github.com/openai/openai-go/packages/resp"
 )
 
 func getSubField(root reflect.Value, index []int, name string) reflect.Value {
@@ -55,10 +56,10 @@ func setMetadataExtraFields(root reflect.Value, index []int, name string, metaEx
 }
 
 func (f Field) toRespField() resp.Field {
-	if f.IsNull() {
-		return resp.NewNullField()
-	} else if f.IsMissing() {
+	if f.IsMissing() {
 		return resp.Field{}
+	} else if f.IsNull() {
+		return resp.NewNullField()
 	} else if f.IsInvalid() {
 		return resp.NewInvalidField(f.raw)
 	} else {


### PR DESCRIPTION
I ran [govanish](https://github.com/sivukhin/govanish) linter and it found one suspicious place:

```go
2025/04/20 15:32:09 module path: /home/sivukhin/code/openai-go
2025/04/20 15:32:09 ready to compile project at path '/home/sivukhin/code/openai-go' for assembly inspection
2025/04/20 15:32:09 ready to parse assembly output
2025/04/20 15:32:10 ready to normalize assembly lines (size 76)
2025/04/20 15:32:10 built func registry: 626 entries
2025/04/20 15:32:10 ready to analyze module AST
2025/04/20 15:32:10 it seems like your code vanished from compiled binary: func=[toRespField], file=[/home/sivukhin/code/openai-go/internal/apijson/subfield.go], lines=[61-61], snippet:
	return resp.Field{}
```

Indeed, as `IsNull()` combine both explicit null and missing case, branch `IsMissing()` were redundant in the previous order of conditions - so compiler removed it from the code.

This looks like a bug - one possible fix is to properly treat `Missing` case by changing the order of conditions. But maybe there is a better (and safer - can this fix break compatibility?) fix. So feel free to close this PR.