### PR TITLE
Normalize `PromptCacheRetention` constants to use `snake_case`.

### DIFF
--- a/chatcompletion.go
+++ b/chatcompletion.go
@@ -3026,7 +3026,7 @@ type ChatCompletionNewParams struct {
 	// of 24 hours.
 	// [Learn more](https://platform.openai.com/docs/guides/prompt-caching#prompt-cache-retention).
 	//
-	// Any of "in-memory", "24h".
+	// Any of "in_memory", "24h".
 	PromptCacheRetention ChatCompletionNewParamsPromptCacheRetention `json:"prompt_cache_retention,omitzero"`
 	// Constrains effort on reasoning for
 	// [reasoning models](https://platform.openai.com/docs/guides/reasoning). Currently
@@ -3210,7 +3210,7 @@ func (r *ChatCompletionNewParamsFunction) UnmarshalJSON(data []byte) error {
 type ChatCompletionNewParamsPromptCacheRetention string
 
 const (
-	ChatCompletionNewParamsPromptCacheRetentionInMemory ChatCompletionNewParamsPromptCacheRetention = "in-memory"
+	ChatCompletionNewParamsPromptCacheRetentionInMemory ChatCompletionNewParamsPromptCacheRetention = "in_memory"
 	ChatCompletionNewParamsPromptCacheRetention24h      ChatCompletionNewParamsPromptCacheRetention = "24h"
 )
 

--- a/responses/response.go
+++ b/responses/response.go
@@ -1028,7 +1028,7 @@ type Response struct {
 	// of 24 hours.
 	// [Learn more](https://platform.openai.com/docs/guides/prompt-caching#prompt-cache-retention).
 	//
-	// Any of "in-memory", "24h".
+	// Any of "in_memory", "24h".
 	PromptCacheRetention ResponsePromptCacheRetention `json:"prompt_cache_retention,nullable"`
 	// **gpt-5 and o-series models only**
 	//
@@ -1314,7 +1314,7 @@ func (r *ResponseConversation) UnmarshalJSON(data []byte) error {
 type ResponsePromptCacheRetention string
 
 const (
-	ResponsePromptCacheRetentionInMemory ResponsePromptCacheRetention = "in-memory"
+	ResponsePromptCacheRetentionInMemory ResponsePromptCacheRetention = "in_memory"
 	ResponsePromptCacheRetention24h      ResponsePromptCacheRetention = "24h"
 )
 
@@ -17411,7 +17411,7 @@ type ResponseNewParams struct {
 	// of 24 hours.
 	// [Learn more](https://platform.openai.com/docs/guides/prompt-caching#prompt-cache-retention).
 	//
-	// Any of "in-memory", "24h".
+	// Any of "in_memory", "24h".
 	PromptCacheRetention ResponseNewParamsPromptCacheRetention `json:"prompt_cache_retention,omitzero"`
 	// Specifies the processing type used for serving the request.
 	//
@@ -17563,7 +17563,7 @@ func (u *ResponseNewParamsInputUnion) asAny() any {
 type ResponseNewParamsPromptCacheRetention string
 
 const (
-	ResponseNewParamsPromptCacheRetentionInMemory ResponseNewParamsPromptCacheRetention = "in-memory"
+	ResponseNewParamsPromptCacheRetentionInMemory ResponseNewParamsPromptCacheRetention = "in_memory"
 	ResponseNewParamsPromptCacheRetention24h      ResponseNewParamsPromptCacheRetention = "24h"
 )
 


### PR DESCRIPTION
This PR updates the PromptCacheRetention constants to use in_memory (snake_case) instead of the **invalid** in-memory (kebab-case)
See this [issue](https://github.com/openai/openai-[go/issues/575](https://www.golinks.io/issues/575?trackSource=github))