### PR TITLE
A more obvious example of audio to text transcription

### DIFF
--- a/examples/audio-transcriptions/main.go
+++ b/examples/audio-transcriptions/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"os"
 
@@ -19,6 +20,23 @@ func main() {
 	transcription, err := client.Audio.Transcriptions.New(ctx, openai.AudioTranscriptionNewParams{
 		Model: openai.AudioModelWhisper1,
 		File:  file,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	println(transcription.Text)
+
+	// Or if you have speech bytes, you have to wrap reader:
+	var speechBytes []byte // Assume this is filled with audio data
+
+	speechReader := openai.File(
+		bytes.NewReader(speechBytes), "speech.mp3", "audio/mp3",
+	)
+
+	transcription, err = client.Audio.Transcriptions.New(ctx, openai.AudioTranscriptionNewParams{
+		Model: openai.AudioModelWhisper1,
+		File:  speechReader,
 	})
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Problem: Unclear `io.Reader` Expectations for Audio Transcription
Today, I encountered an issue with the `openai.AudioTranscriptionNewParams.File` field, where the expected behavior of an `io.Reader` was not immediately obvious.

As a developer, when a function or method expects an `io.Reader`, I typically anticipate that only the Read method will be necessary. However, upon inspection of the library's internal code, it became clear that the `io.Reader` provided to this method is implicitly type-asserted to inline interfaces expecting `Filename()` or `Name()` or `ContentType()` methods.

This hidden dependency leads to a problem when providing a simple `io.Reader` created directly from bytes, such as with bytes.NewReader(audioBytes). In such cases, the OpenAI API returns an "unsupported format" error because it lacks the necessary metadata (filename and content type) to correctly process the audio.

Solution: Explicit Wrapping with `openai.File`
To address this, it's crucial to explicitly wrap the `io.Reader` using `openai.File(bytes.NewReader(audioBytes), filename, contentType)`. This ensures that the required filename and contentType metadata are correctly associated with the reader before it's passed to the API.

This approach is particularly beneficial when audio data is downloaded over the network. It eliminates the need to create a local temporary file simply to satisfy the API's implicit requirements, streamlining the workflow and reducing disk I/O.