### PR TITLE
docs: update module path to v3 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Or to pin the version:
 <!-- x-release-please-start-version -->
 
 ```sh
-go get -u 'github.com/openai/openai-go/v2@v3.8.1'
+go get -u 'github.com/openai/openai-go/v3@v3.8.1'
 ```
 
 <!-- x-release-please-end -->


### PR DESCRIPTION
When I use this command from the README.md (go get -u 'github.com/openai/openai-[go/v2](https://www.golinks.io/v2?trackSource=github)@v3.2.0') to install it, it tells me that it can't be found (go: github.com/openai/openai-[go/v2](https://www.golinks.io/v2?trackSource=github)@v3.2.0: invalid version: go.mod has non-... /v2 module path "github.com/openai/openai-[go/v3](https://www.golinks.io/v3?trackSource=github)" (and ... /v2/go.mod does not exist) at revision v3.2.0) .

The correct command would be (go get -u 'github.com/openai/openai-[go/v3](https://www.golinks.io/v3?trackSource=github)@v3.2.0')

<img width="852" height="53" alt="Image" src="https://github.com/user-attachments/assets/a1776093-8a41-4eac-95a6-b9f86d6bab4c" />