### PR TITLE
fix(ssestream): skip SSE blocks without data

### DIFF
--- a/packages/ssestream/ssestream.go
+++ b/packages/ssestream/ssestream.go
@@ -177,6 +177,9 @@ func (s *Stream[T]) Next() bool {
 		if s.done {
 			continue
 		}
+		if len(s.decoder.Event().Data) == 0 {
+			continue
+		}
 
 		if bytes.HasPrefix(s.decoder.Event().Data, []byte("[DONE]")) {
 			// In this case we don't break because we still want to iterate through the full stream.

--- a/packages/ssestream/ssestream.go
+++ b/packages/ssestream/ssestream.go
@@ -82,6 +82,10 @@ func (s *eventStreamDecoder) Next() bool {
 
 		// Dispatch event on an empty line
 		if len(txt) == 0 {
+			if data.Len() == 0 {
+				event = ""
+				continue
+			}
 			s.evt = Event{
 				Type: event,
 				Data: data.Bytes(),
@@ -175,9 +179,6 @@ func (s *Stream[T]) Next() bool {
 
 	for s.decoder.Next() {
 		if s.done {
-			continue
-		}
-		if len(s.decoder.Event().Data) == 0 {
 			continue
 		}
 

--- a/packages/ssestream/ssestream_test.go
+++ b/packages/ssestream/ssestream_test.go
@@ -1,6 +1,7 @@
 package ssestream
 
 import (
+	"errors"
 	"io"
 	"net/http"
 	"reflect"
@@ -19,6 +20,10 @@ func TestStreamSkipsEventsWithoutData(t *testing.T) {
 		},
 		"retry directive": {
 			body: "retry: 3000\n\ndata: {\"value\":\"first\"}\n\ndata: [DONE]\n\n",
+			want: []string{"first"},
+		},
+		"CRLF comment": {
+			body: ": OPENROUTER PROCESSING\r\n\r\ndata: {\"value\":\"first\"}\r\n\r\ndata: [DONE]\r\n\r\n",
 			want: []string{"first"},
 		},
 		"multiple empty events": {
@@ -53,5 +58,123 @@ func TestStreamSkipsEventsWithoutData(t *testing.T) {
 				t.Fatalf("received values %v, want %v", got, test.want)
 			}
 		})
+	}
+}
+
+func TestDecoderSkipsBlocksWithoutData(t *testing.T) {
+	decoder := NewDecoder(&http.Response{
+		Header: http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body: io.NopCloser(strings.NewReader(
+			": keep-alive\n\nretry: 3000\n\ndata: {\"value\":\"first\"}\n\n",
+		)),
+	})
+
+	if !decoder.Next() {
+		t.Fatalf("decoder stopped before data event: %v", decoder.Err())
+	}
+	if got, want := string(decoder.Event().Data), "{\"value\":\"first\"}\n"; got != want {
+		t.Fatalf("event data = %q, want %q", got, want)
+	}
+	if decoder.Next() {
+		t.Fatalf("unexpected additional event: %+v", decoder.Event())
+	}
+	if err := decoder.Err(); err != nil {
+		t.Fatalf("decoder ended with error: %v", err)
+	}
+}
+
+type testDecoder struct {
+	events  []Event
+	current Event
+	next    int
+}
+
+func (d *testDecoder) Next() bool {
+	if d.next == len(d.events) {
+		return false
+	}
+	d.current = d.events[d.next]
+	d.next++
+	return true
+}
+
+func (d *testDecoder) Event() Event { return d.current }
+func (d *testDecoder) Close() error { return nil }
+func (d *testDecoder) Err() error   { return nil }
+
+func TestSynthesizedStreamPreservesCustomEventsWithoutData(t *testing.T) {
+	decoder := &testDecoder{events: []Event{{Type: "custom.heartbeat"}}}
+	stream := NewStreamWithSynthesizeEventData[struct {
+		Event string `json:"event"`
+		Data  any    `json:"data"`
+	}](decoder, nil)
+
+	if !stream.Next() {
+		t.Fatalf("stream stopped before custom event: %v", stream.Err())
+	}
+	if got := stream.Current(); got.Event != "custom.heartbeat" || got.Data != nil {
+		t.Fatalf("custom event = %#v, want event custom.heartbeat with nil data", got)
+	}
+}
+
+func TestStreamPreservesErrorAfterBlockWithoutData(t *testing.T) {
+	stream := NewStream[map[string]any](NewDecoder(&http.Response{
+		Header: http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body: io.NopCloser(strings.NewReader(
+			": keep-alive\n\ndata: {\"error\":{\"message\":\"bad\"}}\n\n",
+		)),
+	}), nil)
+
+	if stream.Next() {
+		t.Fatal("error event unexpectedly produced a stream value")
+	}
+	var streamErr *StreamError
+	if !errors.As(stream.Err(), &streamErr) {
+		t.Fatalf("stream error = %v, want *StreamError", stream.Err())
+	}
+}
+
+var errTestReader = errors.New("test reader error")
+
+type testErrorReadCloser struct {
+	*strings.Reader
+}
+
+func (r *testErrorReadCloser) Read(p []byte) (int, error) {
+	if r.Len() == 0 {
+		return 0, errTestReader
+	}
+	return r.Reader.Read(p)
+}
+
+func (r *testErrorReadCloser) Close() error { return nil }
+
+func TestStreamPreservesReaderErrorAfterBlockWithoutData(t *testing.T) {
+	stream := NewStream[map[string]any](NewDecoder(&http.Response{
+		Header: http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body: &testErrorReadCloser{
+			Reader: strings.NewReader(": keep-alive\n\n"),
+		},
+	}), nil)
+
+	if stream.Next() {
+		t.Fatal("reader error unexpectedly produced a stream value")
+	}
+	if !errors.Is(stream.Err(), errTestReader) {
+		t.Fatalf("stream error = %v, want %v", stream.Err(), errTestReader)
+	}
+}
+
+func TestStreamRejectsEmptyDataField(t *testing.T) {
+	stream := NewStream[map[string]any](NewDecoder(&http.Response{
+		Header: http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:   io.NopCloser(strings.NewReader("data:\n\n")),
+	}), nil)
+
+	if stream.Next() {
+		t.Fatal("empty data field unexpectedly produced a stream value")
+	}
+	if err := stream.Err(); err == nil || !strings.Contains(err.Error(), "unexpected end of JSON input") {
+		t.Fatalf("stream error = %v, want unexpected end of JSON input", err)
 	}
 }

--- a/packages/ssestream/ssestream_test.go
+++ b/packages/ssestream/ssestream_test.go
@@ -1,0 +1,57 @@
+package ssestream
+
+import (
+	"io"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestStreamSkipsEventsWithoutData(t *testing.T) {
+	tests := map[string]struct {
+		body string
+		want []string
+	}{
+		"comment": {
+			body: ": OPENROUTER PROCESSING\n\ndata: {\"value\":\"first\"}\n\ndata: [DONE]\n\n",
+			want: []string{"first"},
+		},
+		"retry directive": {
+			body: "retry: 3000\n\ndata: {\"value\":\"first\"}\n\ndata: [DONE]\n\n",
+			want: []string{"first"},
+		},
+		"multiple empty events": {
+			body: "data: {\"value\":\"first\"}\n\n: keep-alive\n\nretry: 3000\n\ndata: {\"value\":\"second\"}\n\ndata: [DONE]\n\n",
+			want: []string{"first", "second"},
+		},
+		"only empty events": {
+			body: ": keep-alive\n\nretry: 3000\n\n",
+			want: nil,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			res := &http.Response{
+				Header: http.Header{"Content-Type": []string{"text/event-stream"}},
+				Body:   io.NopCloser(strings.NewReader(test.body)),
+			}
+			stream := NewStream[struct {
+				Value string `json:"value"`
+			}](NewDecoder(res), nil)
+
+			var got []string
+			for stream.Next() {
+				got = append(got, stream.Current().Value)
+			}
+
+			if err := stream.Err(); err != nil {
+				t.Fatalf("stream ended with error: %v", err)
+			}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("received values %v, want %v", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Make the built-in SSE decoder suppress blocks that contain no `data:` fields.

This fixes streaming through OpenAI-compatible providers that send SSE comment or retry blocks, including OpenRouter's `: OPENROUTER PROCESSING` keep-alive comments.

Closes https://github.com/openai/openai-go/issues/556

## Root cause

The decoder correctly ignored comment lines and unhandled fields such as `retry:`, but it unconditionally emitted an `Event` when it reached the following blank line. Because that block contained no `data:` field, the event's `Data` was empty. `Stream.Next` then attempted to decode the empty byte slice as JSON and returned `unexpected end of JSON input`.

Under the SSE dispatch algorithm, a block whose data buffer is empty does not fire an event.

## Fix

When the built-in SSE decoder reaches a blank line with an empty data buffer, it resets the event type and continues scanning. This fixes the issue at the parser layer for both direct decoder consumers and typed streams.

The check is intentionally limited to the built-in SSE decoder. Registered custom decoders and synthesized custom events retain their prior behavior.

A `data:` field with an empty value remains a data-bearing event and therefore remains invalid input for these JSON streams.

## Context

This was observed by Charm's [Fantasy](https://github.com/charmbracelet/fantasy) and [Crush](https://github.com/charmbracelet/crush) projects after setting a custom `User-Agent` while using OpenRouter. OpenRouter documents that its streaming API may send comments to prevent connection timeouts: https://openrouter.ai/docs/api/reference/streaming#additional-information.

Issue #618 reports the same JSON error but attributes it to incomplete JSON caused by transport flushing. That is separate from the no-data comment/retry blocks fixed here, so this PR does not close it.

## Validation

The regression suite covers:

- The exact OpenRouter `: OPENROUTER PROCESSING` comment
- `retry:` directives
- Multiple no-data blocks between JSON events
- Streams containing only no-data blocks
- CRLF framing
- Direct decoder behavior
- Custom synthesized type-only events
- Error events after no-data blocks
- Reader errors after no-data blocks
- Explicit empty `data:` fields

The exact stream fails on the pre-fix commit with `unexpected end of JSON input` and succeeds with this change.

```sh
./scripts/test
./scripts/test -race
./scripts/lint
go test ./packages/ssestream -count=20
```
