### PR TITLE
fix(ssestream): skip dispatching empty events for comment-only SSE blocks

### DIFF
--- a/packages/ssestream/ssestream.go
+++ b/packages/ssestream/ssestream.go
@@ -80,8 +80,14 @@ func (s *eventStreamDecoder) Next() bool {
 	for s.scn.Scan() {
 		txt := s.scn.Bytes()
 
-		// Dispatch event on an empty line
+		// Per the SSE spec, dispatch an event on an empty line only if
+		// data or event type was set; otherwise reset and continue.
+		// This avoids dispatching empty events for comment-only blocks
+		// (e.g. ": ping\n\n" keep-alive messages).
 		if len(txt) == 0 {
+			if data.Len() == 0 && event == "" {
+				continue
+			}
 			s.evt = Event{
 				Type: event,
 				Data: data.Bytes(),

--- a/packages/ssestream/ssestream_test.go
+++ b/packages/ssestream/ssestream_test.go
@@ -1,0 +1,118 @@
+package ssestream
+
+import (
+	"bufio"
+	"io"
+	"strings"
+	"testing"
+)
+
+type nopCloser struct {
+	io.Reader
+}
+
+func (nopCloser) Close() error { return nil }
+
+func newTestDecoder(raw string) *eventStreamDecoder {
+	rc := nopCloser{strings.NewReader(raw)}
+	scn := bufio.NewScanner(rc)
+	return &eventStreamDecoder{rc: rc, scn: scn}
+}
+
+func TestCommentOnlyBlockDoesNotDispatchEvent(t *testing.T) {
+	// A comment line followed by an empty line should NOT produce an event.
+	raw := ": ping\n\n"
+	dec := newTestDecoder(raw)
+
+	if dec.Next() {
+		t.Fatalf("expected no event for comment-only block, got event: Type=%q Data=%q", dec.Event().Type, dec.Event().Data)
+	}
+	if dec.Err() != nil {
+		t.Fatalf("unexpected error: %v", dec.Err())
+	}
+}
+
+func TestCommentBeforeDataEventIsIgnored(t *testing.T) {
+	// A comment followed by a real data event should only produce the data event.
+	raw := ": keep-alive\n\ndata: {\"id\":\"1\"}\n\n"
+	dec := newTestDecoder(raw)
+
+	if !dec.Next() {
+		t.Fatalf("expected an event but got none; err=%v", dec.Err())
+	}
+	evt := dec.Event()
+	if evt.Type != "" {
+		t.Errorf("expected empty event type, got %q", evt.Type)
+	}
+	expected := "{\"id\":\"1\"}\n"
+	if string(evt.Data) != expected {
+		t.Errorf("expected data %q, got %q", expected, string(evt.Data))
+	}
+}
+
+func TestMultipleCommentsDoNotDispatchEvents(t *testing.T) {
+	raw := ": ping\n\n: ping\n\ndata: hello\n\n"
+	dec := newTestDecoder(raw)
+
+	if !dec.Next() {
+		t.Fatalf("expected an event but got none; err=%v", dec.Err())
+	}
+	evt := dec.Event()
+	expected := "hello\n"
+	if string(evt.Data) != expected {
+		t.Errorf("expected data %q, got %q", expected, string(evt.Data))
+	}
+
+	if dec.Next() {
+		t.Fatalf("expected no more events, got Type=%q Data=%q", dec.Event().Type, dec.Event().Data)
+	}
+}
+
+func TestEventTypeOnlyDispatchesEvent(t *testing.T) {
+	// An event with only a type (no data) should still dispatch per SSE spec,
+	// since the event type was explicitly set.
+	raw := "event: ping\n\n"
+	dec := newTestDecoder(raw)
+
+	if !dec.Next() {
+		t.Fatalf("expected an event but got none; err=%v", dec.Err())
+	}
+	evt := dec.Event()
+	if evt.Type != "ping" {
+		t.Errorf("expected event type %q, got %q", "ping", evt.Type)
+	}
+	if len(evt.Data) != 0 {
+		t.Errorf("expected empty data, got %q", string(evt.Data))
+	}
+}
+
+func TestNormalDataEvent(t *testing.T) {
+	raw := "data: {\"msg\":\"hi\"}\n\n"
+	dec := newTestDecoder(raw)
+
+	if !dec.Next() {
+		t.Fatalf("expected an event but got none; err=%v", dec.Err())
+	}
+	evt := dec.Event()
+	expected := "{\"msg\":\"hi\"}\n"
+	if string(evt.Data) != expected {
+		t.Errorf("expected data %q, got %q", expected, string(evt.Data))
+	}
+}
+
+func TestEventWithTypeAndData(t *testing.T) {
+	raw := "event: message\ndata: {\"text\":\"hello\"}\n\n"
+	dec := newTestDecoder(raw)
+
+	if !dec.Next() {
+		t.Fatalf("expected an event but got none; err=%v", dec.Err())
+	}
+	evt := dec.Event()
+	if evt.Type != "message" {
+		t.Errorf("expected event type %q, got %q", "message", evt.Type)
+	}
+	expected := "{\"text\":\"hello\"}\n"
+	if string(evt.Data) != expected {
+		t.Errorf("expected data %q, got %q", expected, string(evt.Data))
+	}
+}


### PR DESCRIPTION
## Summary

The `eventStreamDecoder.Next()` method currently dispatches an event unconditionally whenever it encounters an empty line. This causes issues when SSE keep-alive comments (e.g. `: ping`) are followed by a blank line — an empty `Event` (with no type and no data) is dispatched, which leads to a `json.Unmarshal` error (`unexpected end of JSON input`) in the upstream `Stream[T].Next()`.

Per the [SSE specification](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation):

> If the data buffer is an empty string [...] set the data buffer and the event type buffer to the empty string and return.

In other words, if no `data:` or `event:` fields were set before the blank line, the event should be silently discarded.

### Changes

- **`packages/ssestream/ssestream.go`**: Added a guard in `eventStreamDecoder.Next()` to `continue` (instead of dispatching) when an empty line is encountered but both `data` and `event` are empty.
- **`packages/ssestream/ssestream_test.go`**: Added comprehensive tests covering:
  - Comment-only blocks (`: ping\n\n`) produce no events
  - Comments followed by real data events are handled correctly
  - Multiple consecutive comment blocks are all skipped
  - Events with only a type (no data) still dispatch correctly
  - Normal data events and events with both type and data work as before

### Reproduction

Send an SSE stream containing:

```
: ping

data: {"id":"1"}

```

**Before fix**: The `: ping\n\n` block dispatches an empty event → `json.Unmarshal([]byte{}, ...)` → error.

**After fix**: The `: ping\n\n` block is silently skipped, only the `data: {"id":"1"}` event is dispatched.

## Test plan

- [x] All new unit tests pass (`go test ./packages/ssestream/ -v`)
- [x] No existing tests are broken
- [ ] Maintainers verify behavior against real OpenAI streaming endpoints with keep-alive pings

Made with [Cursor](https://cursor.com)