### PR TITLE
docs: fix Azure API version link typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -971,7 +971,7 @@ func main() {
 	const azureOpenAIEndpoint = "https://<azure-openai-resource>.openai.azure.com"
 
 	// The latest API versions, including previews, can be found here:
-	// https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#rest-api-versionng
+	// https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#rest-api-versioning
 	const azureOpenAIAPIVersion = "2024-06-01"
 
 	tokenCredential, err := azidentity.NewDefaultAzureCredential(nil)


### PR DESCRIPTION
## Summary
- Fix the `versioning` anchor typo in the Azure example comment in `README.md`.

## Related issue
- N/A (trivial docs typo fix)

## Guideline alignment
- Reviewed `CONTRIBUTING.md` before editing.
- Kept the diff to one documentation file and avoided generated code.

## Validation
- Not run (docs-only change).