### PR TITLE
fix: register discriminator for ChatCompletionNewParamsResponseFormatUnion

### DIFF
--- a/chatcompletion.go
+++ b/chatcompletion.go
@@ -3234,6 +3234,15 @@ func (u ChatCompletionNewParamsResponseFormatUnion) GetType() *string {
 	return nil
 }
 
+func init() {
+	apijson.RegisterUnion[ChatCompletionNewParamsResponseFormatUnion](
+		"type",
+		apijson.Discriminator[shared.ResponseFormatTextParam]("text"),
+		apijson.Discriminator[shared.ResponseFormatJSONSchemaParam]("json_schema"),
+		apijson.Discriminator[shared.ResponseFormatJSONObjectParam]("json_object"),
+	)
+}
+
 // Specifies the processing type used for serving the request.
 //
 //   - If set to 'auto', then the request will be processed with the service tier


### PR DESCRIPTION
Problem:
In the current OpenAI Go SDK, the inline union ChatCompletionNewParamsResponseFormatUnion has a deserialization bug:

The union contains three inline structs: OfText, OfJSONSchema, and OfJSONObject, each of which has a type field.

During JSON deserialization, Go’s encoding/json maps the JSON data to the first matching inline struct (OfText), causing OfJSONSchema and OfJSONObject to be ignored.

As a result, when a user sends response_format of type "json_schema" or "json_object", the SDK fails to parse it correctly.

Solution:

Register a union discriminator so that apijson knows how to dispatch JSON to the correct inline struct based on the type field.

Add the following code in the init() function:

```
func init() {
	apijson.RegisterUnion[ChatCompletionNewParamsResponseFormatUnion](
		"type",
		apijson.Discriminator[shared.ResponseFormatTextParam]("text"),
		apijson.Discriminator[shared.ResponseFormatJSONSchemaParam]("json_schema"),
		apijson.Discriminator[shared.ResponseFormatJSONObjectParam]("json_object"),
	)
}
```

Effect:

JSON is automatically deserialized to the correct union struct based on type.

Fixes the issue where response_format of "json_schema" or "json_object" could not be parsed.

Eliminates the need for users to manually patch response_format handling.

Compatibility:

Backward compatible: text type behavior remains unchanged.

Does not affect other union types.