### PR TITLE
fix: resolve union decoder field type reflection for param.Opt types

### DIFF
--- a/chatcompletion.go
+++ b/chatcompletion.go
@@ -2742,6 +2742,15 @@ func (u ChatCompletionToolChoiceOptionUnionParam) GetType() *string {
 	return nil
 }
 
+func init() {
+	apijson.RegisterUnion[ChatCompletionToolChoiceOptionUnionParam](
+		"type",
+		apijson.Discriminator[ChatCompletionAllowedToolChoiceParam]("allowed_tools"),
+		apijson.Discriminator[ChatCompletionNamedToolChoiceParam]("function"),
+		apijson.Discriminator[ChatCompletionNamedToolChoiceCustomParam]("custom"),
+	)
+}
+
 // `none` means the model will not call any tool and instead generates a message.
 // `auto` means the model can pick between generating a message or calling one or
 // more tools. `required` means the model must call one or more tools.

--- a/internal/apijson/union.go
+++ b/internal/apijson/union.go
@@ -2,8 +2,9 @@ package apijson
 
 import (
 	"errors"
-	"github.com/openai/openai-go/v3/packages/param"
 	"reflect"
+
+	"github.com/openai/openai-go/v3/packages/param"
 
 	"github.com/tidwall/gjson"
 )
@@ -66,7 +67,11 @@ func (d *decoderBuilder) newStructUnionDecoder(t reflect.Type) decoderFunc {
 	for _, variant := range unionEntry.variants {
 		// For each union variant, find a matching decoder and save it
 		for _, decoder := range decoders {
-			if decoder.field.Type.Elem() == variant.Type {
+			fieldType := decoder.field.Type
+			if fieldType.Kind() == reflect.Ptr {
+				fieldType = fieldType.Elem()
+			}
+			if fieldType == variant.Type {
 				discriminatedDecoders = append(discriminatedDecoders, discriminatedDecoder{
 					decoder,
 					variant.DiscriminatorValue,


### PR DESCRIPTION
This commit fixes issue #520 by improving the union decoder's ability to handle param.Opt types
during JSON unmarshaling. The problem occurred when the decoder tried to call .Elem() on
param.Opt[string] types, which are not pointer types.

Modified files and changes:
- chatcompletion.go:
  * Added init() function to register ChatCompletionToolChoiceOptionUnionParam with apijson
  * Registered discriminators for "allowed_tools", "function", and "custom" types
  * Enables proper union unmarshaling through the apijson framework

- internal/apijson/union.go:
  * Fixed import ordering (moved param import after reflect)
  * Enhanced newStructUnionDecoder to properly handle non-pointer field types
  * Added fieldType variable to check if field is a pointer before calling .Elem()
  * Only calls .Elem() on pointer types, preventing runtime panics

This fix ensures that union parameters can be properly decoded without type reflection errors,
specifically addressing cases where union fields use param.Opt types instead of pointer types.