### PR TITLE
docs: fix function call comment wording in example

### DIFF
--- a/examples/chat-completion-tool-calling/main.go
+++ b/examples/chat-completion-tool-calling/main.go
@@ -55,7 +55,7 @@ func main() {
 		return
 	}
 
-	// If there is a was a function call, continue the conversation
+	// If there was a function call, continue the conversation
 	params.Messages = append(params.Messages, completion.Choices[0].Message.ToParam())
 	for _, toolCall := range toolCalls {
 		if toolCall.Function.Name == "get_weather" {


### PR DESCRIPTION
## Summary
- fix the duplicated wording in the chat completion tool-calling example comment

## Related issue
- N/A (trivial example comment fix)

## Guideline alignment
- Reviewed https://github.com/openai/openai-go/blob/main/CONTRIBUTING.md and kept this to one focused example-only comment change in `examples/`, which the generator does not modify.

## Validation/testing note
- Not run (comment-only change)
