### PR TITLE
Remove single quotes in README for go get command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Or to pin the version:
 <!-- x-release-please-start-version -->
 
 ```sh
-go get -u 'github.com/openai/openai-go/v3@v3.30.0'
+go get -u github.com/openai/openai-go/v3@v3.30.0
 ```
 
 <!-- x-release-please-end -->


### PR DESCRIPTION
Remove single quotes since they are both unnecessary and break the command on windows

```
C:\Users\xxx>go get -u 'github.com/openai/openai-go/v3@v3.30.0'
go: 'github.com/openai/openai-go/v3@v3.30.0': malformed module path "'github.com/openai/openai-go/v3": invalid char '\''
```