### PR TITLE
fix(client): register union for response_format

### DIFF
--- a/chatcompletion.go
+++ b/chatcompletion.go
@@ -2366,6 +2366,15 @@ type ChatCompletionNewParamsResponseFormatUnion struct {
 	paramUnion
 }
 
+func init() {
+	apijson.RegisterUnion[ChatCompletionNewParamsResponseFormatUnion](
+		"type",
+		apijson.Discriminator[shared.ResponseFormatTextParam]("text"),
+		apijson.Discriminator[shared.ResponseFormatJSONSchemaParam]("json_schema"),
+		apijson.Discriminator[shared.ResponseFormatJSONObjectParam]("json_object"),
+	)
+}
+
 func (u ChatCompletionNewParamsResponseFormatUnion) MarshalJSON() ([]byte, error) {
 	return param.MarshalUnion[ChatCompletionNewParamsResponseFormatUnion](u.OfText, u.OfJSONSchema, u.OfJSONObject)
 }


### PR DESCRIPTION
Hi. I noticed that unmarshaling response_format field in ChatCompletionNewParams is incorrect due to a forgotten union registration.

```go
package main

import (
	"fmt"

	"github.com/openai/openai-go"
)

func main() {
	body := `
	{
		"model": "my_model"
		"response_format": {
			"type": "json_schema",
			"json_schema": {
				"name": "MySchema",
				"schema": {
					"type":"object",
					"properties":{
						"name":{
							"type": "string",
							"description": "The name"
						}
					},
					"additionalProperties":false,
					"required":["name"]
				}
			}
		}
	}
	`
	var params openai.ChatCompletionNewParams
	params.UnmarshalJSON([]byte(body))
	fmt.Println(params.ResponseFormat.OfText)
	raw, _ := params.MarshalJSON()
	fmt.Println(string(raw))
}
```

```bash
❯ go run main.go
&{json_schema {{<nil>}}}
{"model":"my_model","response_format":{"type":"json_schema"}}
```