### PR TITLE
feat: serialize extra fields when sending message requests

### DIFF
--- a/chatcompletion.go
+++ b/chatcompletion.go
@@ -1990,6 +1990,32 @@ type ChatCompletionMessageParamUnion struct {
 }
 
 func (u ChatCompletionMessageParamUnion) MarshalJSON() ([]byte, error) {
+	// Try to marshal with extra fields support
+	extras := u.ExtraFields()
+	if len(extras) > 0 {
+		// Find the non-omitted variant
+		var variant any
+		if !param.IsOmitted(u.OfDeveloper) {
+			variant = u.OfDeveloper
+		} else if !param.IsOmitted(u.OfSystem) {
+			variant = u.OfSystem
+		} else if !param.IsOmitted(u.OfUser) {
+			variant = u.OfUser
+		} else if !param.IsOmitted(u.OfAssistant) {
+			variant = u.OfAssistant
+		} else if !param.IsOmitted(u.OfTool) {
+			variant = u.OfTool
+		} else if !param.IsOmitted(u.OfFunction) {
+			variant = u.OfFunction
+		}
+
+		if variant != nil {
+			// Use MarshalWithExtras to include extra fields
+			return param.MarshalWithExtras(u, variant, extras)
+		}
+	}
+
+	// Fall back to standard union marshaling
 	return param.MarshalUnion(u, u.OfDeveloper,
 		u.OfSystem,
 		u.OfUser,

--- a/chatcompletion.go
+++ b/chatcompletion.go
@@ -1549,6 +1549,23 @@ func (r *ChatCompletionMessage) UnmarshalJSON(data []byte) error {
 	return apijson.UnmarshalRoot(data, r)
 }
 
+// extraFieldsToAny converts ExtraFields from response type to a format suitable for request params.
+func extraFieldsToAny(extraFields map[string]respjson.Field) map[string]any {
+	if len(extraFields) == 0 {
+		return nil
+	}
+	result := make(map[string]any, len(extraFields))
+	for k, v := range extraFields {
+		if v.Valid() {
+			var val any
+			if err := json.Unmarshal([]byte(v.Raw()), &val); err == nil {
+				result[k] = val
+			}
+		}
+	}
+	return result
+}
+
 func (r ChatCompletionMessage) ToParam() ChatCompletionMessageParamUnion {
 	asst := r.ToAssistantMessageParam()
 	return ChatCompletionMessageParamUnion{OfAssistant: &asst}
@@ -1599,6 +1616,12 @@ func (r ChatCompletionMessage) ToAssistantMessageParam() ChatCompletionAssistant
 			p.ToolCalls = append(p.ToolCalls, u)
 		}
 	}
+
+	// Copy ExtraFields from the response to the param type
+	if extras := extraFieldsToAny(r.JSON.ExtraFields); len(extras) > 0 {
+		p.SetExtraFields(extras)
+	}
+
 	return p
 }
 


### PR DESCRIPTION
This make extra fields and extra LLM functions work, like `reasoning_content` for thinking.
Furthermore, this ensures the Go SDK behaves consistently with the Python SDK, which automatically supports extra fields.

I believe many people need this feature—or have already forked the official repo because of it. Please avoid fragmenting the community.

Closes #224. Hope it’s not too late!