### PR TITLE
docs: give https its missing "h" in Azure OpenAI REST API link

### DIFF
--- a/README.md
+++ b/README.md
@@ -911,7 +911,7 @@ func main() {
 	const azureOpenAIEndpoint = "https://<azure-openai-resource>.openai.azure.com"
 
 	// The latest API versions, including previews, can be found here:
-	// ttps://learn.microsoft.com/en-us/azure/ai-services/openai/reference#rest-api-versionng
+	// https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#rest-api-versionng
 	const azureOpenAIAPIVersion = "2024-06-01"
 
 	tokenCredential, err := azidentity.NewDefaultAzureCredential(nil)


### PR DESCRIPTION
- ttps://learn.microsoft.com/en-us/azure/ai-services/openai/reference#rest-api-version

+ https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#rest-api-version