### PR TITLE
fix: embedded reflect.Type breaks Go linker dead-code elimination #609

### DIFF
--- a/internal/apiform/encoder.go
+++ b/internal/apiform/encoder.go
@@ -58,7 +58,7 @@ type encoderField struct {
 }
 
 type encoderEntry struct {
-	reflect.Type
+	typ        reflect.Type
 	dateFormat string
 	arrayFmt   string
 	root       bool
@@ -76,7 +76,7 @@ func (e *encoder) marshal(value any, writer *multipart.Writer) error {
 
 func (e *encoder) typeEncoder(t reflect.Type) encoderFunc {
 	entry := encoderEntry{
-		Type:       t,
+		typ:        t,
 		dateFormat: e.dateFormat,
 		arrayFmt:   e.arrayFmt,
 		root:       e.root,

--- a/internal/apijson/decoder.go
+++ b/internal/apijson/decoder.go
@@ -80,7 +80,7 @@ type decoderField struct {
 }
 
 type decoderEntry struct {
-	reflect.Type
+	typ        reflect.Type
 	dateFormat string
 	root       bool
 }
@@ -108,7 +108,7 @@ func (d *decoderBuilder) unmarshalWithExactness(raw []byte, to any) (exactness, 
 
 func (d *decoderBuilder) typeDecoder(t reflect.Type) decoderFunc {
 	entry := decoderEntry{
-		Type:       t,
+		typ:        t,
 		dateFormat: d.dateFormat,
 		root:       d.root,
 	}

--- a/internal/apijson/encoder.go
+++ b/internal/apijson/encoder.go
@@ -44,7 +44,7 @@ type encoderField struct {
 }
 
 type encoderEntry struct {
-	reflect.Type
+	typ        reflect.Type
 	dateFormat string
 	root       bool
 }
@@ -61,7 +61,7 @@ func (e *encoder) marshal(value any) ([]byte, error) {
 
 func (e *encoder) typeEncoder(t reflect.Type) encoderFunc {
 	entry := encoderEntry{
-		Type:       t,
+		typ:        t,
 		dateFormat: e.dateFormat,
 		root:       e.root,
 	}

--- a/internal/apiquery/encoder.go
+++ b/internal/apiquery/encoder.go
@@ -29,7 +29,7 @@ type encoderField struct {
 }
 
 type encoderEntry struct {
-	reflect.Type
+	typ        reflect.Type
 	dateFormat string
 	root       bool
 	settings   QuerySettings
@@ -42,7 +42,7 @@ type Pair struct {
 
 func (e *encoder) typeEncoder(t reflect.Type) encoderFunc {
 	entry := encoderEntry{
-		Type:       t,
+		typ:        t,
 		dateFormat: e.dateFormat,
 		root:       e.root,
 		settings:   e.settings,


### PR DESCRIPTION
## fix: avoid embedding `reflect.Type` in `decoderEntry` to preserve linker dead-code elimination

Fixes #609

### Summary

Changed the embedded `reflect.Type` field in `decoderEntry` to a named field `typ`, preventing method promotion that defeats the Go linker's dead-code elimination when combined with protobuf dependencies.

### Problem

`decoderEntry` embedded `reflect.Type`, which promoted ~20 interface methods onto the struct. When stored in `sync.Map` (as `any`), the compiler tagged these promoted method wrappers with `REFLECTMETHOD + UsedInIface`. On its own this is harmless, but when any dependency in the same binary calls `reflect.Type.Method(int)` (common in protobuf-generated `init()` code), the linker's dead-code pass matches these markers and disables DCE globally — inflating binaries by 30-40 MB.

### Fix

```go
// before
type decoderEntry struct {
    reflect.Type        // embedded — promotes ~20 methods
    dateFormat string
    root       bool
}

// after
type decoderEntry struct {
    typ        reflect.Type  // named field — no method promotion
    dateFormat string
    root       bool
}
```

This is a zero-behavioral-change fix: `decoderEntry` is unexported, in an `internal` package, and the field is only used as a `sync.Map` key for equality comparison. `reflect.Type` is comparable, so map key semantics are preserved.
