### PR TITLE
Defensive coding for negative indices in tool calls

### DIFF
--- a/streamaccumulator.go
+++ b/streamaccumulator.go
@@ -125,8 +125,14 @@ func (cc *ChatCompletion) accumulateDelta(chunk ChatCompletionChunk) bool {
 		for j := range delta.Delta.ToolCalls {
 			deltaTool := &delta.Delta.ToolCalls[j]
 
-			choice.Message.ToolCalls = expandToFit(choice.Message.ToolCalls, int(deltaTool.Index))
-			tool := &choice.Message.ToolCalls[deltaTool.Index]
+			// Handle negative tool call indices (sometimes -1 from Bedrock)
+			toolIndex := int(deltaTool.Index)
+			if toolIndex < 0 {
+				toolIndex = 0 // Default to 0 for negative indices
+			}
+
+			choice.Message.ToolCalls = expandToFit(choice.Message.ToolCalls, toolIndex)
+			tool := &choice.Message.ToolCalls[toolIndex]
 
 			if deltaTool.ID != "" {
 				tool.ID = deltaTool.ID


### PR DESCRIPTION
Hello,

I was integrating the AWS Bedrock openAI-compatible API and encountered a slight difference in behaviour.

Chunks being streaming back from AWS Bedrock have their index set to `-1`, whilst on openAI they come back as `0` until the JSON is ready to be returned.

This causes an out of bound exception on the modified line.

There are other differences in the chunks, but they don't cause a crash and I seem to be able to consume them fine.


**AWS Bedrock chunk response:**

```json
{
  "id": "chatcmpl-70532f9c",
  "choices": [
    {
      "delta": {
        "content": "",
        "function_call": {
          "arguments": "",
          "name": ""
        },
        "refusal": "",
        "role": "",
        "tool_calls": [
          {
            "index": -1,
            "id": "tooluse_VcI3wsREQIa5oPhbJFQLpw",
            "function": {
              "arguments": "",
              "name": "save_feedback_score"
            },
            "type": "function"
          }
        ]
      },
      "finish_reason": "",
      "index": 0,
      "logprobs": {
        "content": null,
        "refusal": null
      }
    }
  ],
  "created": 1754582425,
  "model": "us.anthropic.claude-sonnet-4-20250514-v1:0",
  "object": "chat.completion.chunk",
  "service_tier": "",
  "system_fingerprint": "fp",
  "usage": {
    "completion_tokens": 0,
    "prompt_tokens": 0,
    "total_tokens": 0,
    "completion_tokens_details": {
      "accepted_prediction_tokens": 0,
      "audio_tokens": 0,
      "reasoning_tokens": 0,
      "rejected_prediction_tokens": 0
    },
    "prompt_tokens_details": {
      "audio_tokens": 0,
      "cached_tokens": 0
    }
  }
}
```

**OpenAI chunk response**
```json
{
  "id": "chatcmpl-C1xgePnJXGTptveRLPTKA3x1LoslN",
  "choices": [
    {
      "delta": {
        "content": "",
        "function_call": {
          "arguments": "",
          "name": ""
        },
        "refusal": "",
        "role": "assistant",
        "tool_calls": [
          {
            "index": 0,
            "id": "call_IVOmd9ris8YOk1b1hiGQtxIE",
            "function": {
              "arguments": "",
              "name": "save_feedback_score"
            },
            "type": "function"
          }
        ]
      },
      "finish_reason": "",
      "index": 0,
      "logprobs": {
        "content": null,
        "refusal": null
      }
    }
  ],
  "created": 1754583800,
  "model": "gpt-4.1-2025-04-14",
  "object": "chat.completion.chunk",
  "service_tier": "default",
  "system_fingerprint": "fp_799e4ca3f1",
  "usage": {
    "completion_tokens": 0,
    "prompt_tokens": 0,
    "total_tokens": 0,
    "completion_tokens_details": {
      "accepted_prediction_tokens": 0,
      "audio_tokens": 0,
      "reasoning_tokens": 0,
      "rejected_prediction_tokens": 0
    },
    "prompt_tokens_details": {
      "audio_tokens": 0,
      "cached_tokens": 0
    }
  }
}
```