### PR TITLE
Fix docs Azure OpenAI link formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -955,7 +955,7 @@ middleware has been applied.
 
 ## Microsoft Azure OpenAI
 
-To use this library with [Azure OpenAI]https://learn.microsoft.com/azure/ai-services/openai/overview),
+To use this library with [Azure OpenAI](https://learn.microsoft.com/azure/ai-services/openai/overview),
 use the option.RequestOption functions in the `azure` package.
 
 ```go


### PR DESCRIPTION
Fixes malformed markdown link in README where Azure OpenAI link was missing opening parenthesis before URL. Corrects [Azure OpenAI]https://...) to [Azure OpenAI](https://...).