### PR TITLE
fix: fix pollstatus issue

### DIFF
--- a/examples/vectorstorefilebatch/main.go
+++ b/examples/vectorstorefilebatch/main.go
@@ -60,14 +60,13 @@ func main() {
 	println("Listing the files from the vector store")
 
 	vector := openai.VectorStoreFileBatchListFilesParams{
-		Order:         openai.VectorStoreFileBatchListFilesParamsOrderAsc,
-		VectorStoreID: vectorStore.ID,
+		Order: openai.VectorStoreFileBatchListFilesParamsOrderAsc,
 	}
 
 	q, _ := vector.URLQuery()
 	println("Vector JSON:", q)
 
-	filesCursor, err := client.VectorStores.FileBatches.ListFiles(ctx, batch.ID, vector)
+	filesCursor, err := client.VectorStores.FileBatches.ListFiles(ctx, vectorStore.ID, batch.ID, vector)
 
 	if err != nil {
 		panic(err)

--- a/polling.go
+++ b/polling.go
@@ -67,7 +67,7 @@ func (r *VectorStoreFileBatchService) PollStatus(ctx context.Context, vectorStor
 	opts = append(opts, option.WithResponseInto(&raw))
 	opts = append(opts, mkPollingOptions(pollIntervalMs)...)
 	for {
-		batch, err := r.Get(ctx, batchID, vectorStoreID, opts...)
+		batch, err := r.Get(ctx, vectorStoreID, batchID, opts...)
 		if err != nil {
 			return nil, fmt.Errorf("vector store file batch poll: received %w", err)
 		}


### PR DESCRIPTION
- fix the issue where the pollstatus was not working correctly
- fix the issue where the vectorstoreid was not being passed correctly in example

Error logs:
```
go run main.go -- test0.txt test1.txt
File to upload: test0.txt
File to upload: test1.txt
Creating a new vector store and uploading files
panic: vector store file batch poll: received GET "https://api.openai.com/v1/vector_stores/vsfb_***/file_batches/vs_***": 400 Bad Request {
            "message": "Invalid 'batch_id': 'vs_686329ef3c6081918a21b7a9fa904dd4'. Expected an ID that begins with 'vsfb_'.",
            "type": "invalid_request_error",
            "param": "batch_id",
            "code": "invalid_value"
          }

goroutine 1 [running]:
main.main()
```