### PR TITLE
Fix panic caused by OOB access in stream accumulator

### DIFF
--- a/streamaccumulator.go
+++ b/streamaccumulator.go
@@ -167,7 +167,7 @@ func (prev *chatCompletionResponseState) update(chunk ChatCompletionChunk) (just
 		new.state = contentResponseState
 	case delta.JSON.Refusal.Valid():
 		new.state = refusalResponseState
-	case delta.JSON.ToolCalls.Valid():
+	case delta.JSON.ToolCalls.Valid() && len(delta.ToolCalls) > 0:
 		new.state = toolResponseState
 		new.index = int(delta.ToolCalls[0].Index)
 	default:


### PR DESCRIPTION
this patch fixes an issue where some openai compatible clients return a tool json delta of "[]" when they are not performing tool requests. this tool call json is valid but the stream accumulator doesn't check if the offset in the chunk delta is greater than zero before accessing it. This leads to panics when we accumulate these chunk deltas.