### PR TITLE
docs: fix Azure API versioning link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1069,7 +1069,7 @@ func main() {
 	const azureOpenAIEndpoint = "https://<azure-openai-resource>.openai.azure.com"
 
 	// The latest API versions, including previews, can be found here:
-	// https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#rest-api-versionng
+	// https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#rest-api-versioning
 	const azureOpenAIAPIVersion = "2024-06-01"
 
 	tokenCredential, err := azidentity.NewDefaultAzureCredential(nil)


### PR DESCRIPTION
## Summary
- Fixes the Azure OpenAI README link so it points to the REST API versioning section.

## Related issue
- N/A

## Guideline alignment
- Single-file README fix
- No behavior changes

## Validation
- `git diff --check`
