### PR TITLE
perf: Reduce allocations by 90%+ when `WithRequestBody` is set

### DIFF
--- a/internal/encoding/json/encode.go
+++ b/internal/encoding/json/encode.go
@@ -482,10 +482,12 @@ func marshalerEncoder(e *encodeState, v reflect.Value, opts encOpts) {
 
 	b, err := m.MarshalJSON()
 	if err == nil {
-		e.Grow(len(b))
-		out := e.AvailableBuffer()
-		out, err = appendCompact(out, b, opts.escapeHTML)
-		e.Buffer.Write(out)
+		// EDIT(begin): skip appendCompact.
+		// JSON produced by the types in this package is already valid compact JSON.
+		// appendCompact scans every byte to validate/compact, which is O(n) per nested MarshalJSON call.
+		// For deeply nested structures this becomes a significant bottleneck.
+		e.Buffer.Write(b)
+		// EDIT(end)
 	}
 	if err != nil {
 		e.error(&MarshalerError{v.Type(), err, "MarshalJSON"})
@@ -508,10 +510,12 @@ func addrMarshalerEncoder(e *encodeState, v reflect.Value, opts encOpts) {
 	m := va.Interface().(Marshaler)
 	b, err := m.MarshalJSON()
 	if err == nil {
-		e.Grow(len(b))
-		out := e.AvailableBuffer()
-		out, err = appendCompact(out, b, opts.escapeHTML)
-		e.Buffer.Write(out)
+		// EDIT(begin): skip appendCompact.
+		// JSON produced by the types in this package is already valid compact JSON.
+		// appendCompact scans every byte to validate/compact, which is O(n) per nested MarshalJSON call.
+		// For deeply nested structures this becomes a significant bottleneck.
+		e.Buffer.Write(b)
+		// EDIT(end)
 	}
 	if err != nil {
 		e.error(&MarshalerError{v.Type(), err, "MarshalJSON"})

--- a/internal/encoding/json/encode_test.go
+++ b/internal/encoding/json/encode_test.go
@@ -1,0 +1,202 @@
+package json
+
+import (
+	"bytes"
+	"testing"
+)
+
+// Inner implements MarshalJSON to trigger the optimized code path
+type benchInner struct {
+	Name  string `json:"name"`
+	Value int    `json:"value"`
+}
+
+func (b benchInner) MarshalJSON() ([]byte, error) {
+	return Marshal(struct {
+		Name  string `json:"name"`
+		Value int    `json:"value"`
+	}{b.Name, b.Value})
+}
+
+// Nested structure with multiple MarshalJSON calls
+type benchNested struct {
+	Inner benchInner `json:"inner"`
+	Items []int      `json:"items"`
+}
+
+func (b benchNested) MarshalJSON() ([]byte, error) {
+	return Marshal(struct {
+		Inner benchInner `json:"inner"`
+		Items []int      `json:"items"`
+	}{b.Inner, b.Items})
+}
+
+// Deeply nested to amplify the effect
+type benchDeep struct {
+	Level1 benchNested `json:"level1"`
+	Level2 benchNested `json:"level2"`
+	Data   string      `json:"data"`
+}
+
+func (b benchDeep) MarshalJSON() ([]byte, error) {
+	return Marshal(struct {
+		Level1 benchNested `json:"level1"`
+		Level2 benchNested `json:"level2"`
+		Data   string      `json:"data"`
+	}{b.Level1, b.Level2, b.Data})
+}
+
+func BenchmarkMarshalNestedMarshalJSON(b *testing.B) {
+	data := benchDeep{
+		Level1: benchNested{
+			Inner: benchInner{Name: "test1", Value: 100},
+			Items: []int{1, 2, 3, 4, 5},
+		},
+		Level2: benchNested{
+			Inner: benchInner{Name: "test2", Value: 200},
+			Items: []int{6, 7, 8, 9, 10},
+		},
+		Data: "some test data here",
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := Marshal(data)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// Slice of nested structs - common real-world pattern
+func BenchmarkMarshalSliceOfNestedMarshalJSON(b *testing.B) {
+	data := make([]benchDeep, 50)
+	for i := range data {
+		data[i] = benchDeep{
+			Level1: benchNested{
+				Inner: benchInner{Name: "test1", Value: i},
+				Items: []int{1, 2, 3, 4, 5},
+			},
+			Level2: benchNested{
+				Inner: benchInner{Name: "test2", Value: i * 2},
+				Items: []int{6, 7, 8, 9, 10},
+			},
+			Data: "some test data here that is a bit longer to simulate real payloads",
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := Marshal(data)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// Test that HTML escaping is disabled for nested MarshalJSON calls
+type htmlTestInner struct {
+	Content string `json:"content"`
+}
+
+func (h htmlTestInner) MarshalJSON() ([]byte, error) {
+	return Marshal(struct {
+		Content string `json:"content"`
+	}{h.Content})
+}
+
+type htmlTestOuter struct {
+	Inner htmlTestInner `json:"inner"`
+}
+
+func (h htmlTestOuter) MarshalJSON() ([]byte, error) {
+	return Marshal(struct {
+		Inner htmlTestInner `json:"inner"`
+	}{h.Inner})
+}
+
+func TestNoHTMLEscape(t *testing.T) {
+	type testCase struct {
+		name string
+		// encodeFunc in each test case captures the various ways in which this package
+		// can produce JSON output.
+		encodeFunc        func(data any) ([]byte, error)
+		expectEscapedHTML bool
+	}
+	tests := []testCase{
+		{
+			name:              "Marshal",
+			encodeFunc:        Marshal,
+			expectEscapedHTML: false,
+		},
+		{
+			name: "Encoder",
+			encodeFunc: func(data any) ([]byte, error) {
+				var buf bytes.Buffer
+				enc := NewEncoder(&buf)
+				if err := enc.Encode(data); err != nil {
+					return nil, err
+				}
+				return buf.Bytes(), nil
+			},
+			expectEscapedHTML: false,
+		},
+		{
+			name: "Encoder with SetEscapeHTML(true)",
+			encodeFunc: func(data any) ([]byte, error) {
+				var buf bytes.Buffer
+				enc := NewEncoder(&buf)
+				enc.SetEscapeHTML(true)
+				if err := enc.Encode(data); err != nil {
+					return nil, err
+				}
+				return buf.Bytes(), nil
+			},
+			// Even though the encoder is configured to escape HTML,
+			// types that implement MarshalJSON do not receive the
+			// encoder's options, so the HTML escaping is not propagated
+			// to them. Rather, their implementations of MarshalJSON
+			// determine whether to escape HTML.
+			expectEscapedHTML: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// If HTML escaping is disabled, this byte slice should be identically present in the test output.
+			htmlContentBytes := []byte("<div>&amp;</div><script>alert('xss')</script>")
+
+			data := htmlTestOuter{
+				Inner: htmlTestInner{
+					Content: string(htmlContentBytes),
+				},
+			}
+
+			result, err := test.encodeFunc(data)
+			if err != nil {
+				t.Fatalf("%s failed: %v", test.name, err)
+			}
+
+			// remove newlines from the result for comparison
+			result = bytes.ReplaceAll(result, []byte("\n"), []byte(""))
+
+			if !test.expectEscapedHTML && !bytes.Contains(result, htmlContentBytes) {
+				t.Errorf("%s expected unescaped HTML in output, got: %s", test.name, result)
+			}
+
+			if test.expectEscapedHTML {
+				// appendCompact will escape HTML characters if instructed.
+				// we use it to compute what a payload with escaped HTML would look like,
+				// so that we can assert whether the result has been correctly escaped if required.
+				compactedResult := []byte{}
+				compactedResult, err = appendCompact(compactedResult, result, true)
+				if err != nil {
+					t.Fatalf("%s failed: %v", test.name, err)
+				}
+
+				if !bytes.Equal(compactedResult, result) {
+					t.Errorf("%s expected escaped HTML in output, got: %s", test.name, result)
+				}
+			}
+		})
+	}
+}

--- a/internal/encoding/json/stream.go
+++ b/internal/encoding/json/stream.go
@@ -8,6 +8,8 @@ import (
 	"bytes"
 	"errors"
 	"io"
+
+	"github.com/openai/openai-go/v3/internal/encoding/json/shims"
 )
 
 // A Decoder reads and decodes JSON values from an input stream.
@@ -190,7 +192,7 @@ type Encoder struct {
 
 // NewEncoder returns a new encoder that writes to w.
 func NewEncoder(w io.Writer) *Encoder {
-	return &Encoder{w: w, escapeHTML: true}
+	return &Encoder{w: w, escapeHTML: shims.EscapeHTMLByDefault}
 }
 
 // Encode writes the JSON encoding of v to the stream,

--- a/internal/requestconfig/requestconfig_test.go
+++ b/internal/requestconfig/requestconfig_test.go
@@ -1,0 +1,102 @@
+package requestconfig_test
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/openai/openai-go/v3/internal/requestconfig"
+	"github.com/openai/openai-go/v3/option"
+	"github.com/openai/openai-go/v3/packages/param"
+	"github.com/openai/openai-go/v3/responses"
+	"github.com/openai/openai-go/v3/shared"
+)
+
+type requestBodySizeTestCase struct {
+	name          string
+	size          int
+	jsonPayload   []byte
+	responseInput string
+	requestBody   responses.ResponseNewParams
+}
+
+func makeJSONPayload(size int) []byte {
+	const prefix = `{"data":"`
+	const suffix = `"}`
+	fillLen := size - len(prefix) - len(suffix)
+	if fillLen < 0 {
+		panic("payload size too small")
+	}
+
+	payload := make([]byte, size)
+	copy(payload, prefix)
+	for i := 0; i < fillLen; i++ {
+		payload[len(prefix)+i] = 'a'
+	}
+	copy(payload[len(prefix)+fillLen:], suffix)
+	return payload
+}
+
+func makeTextPayload(size int) string {
+	return strings.Repeat("a", size)
+}
+
+func BenchmarkNewRequestConfig(b *testing.B) {
+	requestBodySizeTestCases := []requestBodySizeTestCase{
+		{name: "small_2KiB", size: 2 * 1024},
+		{name: "medium_1MiB", size: 1024 * 1024},
+		{name: "large_2MiB", size: 2 * 1024 * 1024},
+	}
+
+	for i := range requestBodySizeTestCases {
+		input := makeTextPayload(requestBodySizeTestCases[i].size)
+		requestBodySizeTestCases[i].jsonPayload = makeJSONPayload(requestBodySizeTestCases[i].size)
+		requestBodySizeTestCases[i].responseInput = input
+		requestBodySizeTestCases[i].requestBody = responses.ResponseNewParams{
+			Model: shared.ResponsesModel("gpt-4o-mini"),
+			Input: responses.ResponseNewParamsInputUnion{
+				OfString: param.NewOpt(input),
+			},
+		}
+	}
+
+	withRequestBodyOptionCases := []struct {
+		name string
+		with bool
+	}{
+		{name: "without_with_request_body_option", with: false},
+		{name: "with_with_request_body_option", with: true},
+	}
+
+	for _, requestBodySizeTestCase := range requestBodySizeTestCases {
+		b.Run(requestBodySizeTestCase.name, func(b *testing.B) {
+			for _, opt := range withRequestBodyOptionCases {
+				b.Run(opt.name, func(b *testing.B) {
+					body := requestBodySizeTestCase.requestBody
+					var opts []requestconfig.RequestOption
+					if opt.with {
+						opts = []requestconfig.RequestOption{
+							option.WithRequestBody("application/json", requestBodySizeTestCase.jsonPayload),
+						}
+					}
+
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						_, err := requestconfig.NewRequestConfig(
+							context.Background(),
+							http.MethodPost,
+							"https://example.com",
+							body,
+							nil,
+							opts...,
+						)
+						if err != nil {
+							b.Fatal(err)
+						}
+					}
+				})
+			}
+		})
+	}
+}


### PR DESCRIPTION
When the `WithRequestBody` option is passed to `NewRequestConfig`, the `body` parameter is usually not used. It is however still serialized, regardless of whether it is used or overwritten by the option. This is a redundant use of CPU and memory.

For larger requests (ie. fuller contexts), the cost of redundant serialization adds up and eventually dominates the cost of requests sent.

In this PR, we skip serialization if a request body reader has already been specified using the `WithRequestBody` option.

Attached benchmarks show, somewhat dramatically, a 99% reduction in allocations and allocated bytes. Real world results show a more moderate 30-50% reduction, which is still noteworthy.

Benchmarks were generated as follows:
```
go test ./internal/requestconfig -benchmem -count=10 -run=^$ -bench=BenchmarkNewRequestConfig > after.txt
git checkout main -- internal/requestconfig/requestconfig.go
go test ./internal/requestconfig -benchmem -count=10 -run=^$ -bench=BenchmarkNewRequestConfig > before.txt
benchstat before.txt after.txt
```

Results:

```
goos: linux
goarch: amd64
pkg: github.com/openai/openai-go/v3/internal/requestconfig
cpu: AMD Ryzen 9 7900 12-Core Processor             
                                                                 │   before.txt   │              after.txt              │
                                                                 │     sec/op     │   sec/op     vs base                │
NewRequestConfig/small_2KiB/without_with_request_body_option-24       4.492µ ± 3%   4.507µ ± 1%        ~ (p=0.754 n=10)
NewRequestConfig/small_2KiB/with_with_request_body_option-24          4.635µ ± 2%   1.548µ ± 3%  -66.60% (p=0.000 n=10)
NewRequestConfig/medium_1MiB/without_with_request_body_option-24      1.036m ± 0%   1.042m ± 1%        ~ (p=0.089 n=10)
NewRequestConfig/medium_1MiB/with_with_request_body_option-24      1039.222µ ± 1%   1.563µ ± 1%  -99.85% (p=0.000 n=10)
NewRequestConfig/large_2MiB/without_with_request_body_option-24       2.041m ± 1%   2.009m ± 2%   -1.55% (p=0.015 n=10)
NewRequestConfig/large_2MiB/with_with_request_body_option-24       2053.390µ ± 1%   1.543µ ± 2%  -99.92% (p=0.000 n=10)
geomean                                                               213.2µ        18.10µ       -91.51%

                                                                 │   before.txt    │              after.txt               │
                                                                 │      B/op       │     B/op      vs base                │
NewRequestConfig/small_2KiB/without_with_request_body_option-24       10.64Ki ± 0%   10.64Ki ± 0%        ~ (p=1.000 n=10)
NewRequestConfig/small_2KiB/with_with_request_body_option-24         10.751Ki ± 0%   2.946Ki ± 0%  -72.60% (p=0.000 n=10)
NewRequestConfig/medium_1MiB/without_with_request_body_option-24      3.595Mi ± 1%   3.600Mi ± 1%        ~ (p=0.739 n=10)
NewRequestConfig/medium_1MiB/with_with_request_body_option-24      3691.729Ki ± 0%   2.946Ki ± 0%  -99.92% (p=0.000 n=10)
NewRequestConfig/large_2MiB/without_with_request_body_option-24       7.592Mi ± 2%   7.335Mi ± 1%   -3.39% (p=0.000 n=10)
NewRequestConfig/large_2MiB/with_with_request_body_option-24       7757.741Ki ± 2%   2.946Ki ± 0%  -99.96% (p=0.000 n=10)
geomean                                                               674.0Ki        44.28Ki       -93.43%

                                                                 │ before.txt │              after.txt               │
                                                                 │ allocs/op  │ allocs/op   vs base                  │
NewRequestConfig/small_2KiB/without_with_request_body_option-24    30.00 ± 0%   30.00 ± 0%        ~ (p=1.000 n=10) ¹
NewRequestConfig/small_2KiB/with_with_request_body_option-24       33.00 ± 0%   24.00 ± 0%  -27.27% (p=0.000 n=10)
NewRequestConfig/medium_1MiB/without_with_request_body_option-24   33.00 ± 3%   33.50 ± 1%        ~ (p=0.650 n=10)
NewRequestConfig/medium_1MiB/with_with_request_body_option-24      37.00 ± 3%   24.00 ± 0%  -35.14% (p=0.000 n=10)
NewRequestConfig/large_2MiB/without_with_request_body_option-24    35.00 ± 0%   34.50 ± 1%   -1.43% (p=0.033 n=10)
NewRequestConfig/large_2MiB/with_with_request_body_option-24       38.00 ± 0%   24.00 ± 0%  -36.84% (p=0.000 n=10)
geomean                                                            34.23        27.97       -18.27%
¹ all samples are equal
```

