### PR TITLE
fix: swap vectorStoreID and fileID parameters in PollStatus Get call

### DIFF
--- a/polling.go
+++ b/polling.go
@@ -32,7 +32,7 @@ func (r *VectorStoreFileService) PollStatus(ctx context.Context, vectorStoreID s
 	opts = append(opts, mkPollingOptions(pollIntervalMs)...)
 	opts = append(opts, option.WithResponseInto(&raw))
 	for {
-		file, err := r.Get(ctx, fileID, vectorStoreID, opts...)
+		file, err := r.Get(ctx, vectorStoreID, fileID, opts...)
 		if err != nil {
 			return nil, fmt.Errorf("vector store file poll: received %w", err)
 		}

--- a/vectorstorefile.go
+++ b/vectorstorefile.go
@@ -61,12 +61,12 @@ func (r *VectorStoreFileService) New(ctx context.Context, vectorStoreID string, 
 //
 // Polls the API and blocks until the task is complete.
 // Default polling interval is 1 second.
-func (r *VectorStoreFileService) NewAndPoll(ctx context.Context, vectorStoreId string, body VectorStoreFileNewParams, pollIntervalMs int, opts ...option.RequestOption) (res *VectorStoreFile, err error) {
-	file, err := r.New(ctx, vectorStoreId, body, opts...)
+func (r *VectorStoreFileService) NewAndPoll(ctx context.Context, vectorStoreID string, body VectorStoreFileNewParams, pollIntervalMs int, opts ...option.RequestOption) (res *VectorStoreFile, err error) {
+	file, err := r.New(ctx, vectorStoreID, body, opts...)
 	if err != nil {
 		return nil, err
 	}
-	return r.PollStatus(ctx, vectorStoreId, file.ID, pollIntervalMs, opts...)
+	return r.PollStatus(ctx, vectorStoreID, file.ID, pollIntervalMs, opts...)
 }
 
 // Upload a file to the `files` API and then attach it to the given vector store.


### PR DESCRIPTION
The parameters were in the wrong order, causing 400 bad request errors. Also added test to verify the correct URL path is used during polling.