### PR TITLE
docs(examples): decode assistant streaming replies

### DIFF
--- a/examples/beta/assistant-streaming/main.go
+++ b/examples/beta/assistant-streaming/main.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openai/openai-go/v3"
+)
+
+func main() {
+	client := openai.NewClient()
+	ctx := context.Background()
+
+	question := "Write me a haiku"
+
+	fmt.Println("> " + question)
+	fmt.Println()
+
+	stream := client.Beta.Threads.NewAndRunStreaming(ctx, openai.BetaThreadNewAndRunParams{
+		AssistantID: "asst_123",
+		Thread: openai.BetaThreadNewAndRunParamsThread{
+			Messages: []openai.BetaThreadNewAndRunParamsThreadMessage{
+				{
+					Role: "user",
+					Content: openai.BetaThreadNewAndRunParamsThreadMessageContentUnion{
+						OfString: openai.String(question),
+					},
+				},
+			},
+		},
+	})
+
+	for stream.Next() {
+		event := stream.Current()
+
+		switch data := event.AsAny().(type) {
+		case openai.AssistantStreamEventThreadMessageDelta:
+			for _, content := range data.Data.Delta.Content {
+				switch block := content.AsAny().(type) {
+				case openai.TextDeltaBlock:
+					fmt.Print(block.Text.Value)
+				case openai.RefusalDeltaBlock:
+					fmt.Print(block.Refusal)
+				}
+			}
+		}
+	}
+
+	fmt.Println()
+
+	if err := stream.Err(); err != nil {
+		panic(err.Error())
+	}
+}


### PR DESCRIPTION
## Summary
- add a beta assistant streaming example under `examples/beta/assistant-streaming`
- show how to switch on `AssistantStreamEventUnion` variants
- decode `thread.message.delta` events into text and refusal output instead of printing only raw event types

## Why
The existing issue points out that the assistant streaming example only printed event data types rather than showing how to decode the streamed assistant reply. This example demonstrates the recommended event-handling pattern directly.

Fixes #405.

## Verification
- example follows the same structure as the existing streaming examples in this repo
- Go tooling (`gofmt`, `go test`) was not available in this local workspace, so I could not run compile-time verification here