### PR TITLE
Close leaking resource

### DIFF
--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -508,6 +508,7 @@ func (cfg *RequestConfig) Execute() (err error) {
 	}
 
 	contents, err := io.ReadAll(res.Body)
+	res.Body.Close()
 	if err != nil {
 		return fmt.Errorf("error reading response body: %w", err)
 	}


### PR DESCRIPTION
It seems as though upon success, the http response body isn't closed, leading to a possible go routine leak.
This closes it.