### PR TITLE
fix(ssestream): normalize content-type header for decoder lookup

### DIFF
--- a/packages/ssestream/ssestream.go
+++ b/packages/ssestream/ssestream.go
@@ -28,7 +28,7 @@ func NewDecoder(res *http.Response) Decoder {
 
 	var decoder Decoder
 	contentType := res.Header.Get("content-type")
-	if t, ok := decoderTypes[contentType]; ok {
+	if t, ok := decoderTypes[strings.ToLower(contentType)]; ok {
 		decoder = t(res.Body)
 	} else {
 		scn := bufio.NewScanner(res.Body)


### PR DESCRIPTION
[RegisterDecoder](https://github.com/openai/openai-[go/blob/main/packages/ssestream/ssestream.go#L43-L45](https://www.golinks.io/blob/main/packages/ssestream/ssestream.go#L43-L45?trackSource=github)) convert the `contentType` to lowercase, the same operation is added in NewDecoder. This allows a custom Decoder to be matched when the `contentType` is `text/event-stream;charset=UTF-8`.