### PR TITLE
fix: add missing tool_calls finish reason

### DIFF
--- a/completion.go
+++ b/completion.go
@@ -133,6 +133,7 @@ const (
 	CompletionChoiceFinishReasonStop          CompletionChoiceFinishReason = "stop"
 	CompletionChoiceFinishReasonLength        CompletionChoiceFinishReason = "length"
 	CompletionChoiceFinishReasonContentFilter CompletionChoiceFinishReason = "content_filter"
+	CompletionChoiceFinishReasonToolCalls     CompletionChoiceFinishReason = "tool_calls"
 )
 
 type CompletionChoiceLogprobs struct {


### PR DESCRIPTION
I don't see an example of this anywhere in the docs on platform.openai.com, but `"finish_reason": "tool_calls"` is used by many OpenAI API providers that I'm trying to integrate with.

The tool calling documentation for all of the providers below support `"finish_reason": "tool_calls"`:
- Meta Llama: https://llama.developer.meta.com/docs/features/tool-calling/
- Qwen: https://qwen.readthedocs.io/en/latest/framework/function_call.html
- LiteLLM: https://docs.litellm.ai/docs/completion/function_call
- LangChain: https://python.langchain.com/docs/how_to/tool_calling/
- Mistral: https://docs.mistral.ai/capabilities/function_calling/
- vLLM: https://github.com/search?q=repo%3Avllm-project%2Fvllm+finish_reason%3D%22tool_calls%22&type=code