### PR TITLE
feat: support websocket on responses api

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/aws/smithy-go v1.27.8 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.2 // indirect
+	github.com/coder/websocket v1.8.15 // indirect
 	github.com/ebitengine/purego v0.9.0 // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	github.com/tidwall/gjson v1.19.0 // indirect

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/aws/smithy-go v1.27.5 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.2 // indirect
+	github.com/coder/websocket v1.8.15 // indirect
 	github.com/ebitengine/purego v0.9.0 // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	github.com/tidwall/gjson v1.19.0 // indirect

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -38,6 +38,8 @@ github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPn
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=
 github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
+github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNUA=
+github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/ebitengine/oto/v3 v3.4.0 h1:br0PgASsEWaoWn38b2Goe7m1GKFYfNgnsjSd5Gg+/bQ=

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -38,6 +38,8 @@ github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPn
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=
 github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
+github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNUA=
+github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/ebitengine/oto/v3 v3.4.1 h1:uX7B03/P2P8oWiSI5HXjyjSP4besYn3V9nDk3cR+eIY=

--- a/examples/responses-websocket/main.go
+++ b/examples/responses-websocket/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"context"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/responses"
+)
+
+func main() {
+	client := openai.NewClient()
+	ctx := context.Background()
+
+	conn, err := client.Responses.ConnectWebSocket(ctx)
+	if err != nil {
+		panic(err)
+	}
+	defer conn.Close()
+
+	stream, err := conn.New(ctx, responses.ResponseNewParams{
+		Input: responses.ResponseNewParamsInputUnion{OfString: openai.String("Tell me a short joke")},
+		Model: openai.ChatModelGPT4oMini,
+	})
+	if err != nil {
+		panic(err)
+	}
+	defer stream.Close()
+
+	for stream.Next() {
+		event := stream.Current()
+		if event.Delta != "" {
+			print(event.Delta)
+		}
+	}
+	if err := stream.Err(); err != nil {
+		panic(err)
+	}
+}

--- a/examples/responses-websocket/main.go
+++ b/examples/responses-websocket/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"context"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/responses"
+)
+
+func main() {
+	client := openai.NewClient()
+	ctx := context.Background()
+
+	conn, err := client.Responses.ConnectWebSocket(ctx)
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		if closeErr := conn.Close(); closeErr != nil {
+			panic(closeErr)
+		}
+	}()
+
+	stream, err := conn.New(ctx, responses.ResponseNewParams{
+		Input: responses.ResponseNewParamsInputUnion{OfString: openai.String("Tell me a short joke")},
+		Model: openai.ChatModelGPT4oMini,
+	})
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		if closeErr := stream.Close(); closeErr != nil {
+			panic(closeErr)
+		}
+	}()
+
+	for stream.Next() {
+		event := stream.Current()
+		if event.Delta != "" {
+			print(event.Delta)
+		}
+	}
+	if err := stream.Err(); err != nil {
+		panic(err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
 	github.com/aws/aws-sdk-go-v2 v1.43.6
 	github.com/aws/aws-sdk-go-v2/config v1.32.37
+	github.com/coder/websocket v1.8.15
 	github.com/tidwall/gjson v1.19.0
 	github.com/tidwall/sjson v1.2.5
 )

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
 	github.com/aws/aws-sdk-go-v2 v1.43.2
 	github.com/aws/aws-sdk-go-v2/config v1.32.33
+	github.com/coder/websocket v1.8.15
 	github.com/tidwall/gjson v1.19.0
 	github.com/tidwall/sjson v1.2.5
 )

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.45.2 h1:EJd8vZO3E8SE6nmPqxuxlQ1NeSb8
 github.com/aws/aws-sdk-go-v2/service/sts v1.45.2/go.mod h1:OgpPvKzsO2Ranjpli/20djMkg6UrV5mw4W3pZpq1Mqo=
 github.com/aws/smithy-go v1.27.5 h1:d1ro7KpYOYwP6m73YFa+Kc/A130VsAdX68SpsJwARMM=
 github.com/aws/smithy-go v1.27.5/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
+github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNUA=
+github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.45.6 h1:JvExZWabChDM0qJAirQYGfOYo0nd
 github.com/aws/aws-sdk-go-v2/service/sts v1.45.6/go.mod h1:XZcaQkV2cItp6yEkrwljyaPOf22RuX7T43jxap/FOmM=
 github.com/aws/smithy-go v1.27.8 h1:FR0dxZfIlV7Z8eh2iHfIofdunw382XsDV3Mxt9nUvRY=
 github.com/aws/smithy-go v1.27.8/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
+github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNUA=
+github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=

--- a/internal/testdata/consumer/go.mod
+++ b/internal/testdata/consumer/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require github.com/openai/openai-go/v3 v3.0.0
 
 require (
+	github.com/coder/websocket v1.8.15 // indirect
 	github.com/tidwall/gjson v1.19.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect

--- a/internal/testdata/consumer/go.sum
+++ b/internal/testdata/consumer/go.sum
@@ -1,3 +1,5 @@
+github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNUA=
+github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.19.0 h1:xwxm7n691Uf3u5OFjzngavjGTh55KX5q/9w9xHW88JU=
 github.com/tidwall/gjson v1.19.0/go.mod h1:V37/opeE/JbLUOfH0QTXiNez2l0RUjYUhpT4szFQAfc=

--- a/responses/websocket.go
+++ b/responses/websocket.go
@@ -1,0 +1,402 @@
+package responses
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"slices"
+	"strings"
+	"sync"
+
+	"github.com/coder/websocket"
+	"github.com/openai/openai-go/v3/internal/requestconfig"
+	"github.com/openai/openai-go/v3/option"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// ConnectWebSocket connects to the Responses API WebSocket endpoint.
+func (r *ResponseService) ConnectWebSocket(ctx context.Context, opts ...option.RequestOption) (*WebSocketConn, error) {
+	opts = slices.Concat(r.Options, opts)
+
+	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, "responses", nil, nil, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	wsURL, err := responsesWebSocketURL(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	dialCtx := cfg.Request.Context()
+	if cfg.RequestTimeout > 0 {
+		var cancel context.CancelFunc
+		dialCtx, cancel = context.WithTimeout(dialCtx, cfg.RequestTimeout)
+		defer cancel()
+	}
+
+	conn, _, err := websocket.Dial(dialCtx, wsURL, &websocket.DialOptions{
+		HTTPClient: websocketHTTPClient(cfg),
+		HTTPHeader: cfg.Request.Header.Clone(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return newWebSocketConn(conn), nil
+}
+
+func responsesWebSocketURL(cfg *requestconfig.RequestConfig) (string, error) {
+	baseURL := cfg.BaseURL
+	if baseURL == nil {
+		baseURL = cfg.DefaultBaseURL
+	}
+	if baseURL == nil {
+		return "", errors.New("requestconfig: base url is not set")
+	}
+
+	u, err := baseURL.Parse(strings.TrimLeft(cfg.Request.URL.String(), "/"))
+	if err != nil {
+		return "", err
+	}
+
+	switch u.Scheme {
+	case "https":
+		u.Scheme = "wss"
+	case "http":
+		u.Scheme = "ws"
+	case "wss", "ws":
+	default:
+		return "", fmt.Errorf("responses websocket: unsupported base URL scheme %q", u.Scheme)
+	}
+
+	return u.String(), nil
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func websocketHTTPClient(cfg *requestconfig.RequestConfig) *http.Client {
+	if cfg.CustomHTTPDoer == nil && len(cfg.Middlewares) == 0 {
+		return cfg.HTTPClient
+	}
+
+	handler := cfg.HTTPClient.Do
+	if cfg.CustomHTTPDoer != nil {
+		handler = cfg.CustomHTTPDoer.Do
+	}
+	for i := len(cfg.Middlewares) - 1; i >= 0; i-- {
+		middleware := cfg.Middlewares[i]
+		next := handler
+		handler = func(req *http.Request) (*http.Response, error) {
+			return middleware(req, next)
+		}
+	}
+
+	return &http.Client{Transport: roundTripperFunc(handler)}
+}
+
+type wsMessage struct {
+	messageType websocket.MessageType
+	data        []byte
+	err         error
+}
+
+// WebSocketConn is a WebSocket connection to the Responses API.
+type WebSocketConn struct {
+	conn *websocket.Conn
+
+	msgCh   chan wsMessage
+	writeMu sync.Mutex
+
+	mu       sync.Mutex
+	inFlight bool
+	closed   bool
+
+	closeOnce sync.Once
+	closeErr  error
+}
+
+func newWebSocketConn(conn *websocket.Conn) *WebSocketConn {
+	c := &WebSocketConn{
+		conn:  conn,
+		msgCh: make(chan wsMessage, 16),
+	}
+	go c.readPump()
+	return c
+}
+
+func (c *WebSocketConn) readPump() {
+	defer close(c.msgCh)
+	for {
+		messageType, data, err := c.conn.Read(context.Background())
+		if err != nil {
+			c.markClosed()
+			c.msgCh <- wsMessage{err: err}
+			return
+		}
+		c.msgCh <- wsMessage{messageType: messageType, data: data}
+	}
+}
+
+// New creates a response over the WebSocket connection.
+func (c *WebSocketConn) New(ctx context.Context, body ResponseNewParams) (*WebSocketStream, error) {
+	if err := c.acquireStream(); err != nil {
+		return nil, err
+	}
+
+	payload, err := body.MarshalJSON()
+	if err != nil {
+		c.releaseStream()
+		return nil, err
+	}
+	payload, err = sjson.SetBytes(payload, "type", "response.create")
+	if err != nil {
+		c.releaseStream()
+		return nil, err
+	}
+
+	c.writeMu.Lock()
+	err = c.conn.Write(ctx, websocket.MessageText, payload)
+	c.writeMu.Unlock()
+	if err != nil {
+		c.releaseStream()
+		c.markClosed()
+		return nil, err
+	}
+
+	return &WebSocketStream{conn: c, ctx: ctx}, nil
+}
+
+func (c *WebSocketConn) acquireStream() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.closed {
+		return errors.New("responses websocket: connection is closed")
+	}
+	if c.inFlight {
+		return errors.New("responses websocket: another response stream is already active on this connection")
+	}
+	c.inFlight = true
+	return nil
+}
+
+func (c *WebSocketConn) releaseStream() {
+	c.mu.Lock()
+	c.inFlight = false
+	c.mu.Unlock()
+}
+
+func (c *WebSocketConn) markClosed() {
+	c.mu.Lock()
+	c.closed = true
+	c.inFlight = false
+	c.mu.Unlock()
+}
+
+func (c *WebSocketConn) isClosed() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.closed
+}
+
+// Close closes the WebSocket connection. It is safe to call multiple times.
+func (c *WebSocketConn) Close() error {
+	c.closeOnce.Do(func() {
+		c.markClosed()
+		err := c.conn.Close(websocket.StatusNormalClosure, "")
+		if errors.Is(err, net.ErrClosed) {
+			err = nil
+		}
+		c.closeErr = err
+	})
+	return c.closeErr
+}
+
+// WebSocketStream is a stream of Responses API events received over a WebSocket.
+type WebSocketStream struct {
+	conn *WebSocketConn
+	ctx  context.Context
+
+	cur ResponseStreamEventUnion
+	err error
+
+	done     bool
+	released bool
+
+	closeOnce sync.Once
+	closeErr  error
+}
+
+// Next advances the stream to the next event.
+func (s *WebSocketStream) Next() bool {
+	if s.err != nil || s.done {
+		s.release()
+		return false
+	}
+
+	for {
+		msg, ok := s.nextMessage()
+		if !ok {
+			return false
+		}
+		if msg.err != nil {
+			s.handleReadError(msg.err)
+			return false
+		}
+		messageType, data := msg.messageType, msg.data
+		if messageType != websocket.MessageText && messageType != websocket.MessageBinary {
+			continue
+		}
+		if strings.HasPrefix(string(data), "[DONE]") {
+			s.done = true
+			s.release()
+			return false
+		}
+
+		if wsErr := parseWebSocketError(data); wsErr != nil {
+			s.err = wsErr
+			s.done = true
+			s.release()
+			return false
+		}
+
+		var event ResponseStreamEventUnion
+		if err := json.Unmarshal(data, &event); err != nil {
+			s.err = fmt.Errorf("responses websocket: error decoding event: %w", err)
+			s.done = true
+			s.release()
+			return false
+		}
+
+		s.cur = event
+		if isTerminalResponseStreamEvent(event.Type) {
+			s.done = true
+			s.release()
+		}
+		return true
+	}
+}
+
+func (s *WebSocketStream) nextMessage() (wsMessage, bool) {
+	select {
+	case msg, ok := <-s.conn.msgCh:
+		if !ok {
+			s.handleReadError(net.ErrClosed)
+			return wsMessage{}, false
+		}
+		return msg, true
+	case <-s.ctx.Done():
+		s.err = s.ctx.Err()
+		s.done = true
+		s.release()
+		return wsMessage{}, false
+	}
+}
+
+func (s *WebSocketStream) handleReadError(err error) {
+	status := websocket.CloseStatus(err)
+	if status == websocket.StatusNormalClosure || status == websocket.StatusGoingAway || status == websocket.StatusNoStatusRcvd || errors.Is(err, net.ErrClosed) || s.conn.isClosed() {
+		s.err = nil
+	} else {
+		s.err = err
+	}
+	if status != -1 || errors.Is(err, net.ErrClosed) {
+		s.conn.markClosed()
+	}
+	s.done = true
+	s.release()
+}
+
+func isTerminalResponseStreamEvent(eventType string) bool {
+	switch eventType {
+	case "response.completed", "response.failed", "response.incomplete", "response.cancelled", "error":
+		return true
+	default:
+		return false
+	}
+}
+
+// Current returns the current event.
+func (s *WebSocketStream) Current() ResponseStreamEventUnion {
+	return s.cur
+}
+
+// Err returns the stream error, if any.
+func (s *WebSocketStream) Err() error {
+	return s.err
+}
+
+// Close closes the stream. If the stream is still active, it closes the underlying
+// WebSocket connection because unread events cannot be safely skipped.
+func (s *WebSocketStream) Close() error {
+	s.closeOnce.Do(func() {
+		if s.done {
+			s.release()
+			return
+		}
+		s.done = true
+		s.release()
+		s.closeErr = s.conn.Close()
+	})
+	return s.closeErr
+}
+
+func (s *WebSocketStream) release() {
+	if s.released {
+		return
+	}
+	s.released = true
+	s.conn.releaseStream()
+}
+
+// WebSocketError is returned by WebSocketStream.Err for documented Responses API
+// WebSocket error messages.
+type WebSocketError struct {
+	Status  int
+	Code    string
+	Message string
+	Param   string
+}
+
+func (e *WebSocketError) Error() string {
+	msg := "responses websocket error"
+	if e.Status != 0 {
+		msg += fmt.Sprintf(": status %d", e.Status)
+	}
+	if e.Code != "" {
+		msg += fmt.Sprintf(": %s", e.Code)
+	}
+	if e.Message != "" {
+		msg += fmt.Sprintf(": %s", e.Message)
+	}
+	if e.Param != "" {
+		msg += fmt.Sprintf(" (param: %s)", e.Param)
+	}
+	return msg
+}
+
+func parseWebSocketError(data []byte) *WebSocketError {
+	if gjson.GetBytes(data, "type").String() != "error" {
+		return nil
+	}
+	errorObject := gjson.GetBytes(data, "error")
+	if !errorObject.Exists() || !errorObject.IsObject() {
+		return nil
+	}
+
+	return &WebSocketError{
+		Status:  int(gjson.GetBytes(data, "status").Int()),
+		Code:    errorObject.Get("code").String(),
+		Message: errorObject.Get("message").String(),
+		Param:   errorObject.Get("param").String(),
+	}
+}

--- a/responses/websocket.go
+++ b/responses/websocket.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"slices"
@@ -39,15 +40,19 @@ func (r *ResponseService) ConnectWebSocket(ctx context.Context, opts ...option.R
 		defer cancel()
 	}
 
-	conn, _, err := websocket.Dial(dialCtx, wsURL, &websocket.DialOptions{
+	conn, resp, err := websocket.Dial(dialCtx, wsURL, &websocket.DialOptions{
 		HTTPClient: websocketHTTPClient(cfg),
 		HTTPHeader: cfg.Request.Header.Clone(),
 	})
 	if err != nil {
-		return nil, err
+		return nil, newWebSocketDialError(wsURL, resp, err)
 	}
 
-	return newWebSocketConn(conn), nil
+	var header http.Header
+	if resp != nil {
+		header = resp.Header
+	}
+	return newWebSocketConn(conn, header), nil
 }
 
 func responsesWebSocketURL(cfg *requestconfig.RequestConfig) (string, error) {
@@ -111,7 +116,8 @@ type wsMessage struct {
 
 // WebSocketConn is a WebSocket connection to the Responses API.
 type WebSocketConn struct {
-	conn *websocket.Conn
+	conn   *websocket.Conn
+	header http.Header
 
 	msgCh   chan wsMessage
 	writeMu sync.Mutex
@@ -124,10 +130,21 @@ type WebSocketConn struct {
 	closeErr  error
 }
 
-func newWebSocketConn(conn *websocket.Conn) *WebSocketConn {
+var (
+	// ErrWebSocketConnectionClosed is returned when a new stream is attempted on
+	// a Responses WebSocket connection the SDK already knows is closed.
+	ErrWebSocketConnectionClosed = errors.New("responses websocket: connection is closed")
+
+	// ErrWebSocketStreamActive is returned when a new stream is attempted while
+	// another response stream is still active on the same WebSocket connection.
+	ErrWebSocketStreamActive = errors.New("responses websocket: another response stream is already active on this connection")
+)
+
+func newWebSocketConn(conn *websocket.Conn, header http.Header) *WebSocketConn {
 	c := &WebSocketConn{
-		conn:  conn,
-		msgCh: make(chan wsMessage, 16),
+		conn:   conn,
+		header: header.Clone(),
+		msgCh:  make(chan wsMessage, 16),
 	}
 	go c.readPump()
 	return c
@@ -169,7 +186,7 @@ func (c *WebSocketConn) New(ctx context.Context, body ResponseNewParams) (*WebSo
 	if err != nil {
 		c.releaseStream()
 		c.markClosed()
-		return nil, err
+		return nil, &WebSocketTransportError{Op: "write", Err: err}
 	}
 
 	return &WebSocketStream{conn: c, ctx: ctx}, nil
@@ -180,10 +197,10 @@ func (c *WebSocketConn) acquireStream() error {
 	defer c.mu.Unlock()
 
 	if c.closed {
-		return errors.New("responses websocket: connection is closed")
+		return ErrWebSocketConnectionClosed
 	}
 	if c.inFlight {
-		return errors.New("responses websocket: another response stream is already active on this connection")
+		return ErrWebSocketStreamActive
 	}
 	c.inFlight = true
 	return nil
@@ -202,12 +219,6 @@ func (c *WebSocketConn) markClosed() {
 	c.mu.Unlock()
 }
 
-func (c *WebSocketConn) isClosed() bool {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.closed
-}
-
 // Close closes the WebSocket connection. It is safe to call multiple times.
 func (c *WebSocketConn) Close() error {
 	c.closeOnce.Do(func() {
@@ -221,12 +232,22 @@ func (c *WebSocketConn) Close() error {
 	return c.closeErr
 }
 
+// HandshakeHeader returns the HTTP response headers from the successful
+// WebSocket upgrade. The returned header is a copy and may be mutated by the
+// caller.
+func (c *WebSocketConn) HandshakeHeader() http.Header {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.header.Clone()
+}
+
 // WebSocketStream is a stream of Responses API events received over a WebSocket.
 type WebSocketStream struct {
 	conn *WebSocketConn
 	ctx  context.Context
 
 	cur ResponseStreamEventUnion
+	raw []byte
 	err error
 
 	done     bool
@@ -271,13 +292,14 @@ func (s *WebSocketStream) Next() bool {
 
 		var event ResponseStreamEventUnion
 		if err := json.Unmarshal(data, &event); err != nil {
-			s.err = fmt.Errorf("responses websocket: error decoding event: %w", err)
+			s.err = &WebSocketDecodeError{Data: append([]byte(nil), data...), Err: err}
 			s.done = true
 			s.release()
 			return false
 		}
 
 		s.cur = event
+		s.raw = append(s.raw[:0], data...)
 		if isTerminalResponseStreamEvent(event.Type) {
 			s.done = true
 			s.release()
@@ -304,10 +326,18 @@ func (s *WebSocketStream) nextMessage() (wsMessage, bool) {
 
 func (s *WebSocketStream) handleReadError(err error) {
 	status := websocket.CloseStatus(err)
-	if status == websocket.StatusNormalClosure || status == websocket.StatusGoingAway || status == websocket.StatusNoStatusRcvd || errors.Is(err, net.ErrClosed) || s.conn.isClosed() {
+	if errors.Is(err, net.ErrClosed) {
 		s.err = nil
+	} else if status != -1 {
+		var closeErr websocket.CloseError
+		_ = errors.As(err, &closeErr)
+		s.err = &WebSocketCloseError{
+			Status: status,
+			Reason: closeErr.Reason,
+			Err:    err,
+		}
 	} else {
-		s.err = err
+		s.err = &WebSocketTransportError{Op: "read", Err: err}
 	}
 	if status != -1 || errors.Is(err, net.ErrClosed) {
 		s.conn.markClosed()
@@ -328,6 +358,13 @@ func isTerminalResponseStreamEvent(eventType string) bool {
 // Current returns the current event.
 func (s *WebSocketStream) Current() ResponseStreamEventUnion {
 	return s.cur
+}
+
+// CurrentRaw returns the raw JSON payload for the current event. It can be used
+// to inspect fields that are not yet modeled by this SDK or to debug ordering
+// issues between event types.
+func (s *WebSocketStream) CurrentRaw() []byte {
+	return append([]byte(nil), s.raw...)
 }
 
 // Err returns the stream error, if any.
@@ -361,10 +398,15 @@ func (s *WebSocketStream) release() {
 // WebSocketError is returned by WebSocketStream.Err for documented Responses API
 // WebSocket error messages.
 type WebSocketError struct {
+	// Type is the top-level event type. It is usually "error".
+	Type    string
 	Status  int
 	Code    string
 	Message string
 	Param   string
+	Header  http.Header
+	// Raw is the complete JSON payload received from the server.
+	Raw []byte
 }
 
 func (e *WebSocketError) Error() string {
@@ -385,7 +427,8 @@ func (e *WebSocketError) Error() string {
 }
 
 func parseWebSocketError(data []byte) *WebSocketError {
-	if gjson.GetBytes(data, "type").String() != "error" {
+	eventType := gjson.GetBytes(data, "type").String()
+	if eventType != "error" {
 		return nil
 	}
 	errorObject := gjson.GetBytes(data, "error")
@@ -393,10 +436,194 @@ func parseWebSocketError(data []byte) *WebSocketError {
 		return nil
 	}
 
+	header := make(http.Header)
+	headersObject := gjson.GetBytes(data, "headers")
+	if headersObject.Exists() && headersObject.IsObject() {
+		headersObject.ForEach(func(key, value gjson.Result) bool {
+			if value.IsArray() {
+				value.ForEach(func(_, item gjson.Result) bool {
+					header.Add(key.String(), item.String())
+					return true
+				})
+				return true
+			}
+			header.Add(key.String(), value.String())
+			return true
+		})
+	}
+
+	status := int(gjson.GetBytes(data, "status").Int())
+	if status == 0 {
+		status = int(gjson.GetBytes(data, "status_code").Int())
+	}
+
 	return &WebSocketError{
-		Status:  int(gjson.GetBytes(data, "status").Int()),
+		Type:    eventType,
+		Status:  status,
 		Code:    errorObject.Get("code").String(),
 		Message: errorObject.Get("message").String(),
 		Param:   errorObject.Get("param").String(),
+		Header:  header.Clone(),
+		Raw:     append([]byte(nil), data...),
 	}
+}
+
+// WebSocketDialError is returned by ConnectWebSocket when the WebSocket
+// handshake fails. When the server returned an HTTP response, StatusCode,
+// Header, and Body contain the handshake response details.
+type WebSocketDialError struct {
+	URL        string
+	StatusCode int
+	Header     http.Header
+	Body       string
+	Err        error
+}
+
+func newWebSocketDialError(url string, resp *http.Response, err error) error {
+	dialErr := &WebSocketDialError{URL: url, Err: err}
+	if resp != nil {
+		dialErr.StatusCode = resp.StatusCode
+		dialErr.Header = resp.Header.Clone()
+		if resp.Body != nil {
+			body, readErr := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			if readErr == nil {
+				dialErr.Body = string(body)
+			}
+		}
+	}
+	return dialErr
+}
+
+func (e *WebSocketDialError) Error() string {
+	msg := "responses websocket: dial failed"
+	if e.StatusCode != 0 {
+		msg += fmt.Sprintf(": status %d", e.StatusCode)
+	}
+	if e.URL != "" {
+		msg += fmt.Sprintf(": %s", e.URL)
+	}
+	if e.Body != "" {
+		msg += fmt.Sprintf(": %s", e.Body)
+	}
+	if e.Err != nil {
+		msg += fmt.Sprintf(": %v", e.Err)
+	}
+	return msg
+}
+
+func (e *WebSocketDialError) Unwrap() error {
+	return e.Err
+}
+
+// WebSocketCloseError is returned by WebSocketStream.Err when the server closes
+// the connection unexpectedly. It exposes the WebSocket close status and reason
+// separately from the underlying error string.
+type WebSocketCloseError struct {
+	Status websocket.StatusCode
+	Reason string
+	Err    error
+}
+
+func (e *WebSocketCloseError) Error() string {
+	msg := fmt.Sprintf("responses websocket: closed unexpectedly: status %d", e.Status)
+	if e.Reason != "" {
+		msg += fmt.Sprintf(": %s", e.Reason)
+	}
+	if e.Err != nil {
+		msg += fmt.Sprintf(": %v", e.Err)
+	}
+	return msg
+}
+
+func (e *WebSocketCloseError) Unwrap() error {
+	return e.Err
+}
+
+// WebSocketTransportError is returned by WebSocketStream.Err when the
+// underlying WebSocket transport fails outside the close-frame path.
+type WebSocketTransportError struct {
+	Op  string
+	Err error
+}
+
+func (e *WebSocketTransportError) Error() string {
+	if e.Err == nil {
+		return "responses websocket: transport error"
+	}
+	if e.Op == "" {
+		return fmt.Sprintf("responses websocket: transport error: %v", e.Err)
+	}
+	return fmt.Sprintf("responses websocket: transport %s error: %v", e.Op, e.Err)
+}
+
+func (e *WebSocketTransportError) Unwrap() error {
+	return e.Err
+}
+
+// WebSocketDecodeError is returned by WebSocketStream.Err when an event payload
+// cannot be decoded into a Responses API stream event. Data contains the raw
+// payload for debugging malformed or not-yet-modeled events.
+type WebSocketDecodeError struct {
+	Data []byte
+	Err  error
+}
+
+func (e *WebSocketDecodeError) Error() string {
+	if e.Err == nil {
+		return "responses websocket: error decoding event"
+	}
+	return fmt.Sprintf("responses websocket: error decoding event: %v: %s", e.Err, string(e.Data))
+}
+
+func (e *WebSocketDecodeError) Unwrap() error {
+	return e.Err
+}
+
+// IsWebSocketRetryableError reports whether err is generally retryable at the
+// WebSocket transport/API layer. Callers must still decide whether replaying a
+// streamed request is safe for their application, for example based on whether
+// any output has already been emitted.
+func IsWebSocketRetryableError(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	if errors.Is(err, ErrWebSocketStreamActive) {
+		return false
+	}
+	if errors.Is(err, ErrWebSocketConnectionClosed) || errors.Is(err, io.EOF) {
+		return true
+	}
+	var dialErr *WebSocketDialError
+	if errors.As(err, &dialErr) {
+		if dialErr.StatusCode == 0 {
+			return true
+		}
+		return dialErr.StatusCode == http.StatusRequestTimeout ||
+			dialErr.StatusCode == http.StatusConflict ||
+			dialErr.StatusCode == http.StatusTooManyRequests ||
+			dialErr.StatusCode >= http.StatusInternalServerError
+	}
+	var transportErr *WebSocketTransportError
+	if errors.As(err, &transportErr) {
+		return true
+	}
+	var closeErr *WebSocketCloseError
+	if errors.As(err, &closeErr) {
+		return closeErr.Status != websocket.StatusNormalClosure
+	}
+	var wsErr *WebSocketError
+	if errors.As(err, &wsErr) {
+		switch wsErr.Code {
+		case "rate_limit_exceeded", "server_error", "internal_server_error",
+			"service_unavailable", "timeout", "request_timeout",
+			"connection_limit_exceeded", "too_many_connections":
+			return true
+		}
+		return wsErr.Status == http.StatusRequestTimeout ||
+			wsErr.Status == http.StatusConflict ||
+			wsErr.Status == http.StatusTooManyRequests ||
+			wsErr.Status >= http.StatusInternalServerError
+	}
+	return false
 }

--- a/responses/websocket.go
+++ b/responses/websocket.go
@@ -48,12 +48,24 @@ func (r *ResponseService) ConnectWebSocket(ctx context.Context, opts ...option.R
 		return nil, newWebSocketDialError(wsURL, resp, err)
 	}
 
+	// github.com/coder/websocket defaults to a 32 KiB per-message read limit,
+	// which is too small for Responses events that carry large tool-call
+	// arguments. Codex's code-mode host allows 64 MiB frames
+	// (MAX_FRAME_BYTES = 64 * 1024 * 1024); match that here.
+	// See: openai/codex code-mode-protocol host MAX_FRAME_BYTES.
+	conn.SetReadLimit(responsesWebSocketReadLimit)
+
 	var header http.Header
 	if resp != nil {
 		header = resp.Header
 	}
 	return newWebSocketConn(conn, header), nil
 }
+
+// responsesWebSocketReadLimit is the max size of a single WebSocket message
+// read from the Responses API. Aligns with Codex code-mode MAX_FRAME_BYTES
+// (64 MiB). coder/websocket's default is only 32 KiB.
+const responsesWebSocketReadLimit int64 = 64 << 20
 
 func responsesWebSocketURL(cfg *requestconfig.RequestConfig) (string, error) {
 	baseURL := cfg.BaseURL

--- a/responses/websocket_live_test.go
+++ b/responses/websocket_live_test.go
@@ -1,0 +1,164 @@
+//go:build live
+
+package responses_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+	"github.com/openai/openai-go/v3/responses"
+)
+
+func requireLiveResponsesWebSocket(t *testing.T) {
+	t.Helper()
+	if os.Getenv("RUN_LIVE_API_TESTS") != "1" {
+		t.Skip("set RUN_LIVE_API_TESTS=1 to run live API tests")
+	}
+	if os.Getenv("OPENAI_API_KEY") == "" {
+		t.Skip("set OPENAI_API_KEY to run live API tests")
+	}
+}
+
+func liveResponsesModel() openai.ResponsesModel {
+	if model := os.Getenv("OPENAI_MODEL"); model != "" {
+		return openai.ResponsesModel(model)
+	}
+	return openai.ResponsesModelGPT5Codex
+}
+
+func TestLiveResponseWebSocketSimpleText(t *testing.T) {
+	requireLiveResponsesWebSocket(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client := openai.NewClient()
+	conn, err := client.Responses.ConnectWebSocket(ctx)
+	if err != nil {
+		t.Fatalf("ConnectWebSocket() error = %v", err)
+	}
+	defer conn.Close()
+
+	for _, key := range []string{"x-reasoning-included", "openai-model", "x-models-etag"} {
+		if value := conn.HandshakeHeader().Get(key); value != "" {
+			t.Logf("handshake %s: %s", key, value)
+		}
+	}
+
+	stream, err := conn.New(ctx, responses.ResponseNewParams{
+		Input: responses.ResponseNewParamsInputUnion{OfString: openai.String("Reply with exactly: websocket ok")},
+		Model: liveResponsesModel(),
+	})
+	if err != nil {
+		t.Fatalf("conn.New() error = %v", err)
+	}
+	defer stream.Close()
+
+	for stream.Next() {
+		event := stream.Current()
+		var raw map[string]any
+		sequenceNumber := any(nil)
+		if err := json.Unmarshal(stream.CurrentRaw(), &raw); err == nil {
+			sequenceNumber = raw["sequence_number"]
+		}
+		t.Logf("event type=%s sequence_number=%v", event.Type, sequenceNumber)
+	}
+	if err := stream.Err(); err != nil {
+		t.Fatalf("stream.Err() = %v", err)
+	}
+}
+
+func TestLiveResponseWebSocketBadAPIKeyDialError(t *testing.T) {
+	if os.Getenv("RUN_LIVE_API_TESTS") != "1" {
+		t.Skip("set RUN_LIVE_API_TESTS=1 to run live API tests")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	client := openai.NewClient(option.WithAPIKey("sk-this-key-is-deliberately-invalid"))
+	_, err := client.Responses.ConnectWebSocket(ctx)
+	if err == nil {
+		t.Fatal("ConnectWebSocket() error = nil, want bad-key error")
+	}
+	var dialErr *responses.WebSocketDialError
+	if !errors.As(err, &dialErr) {
+		t.Fatalf("ConnectWebSocket() error = %T %[1]v, want *responses.WebSocketDialError", err)
+	}
+	t.Logf("status=%d request-id=%s body=%s", dialErr.StatusCode, dialErr.Header.Get("x-request-id"), dialErr.Body)
+}
+
+func TestLiveResponseWebSocketInvalidModelClassifiesAsAPIError(t *testing.T) {
+	requireLiveResponsesWebSocket(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client := openai.NewClient()
+	conn, err := client.Responses.ConnectWebSocket(ctx)
+	if err != nil {
+		t.Fatalf("ConnectWebSocket() error = %v", err)
+	}
+	defer conn.Close()
+
+	stream, err := conn.New(ctx, responses.ResponseNewParams{
+		Input: responses.ResponseNewParamsInputUnion{OfString: openai.String("hello")},
+		Model: openai.ResponsesModel("definitely-not-a-real-model"),
+	})
+	if err != nil {
+		t.Fatalf("conn.New() error = %v", err)
+	}
+	defer stream.Close()
+
+	var sawFailed bool
+	for stream.Next() {
+		event := stream.Current()
+		t.Logf("event type=%s raw=%s", event.Type, string(stream.CurrentRaw()))
+		if event.Type == "response.failed" {
+			sawFailed = true
+		}
+	}
+	if err := stream.Err(); err != nil {
+		var wsErr *responses.WebSocketError
+		if !errors.As(err, &wsErr) {
+			var closeErr *responses.WebSocketCloseError
+			if errors.As(err, &closeErr) {
+				t.Fatalf("stream.Err() = %T %[1]v, want API/model failure, not close error", err)
+			}
+			var transportErr *responses.WebSocketTransportError
+			if errors.As(err, &transportErr) {
+				t.Fatalf("stream.Err() = %T %[1]v, want API/model failure, not transport failure", err)
+			}
+			t.Fatalf("stream.Err() = %T %[1]v, want *responses.WebSocketError or response.failed event", err)
+		}
+		t.Logf("websocket api error status=%d code=%s message=%s", wsErr.Status, wsErr.Code, wsErr.Message)
+		return
+	}
+	if !sawFailed {
+		t.Fatal("invalid model produced no WebSocketError and no response.failed event")
+	}
+}
+
+func TestLiveResponseWebSocketHandshakeMetadata(t *testing.T) {
+	requireLiveResponsesWebSocket(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	client := openai.NewClient()
+	conn, err := client.Responses.ConnectWebSocket(ctx)
+	if err != nil {
+		t.Fatalf("ConnectWebSocket() error = %v", err)
+	}
+	defer conn.Close()
+
+	for _, key := range []string{"x-reasoning-included", "openai-model", "x-models-etag"} {
+		t.Logf("handshake %s: %q", key, conn.HandshakeHeader().Get(key))
+	}
+}

--- a/responses/websocket_test.go
+++ b/responses/websocket_test.go
@@ -1,0 +1,340 @@
+package responses_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+	"github.com/openai/openai-go/v3/responses"
+)
+
+type responsesWebSocketTestServer struct {
+	t      *testing.T
+	server *httptest.Server
+
+	mu       sync.Mutex
+	path     string
+	header   http.Header
+	messages [][]byte
+
+	accepted chan struct{}
+	received chan []byte
+	resume   chan struct{}
+}
+
+func newResponsesWebSocketTestServer(t *testing.T, handler func(context.Context, *websocket.Conn)) *responsesWebSocketTestServer {
+	t.Helper()
+
+	ts := &responsesWebSocketTestServer{
+		t:        t,
+		accepted: make(chan struct{}),
+		received: make(chan []byte, 1),
+		resume:   make(chan struct{}),
+	}
+	ts.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ts.mu.Lock()
+		ts.path = r.URL.Path
+		ts.header = r.Header.Clone()
+		ts.mu.Unlock()
+
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Logf("websocket accept failed: %v", err)
+			return
+		}
+		defer conn.Close(websocket.StatusNormalClosure, "")
+		close(ts.accepted)
+
+		if handler != nil {
+			handler(r.Context(), conn)
+		}
+	}))
+	t.Cleanup(ts.server.Close)
+	return ts
+}
+
+func (ts *responsesWebSocketTestServer) recordOneAndWait(ctx context.Context, conn *websocket.Conn) {
+	_, msg, err := conn.Read(ctx)
+	if err != nil {
+		ts.t.Logf("websocket read failed: %v", err)
+		return
+	}
+	ts.mu.Lock()
+	ts.messages = append(ts.messages, append([]byte(nil), msg...))
+	ts.mu.Unlock()
+	ts.received <- msg
+
+	select {
+	case <-ts.resume:
+	case <-ctx.Done():
+	}
+}
+
+func (ts *responsesWebSocketTestServer) headerValue(key string) string {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.header.Get(key)
+}
+
+func (ts *responsesWebSocketTestServer) requestPath() string {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.path
+}
+
+func (ts *responsesWebSocketTestServer) firstMessage() []byte {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	if len(ts.messages) == 0 {
+		return nil
+	}
+	return append([]byte(nil), ts.messages[0]...)
+}
+
+func (ts *responsesWebSocketTestServer) waitAccepted(t *testing.T) {
+	t.Helper()
+	select {
+	case <-ts.accepted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for websocket accept")
+	}
+}
+
+func (ts *responsesWebSocketTestServer) waitReceived(t *testing.T) []byte {
+	t.Helper()
+	select {
+	case msg := <-ts.received:
+		return msg
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for websocket message")
+		return nil
+	}
+}
+
+func connectTestWebSocket(t *testing.T, ts *responsesWebSocketTestServer, opts ...option.RequestOption) *responses.WebSocketConn {
+	t.Helper()
+	client := openai.NewClient(append([]option.RequestOption{
+		option.WithBaseURL(ts.server.URL),
+		option.WithAPIKey("test-key"),
+	}, opts...)...)
+	conn, err := client.Responses.ConnectWebSocket(context.Background())
+	if err != nil {
+		t.Fatalf("ConnectWebSocket() error = %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}
+
+func newTestResponseStream(t *testing.T, conn *responses.WebSocketConn) *responses.WebSocketStream {
+	t.Helper()
+	stream, err := conn.New(context.Background(), responses.ResponseNewParams{
+		Input: responses.ResponseNewParamsInputUnion{OfString: openai.String("hello")},
+		Model: openai.ChatModelGPT4oMini,
+	})
+	if err != nil {
+		t.Fatalf("conn.New() error = %v", err)
+	}
+	return stream
+}
+
+func TestResponseWebSocketURLConversion(t *testing.T) {
+	ts := newResponsesWebSocketTestServer(t, func(ctx context.Context, conn *websocket.Conn) {
+		<-ctx.Done()
+	})
+
+	conn := connectTestWebSocket(t, ts)
+	defer conn.Close()
+
+	ts.waitAccepted(t)
+	if got, want := ts.requestPath(), "/responses"; got != want {
+		t.Fatalf("request path = %q, want %q", got, want)
+	}
+}
+
+func TestResponseWebSocketHeadersAndAuth(t *testing.T) {
+	ts := newResponsesWebSocketTestServer(t, func(ctx context.Context, conn *websocket.Conn) {
+		<-ctx.Done()
+	})
+
+	client := openai.NewClient(
+		option.WithBaseURL(ts.server.URL),
+		option.WithAPIKey("test-key"),
+		option.WithOrganization("org_123"),
+		option.WithProject("proj_123"),
+		option.WithHeader("X-Custom-Header", "custom-value"),
+	)
+	conn, err := client.Responses.ConnectWebSocket(context.Background())
+	if err != nil {
+		t.Fatalf("ConnectWebSocket() error = %v", err)
+	}
+	defer conn.Close()
+
+	ts.waitAccepted(t)
+	if got, want := ts.headerValue("Authorization"), "Bearer test-key"; got != want {
+		t.Fatalf("Authorization = %q, want %q", got, want)
+	}
+	if got, want := ts.headerValue("OpenAI-Organization"), "org_123"; got != want {
+		t.Fatalf("OpenAI-Organization = %q, want %q", got, want)
+	}
+	if got, want := ts.headerValue("OpenAI-Project"), "proj_123"; got != want {
+		t.Fatalf("OpenAI-Project = %q, want %q", got, want)
+	}
+	if got, want := ts.headerValue("X-Custom-Header"), "custom-value"; got != want {
+		t.Fatalf("X-Custom-Header = %q, want %q", got, want)
+	}
+}
+
+func TestResponseWebSocketNewSendsResponseCreate(t *testing.T) {
+	var ts *responsesWebSocketTestServer
+	ts = newResponsesWebSocketTestServer(t, func(ctx context.Context, conn *websocket.Conn) {
+		ts.recordOneAndWait(ctx, conn)
+	})
+	conn := connectTestWebSocket(t, ts)
+
+	stream := newTestResponseStream(t, conn)
+	defer stream.Close()
+	msg := ts.waitReceived(t)
+
+	var payload map[string]any
+	if err := json.Unmarshal(msg, &payload); err != nil {
+		t.Fatalf("message was not JSON: %v", err)
+	}
+	if got, want := payload["type"], "response.create"; got != want {
+		t.Fatalf("type = %v, want %q", got, want)
+	}
+	if got, want := payload["model"], string(openai.ChatModelGPT4oMini); got != want {
+		t.Fatalf("model = %v, want %q", got, want)
+	}
+	if got, want := payload["input"], "hello"; got != want {
+		t.Fatalf("input = %v, want %q", got, want)
+	}
+	close(ts.resume)
+}
+
+func TestResponseWebSocketNewDoesNotForceStreamTrue(t *testing.T) {
+	var ts *responsesWebSocketTestServer
+	ts = newResponsesWebSocketTestServer(t, func(ctx context.Context, conn *websocket.Conn) {
+		ts.recordOneAndWait(ctx, conn)
+	})
+	conn := connectTestWebSocket(t, ts)
+
+	stream := newTestResponseStream(t, conn)
+	defer stream.Close()
+	msg := ts.waitReceived(t)
+
+	var payload map[string]any
+	if err := json.Unmarshal(msg, &payload); err != nil {
+		t.Fatalf("message was not JSON: %v", err)
+	}
+	if v, ok := payload["stream"]; ok {
+		t.Fatalf("stream was set to %v; want omitted", v)
+	}
+	close(ts.resume)
+}
+
+func TestResponseWebSocketEventsDecode(t *testing.T) {
+	ts := newResponsesWebSocketTestServer(t, func(ctx context.Context, conn *websocket.Conn) {
+		_, _, err := conn.Read(ctx)
+		if err != nil {
+			t.Logf("websocket read failed: %v", err)
+			return
+		}
+		event := []byte(`{"type":"response.output_text.delta","sequence_number":1,"item_id":"item_123","output_index":0,"content_index":0,"delta":"hi","logprobs":[]}`)
+		if err := conn.Write(ctx, websocket.MessageText, event); err != nil {
+			t.Logf("websocket write failed: %v", err)
+		}
+	})
+	conn := connectTestWebSocket(t, ts)
+
+	stream := newTestResponseStream(t, conn)
+	if !stream.Next() {
+		t.Fatalf("stream.Next() = false, err = %v", stream.Err())
+	}
+	event := stream.Current()
+	if got, want := event.Type, "response.output_text.delta"; got != want {
+		t.Fatalf("event.Type = %q, want %q", got, want)
+	}
+	if got, want := event.Delta, "hi"; got != want {
+		t.Fatalf("event.Delta = %q, want %q", got, want)
+	}
+	if _, ok := event.AsAny().(responses.ResponseTextDeltaEvent); !ok {
+		t.Fatalf("event.AsAny() = %T, want responses.ResponseTextDeltaEvent", event.AsAny())
+	}
+}
+
+func TestResponseWebSocketOneInFlightEnforced(t *testing.T) {
+	var ts *responsesWebSocketTestServer
+	ts = newResponsesWebSocketTestServer(t, func(ctx context.Context, conn *websocket.Conn) {
+		ts.recordOneAndWait(ctx, conn)
+	})
+	conn := connectTestWebSocket(t, ts)
+
+	stream := newTestResponseStream(t, conn)
+	defer stream.Close()
+	ts.waitReceived(t)
+
+	_, err := conn.New(context.Background(), responses.ResponseNewParams{
+		Input: responses.ResponseNewParamsInputUnion{OfString: openai.String("second")},
+		Model: openai.ChatModelGPT4oMini,
+	})
+	if err == nil {
+		t.Fatal("conn.New() while stream active returned nil error")
+	}
+	if !strings.Contains(err.Error(), "already active") {
+		t.Fatalf("conn.New() error = %q, want already active", err.Error())
+	}
+	close(ts.resume)
+}
+
+func TestResponseWebSocketDocumentedError(t *testing.T) {
+	ts := newResponsesWebSocketTestServer(t, func(ctx context.Context, conn *websocket.Conn) {
+		_, _, err := conn.Read(ctx)
+		if err != nil {
+			t.Logf("websocket read failed: %v", err)
+			return
+		}
+		errEvent := []byte(`{"type":"error","status":400,"error":{"code":"previous_response_not_found","message":"missing response","param":"previous_response_id"}}`)
+		if err := conn.Write(ctx, websocket.MessageText, errEvent); err != nil {
+			t.Logf("websocket write failed: %v", err)
+		}
+	})
+	conn := connectTestWebSocket(t, ts)
+
+	stream := newTestResponseStream(t, conn)
+	if stream.Next() {
+		t.Fatal("stream.Next() = true, want false")
+	}
+	var wsErr *responses.WebSocketError
+	if !errors.As(stream.Err(), &wsErr) {
+		t.Fatalf("stream.Err() = %T %[1]v, want *responses.WebSocketError", stream.Err())
+	}
+	if wsErr.Status != 400 || wsErr.Code != "previous_response_not_found" || wsErr.Param != "previous_response_id" {
+		t.Fatalf("unexpected WebSocketError: %+v", wsErr)
+	}
+	if !strings.Contains(wsErr.Error(), "missing response") {
+		t.Fatalf("WebSocketError.Error() = %q, want message", wsErr.Error())
+	}
+}
+
+func TestResponseWebSocketCloseIdempotent(t *testing.T) {
+	ts := newResponsesWebSocketTestServer(t, func(ctx context.Context, conn *websocket.Conn) {
+		_, _, _ = conn.Read(ctx)
+	})
+	conn := connectTestWebSocket(t, ts)
+
+	if err := conn.Close(); err != nil {
+		t.Fatalf("first Close() error = %v", err)
+	}
+	if err := conn.Close(); err != nil {
+		t.Fatalf("second Close() error = %v", err)
+	}
+}

--- a/responses/websocket_test.go
+++ b/responses/websocket_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -46,6 +47,42 @@ func newResponsesWebSocketTestServer(t *testing.T, handler func(context.Context,
 		ts.header = r.Header.Clone()
 		ts.mu.Unlock()
 
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Logf("websocket accept failed: %v", err)
+			return
+		}
+		defer conn.Close(websocket.StatusNormalClosure, "")
+		close(ts.accepted)
+
+		if handler != nil {
+			handler(r.Context(), conn)
+		}
+	}))
+	t.Cleanup(ts.server.Close)
+	return ts
+}
+
+func newResponsesWebSocketHeaderTestServer(t *testing.T, header http.Header, handler func(context.Context, *websocket.Conn)) *responsesWebSocketTestServer {
+	t.Helper()
+
+	ts := &responsesWebSocketTestServer{
+		t:        t,
+		accepted: make(chan struct{}),
+		received: make(chan []byte, 1),
+		resume:   make(chan struct{}),
+	}
+	ts.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ts.mu.Lock()
+		ts.path = r.URL.Path
+		ts.header = r.Header.Clone()
+		ts.mu.Unlock()
+
+		for key, values := range header {
+			for _, value := range values {
+				w.Header().Add(key, value)
+			}
+		}
 		conn, err := websocket.Accept(w, r, nil)
 		if err != nil {
 			t.Logf("websocket accept failed: %v", err)
@@ -269,9 +306,17 @@ func TestResponseWebSocketEventsDecode(t *testing.T) {
 	if _, ok := event.AsAny().(responses.ResponseTextDeltaEvent); !ok {
 		t.Fatalf("event.AsAny() = %T, want responses.ResponseTextDeltaEvent", event.AsAny())
 	}
+	if got := string(stream.CurrentRaw()); !strings.Contains(got, `"response.output_text.delta"`) {
+		t.Fatalf("stream.CurrentRaw() = %q, want raw event", got)
+	}
+	raw := stream.CurrentRaw()
+	raw[0] = '!'
+	if got := string(stream.CurrentRaw()); !strings.HasPrefix(got, `{"type"`) {
+		t.Fatalf("mutating CurrentRaw result changed internal raw payload: %q", got)
+	}
 }
 
-func TestResponseWebSocketOneInFlightEnforced(t *testing.T) {
+func TestResponseWebSocketOneInFlightReturnsSentinel(t *testing.T) {
 	var ts *responsesWebSocketTestServer
 	ts = newResponsesWebSocketTestServer(t, func(ctx context.Context, conn *websocket.Conn) {
 		ts.recordOneAndWait(ctx, conn)
@@ -289,10 +334,26 @@ func TestResponseWebSocketOneInFlightEnforced(t *testing.T) {
 	if err == nil {
 		t.Fatal("conn.New() while stream active returned nil error")
 	}
-	if !strings.Contains(err.Error(), "already active") {
-		t.Fatalf("conn.New() error = %q, want already active", err.Error())
+	if !errors.Is(err, responses.ErrWebSocketStreamActive) {
+		t.Fatalf("conn.New() error = %T %[1]v, want ErrWebSocketStreamActive", err)
 	}
 	close(ts.resume)
+}
+
+func TestResponseWebSocketNewOnClosedConnReturnsSentinel(t *testing.T) {
+	ts := newResponsesWebSocketTestServer(t, func(ctx context.Context, conn *websocket.Conn) {
+		<-ctx.Done()
+	})
+	conn := connectTestWebSocket(t, ts)
+	_ = conn.Close()
+
+	_, err := conn.New(context.Background(), responses.ResponseNewParams{
+		Input: responses.ResponseNewParamsInputUnion{OfString: openai.String("second")},
+		Model: openai.ChatModelGPT4oMini,
+	})
+	if !errors.Is(err, responses.ErrWebSocketConnectionClosed) {
+		t.Fatalf("conn.New() error = %T %[1]v, want ErrWebSocketConnectionClosed", err)
+	}
 }
 
 func TestResponseWebSocketDocumentedError(t *testing.T) {
@@ -323,6 +384,354 @@ func TestResponseWebSocketDocumentedError(t *testing.T) {
 	if !strings.Contains(wsErr.Error(), "missing response") {
 		t.Fatalf("WebSocketError.Error() = %q, want message", wsErr.Error())
 	}
+	if got := string(wsErr.Raw); !strings.Contains(got, "previous_response_not_found") {
+		t.Fatalf("WebSocketError.Raw = %q, want raw payload", got)
+	}
+}
+
+func TestResponseWebSocketDocumentedErrorPreservesDetails(t *testing.T) {
+	ts := newResponsesWebSocketTestServer(t, func(ctx context.Context, conn *websocket.Conn) {
+		_, _, err := conn.Read(ctx)
+		if err != nil {
+			t.Logf("websocket read failed: %v", err)
+			return
+		}
+		errEvent := []byte(`{"type":"error","status":429,"headers":{"x-request-id":"req_123","x-ratelimit-reset":["1","2"]},"error":{"code":"rate_limit_exceeded","message":"slow down","param":"input"}}`)
+		if err := conn.Write(ctx, websocket.MessageText, errEvent); err != nil {
+			t.Logf("websocket write failed: %v", err)
+		}
+	})
+	conn := connectTestWebSocket(t, ts)
+
+	stream := newTestResponseStream(t, conn)
+	if stream.Next() {
+		t.Fatal("stream.Next() = true, want false")
+	}
+	var wsErr *responses.WebSocketError
+	if !errors.As(stream.Err(), &wsErr) {
+		t.Fatalf("stream.Err() = %T %[1]v, want *responses.WebSocketError", stream.Err())
+	}
+	if got, want := wsErr.Status, http.StatusTooManyRequests; got != want {
+		t.Fatalf("Status = %d, want %d", got, want)
+	}
+	if got, want := wsErr.Code, "rate_limit_exceeded"; got != want {
+		t.Fatalf("Code = %q, want %q", got, want)
+	}
+	if got, want := wsErr.Message, "slow down"; got != want {
+		t.Fatalf("Message = %q, want %q", got, want)
+	}
+	if got, want := wsErr.Param, "input"; got != want {
+		t.Fatalf("Param = %q, want %q", got, want)
+	}
+	if got, want := wsErr.Header.Get("x-request-id"), "req_123"; got != want {
+		t.Fatalf("Header.Get(x-request-id) = %q, want %q", got, want)
+	}
+	if got, want := wsErr.Header.Values("x-ratelimit-reset"), []string{"1", "2"}; strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("Header.Values(x-ratelimit-reset) = %v, want %v", got, want)
+	}
+	if got := string(wsErr.Raw); !strings.Contains(got, `"status":429`) {
+		t.Fatalf("Raw = %q, want status payload", got)
+	}
+}
+
+func TestResponseWebSocketErrorParsesHeaders(t *testing.T) {
+	ts := newResponsesWebSocketTestServer(t, func(ctx context.Context, conn *websocket.Conn) {
+		_, _, err := conn.Read(ctx)
+		if err != nil {
+			t.Logf("websocket read failed: %v", err)
+			return
+		}
+		errEvent := []byte(`{"type":"error","headers":{"x-request-id":"req_header"},"error":{"code":"bad","message":"bad"}}`)
+		_ = conn.Write(ctx, websocket.MessageText, errEvent)
+	})
+	conn := connectTestWebSocket(t, ts)
+
+	stream := newTestResponseStream(t, conn)
+	if stream.Next() {
+		t.Fatal("stream.Next() = true, want false")
+	}
+	var wsErr *responses.WebSocketError
+	if !errors.As(stream.Err(), &wsErr) {
+		t.Fatalf("stream.Err() = %T %[1]v, want *responses.WebSocketError", stream.Err())
+	}
+	if got, want := wsErr.Header.Get("x-request-id"), "req_header"; got != want {
+		t.Fatalf("Header.Get(x-request-id) = %q, want %q", got, want)
+	}
+}
+
+func TestResponseWebSocketErrorParsesStatusCodeAlias(t *testing.T) {
+	ts := newResponsesWebSocketTestServer(t, func(ctx context.Context, conn *websocket.Conn) {
+		_, _, err := conn.Read(ctx)
+		if err != nil {
+			t.Logf("websocket read failed: %v", err)
+			return
+		}
+		errEvent := []byte(`{"type":"error","status_code":500,"error":{"code":"server_error","message":"try later"}}`)
+		_ = conn.Write(ctx, websocket.MessageText, errEvent)
+	})
+	conn := connectTestWebSocket(t, ts)
+
+	stream := newTestResponseStream(t, conn)
+	if stream.Next() {
+		t.Fatal("stream.Next() = true, want false")
+	}
+	var wsErr *responses.WebSocketError
+	if !errors.As(stream.Err(), &wsErr) {
+		t.Fatalf("stream.Err() = %T %[1]v, want *responses.WebSocketError", stream.Err())
+	}
+	if got, want := wsErr.Status, http.StatusInternalServerError; got != want {
+		t.Fatalf("Status = %d, want %d", got, want)
+	}
+}
+
+func TestResponseWebSocketDialErrorIncludesHandshakeResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Request-ID", "req_123")
+		http.Error(w, `{"error":"bad auth"}`, http.StatusUnauthorized)
+	}))
+	t.Cleanup(server.Close)
+
+	client := openai.NewClient(
+		option.WithBaseURL(server.URL),
+		option.WithAPIKey("test-key"),
+	)
+	_, err := client.Responses.ConnectWebSocket(context.Background())
+	if err == nil {
+		t.Fatal("ConnectWebSocket() error = nil, want error")
+	}
+	var dialErr *responses.WebSocketDialError
+	if !errors.As(err, &dialErr) {
+		t.Fatalf("ConnectWebSocket() error = %T %[1]v, want *responses.WebSocketDialError", err)
+	}
+	if got, want := dialErr.StatusCode, http.StatusUnauthorized; got != want {
+		t.Fatalf("StatusCode = %d, want %d", got, want)
+	}
+	if got, want := dialErr.Header.Get("X-Request-ID"), "req_123"; got != want {
+		t.Fatalf("Header.Get(X-Request-ID) = %q, want %q", got, want)
+	}
+	if !strings.Contains(dialErr.Body, "bad auth") {
+		t.Fatalf("Body = %q, want bad auth", dialErr.Body)
+	}
+	if errors.Unwrap(dialErr) == nil {
+		t.Fatal("errors.Unwrap(dialErr) = nil, want original dial error")
+	}
+}
+
+func TestResponseWebSocketUnexpectedCloseError(t *testing.T) {
+	ts := newResponsesWebSocketTestServer(t, func(ctx context.Context, conn *websocket.Conn) {
+		_, _, err := conn.Read(ctx)
+		if err != nil {
+			t.Logf("websocket read failed: %v", err)
+			return
+		}
+		_ = conn.Close(websocket.StatusPolicyViolation, "keepalive timeout")
+	})
+	conn := connectTestWebSocket(t, ts)
+
+	stream := newTestResponseStream(t, conn)
+	if stream.Next() {
+		t.Fatal("stream.Next() = true, want false")
+	}
+	var closeErr *responses.WebSocketCloseError
+	if !errors.As(stream.Err(), &closeErr) {
+		t.Fatalf("stream.Err() = %T %[1]v, want *responses.WebSocketCloseError", stream.Err())
+	}
+	if got, want := closeErr.Status, websocket.StatusPolicyViolation; got != want {
+		t.Fatalf("Status = %d, want %d", got, want)
+	}
+	if got, want := closeErr.Reason, "keepalive timeout"; got != want {
+		t.Fatalf("Reason = %q, want %q", got, want)
+	}
+}
+
+func TestResponseWebSocketNormalCloseBeforeTerminalEventIsError(t *testing.T) {
+	ts := newResponsesWebSocketTestServer(t, func(ctx context.Context, conn *websocket.Conn) {
+		_, _, err := conn.Read(ctx)
+		if err != nil {
+			t.Logf("websocket read failed: %v", err)
+			return
+		}
+		_ = conn.Close(websocket.StatusNormalClosure, "done early")
+	})
+	conn := connectTestWebSocket(t, ts)
+
+	stream := newTestResponseStream(t, conn)
+	if stream.Next() {
+		t.Fatal("stream.Next() = true, want false")
+	}
+	var closeErr *responses.WebSocketCloseError
+	if !errors.As(stream.Err(), &closeErr) {
+		t.Fatalf("stream.Err() = %T %[1]v, want *responses.WebSocketCloseError", stream.Err())
+	}
+	if got, want := closeErr.Status, websocket.StatusNormalClosure; got != want {
+		t.Fatalf("Status = %d, want %d", got, want)
+	}
+	if got, want := closeErr.Reason, "done early"; got != want {
+		t.Fatalf("Reason = %q, want %q", got, want)
+	}
+}
+
+func TestResponseWebSocketCompletedThenCloseIsClean(t *testing.T) {
+	ts := newResponsesWebSocketTestServer(t, func(ctx context.Context, conn *websocket.Conn) {
+		_, _, err := conn.Read(ctx)
+		if err != nil {
+			t.Logf("websocket read failed: %v", err)
+			return
+		}
+		event := []byte(`{"type":"response.completed","sequence_number":1,"response":{"id":"resp_123","created_at":123,"model":"gpt-4o-mini","object":"response","output":[],"parallel_tool_calls":true,"tool_choice":"auto","tools":[]}}`)
+		if err := conn.Write(ctx, websocket.MessageText, event); err != nil {
+			t.Logf("websocket write failed: %v", err)
+			return
+		}
+		_ = conn.Close(websocket.StatusNormalClosure, "")
+	})
+	conn := connectTestWebSocket(t, ts)
+
+	stream := newTestResponseStream(t, conn)
+	if !stream.Next() {
+		t.Fatalf("stream.Next() = false, err = %v", stream.Err())
+	}
+	if got, want := stream.Current().Type, "response.completed"; got != want {
+		t.Fatalf("event.Type = %q, want %q", got, want)
+	}
+	if stream.Next() {
+		t.Fatal("second stream.Next() = true, want false")
+	}
+	if err := stream.Err(); err != nil {
+		t.Fatalf("stream.Err() = %v, want nil", err)
+	}
+}
+
+func TestResponseWebSocketFailedEventIsTerminalAndReleasesStream(t *testing.T) {
+	ts := newResponsesWebSocketTestServer(t, func(ctx context.Context, conn *websocket.Conn) {
+		if _, _, err := conn.Read(ctx); err != nil {
+			t.Logf("websocket read failed: %v", err)
+			return
+		}
+		failed := []byte(`{"type":"response.failed","sequence_number":1,"response":{"id":"resp_failed","created_at":123,"model":"gpt-4o-mini","object":"response","output":[],"parallel_tool_calls":true,"tool_choice":"auto","tools":[],"status":"failed"}}`)
+		if err := conn.Write(ctx, websocket.MessageText, failed); err != nil {
+			t.Logf("websocket write failed: %v", err)
+			return
+		}
+
+		if _, _, err := conn.Read(ctx); err != nil {
+			t.Logf("second websocket read failed: %v", err)
+			return
+		}
+		completed := []byte(`{"type":"response.completed","sequence_number":2,"response":{"id":"resp_completed","created_at":123,"model":"gpt-4o-mini","object":"response","output":[],"parallel_tool_calls":true,"tool_choice":"auto","tools":[]}}`)
+		_ = conn.Write(ctx, websocket.MessageText, completed)
+	})
+	conn := connectTestWebSocket(t, ts)
+
+	stream := newTestResponseStream(t, conn)
+	if !stream.Next() {
+		t.Fatalf("stream.Next() = false, err = %v", stream.Err())
+	}
+	if got, want := stream.Current().Type, "response.failed"; got != want {
+		t.Fatalf("event.Type = %q, want %q", got, want)
+	}
+	if stream.Next() {
+		t.Fatal("second stream.Next() = true, want false after terminal response.failed")
+	}
+	if err := stream.Err(); err != nil {
+		t.Fatalf("stream.Err() = %v, want nil for response.failed event", err)
+	}
+
+	next := newTestResponseStream(t, conn)
+	if !next.Next() {
+		t.Fatalf("next stream.Next() = false, err = %v", next.Err())
+	}
+	if got, want := next.Current().Type, "response.completed"; got != want {
+		t.Fatalf("next event.Type = %q, want %q", got, want)
+	}
+}
+
+func TestResponseWebSocketDropBeforeTerminalEventIsError(t *testing.T) {
+	ts := newResponsesWebSocketTestServer(t, func(ctx context.Context, conn *websocket.Conn) {
+		_, _, err := conn.Read(ctx)
+		if err != nil {
+			t.Logf("websocket read failed: %v", err)
+			return
+		}
+		_ = conn.CloseNow()
+	})
+	conn := connectTestWebSocket(t, ts)
+
+	stream := newTestResponseStream(t, conn)
+	if stream.Next() {
+		t.Fatal("stream.Next() = true, want false")
+	}
+	if stream.Err() == nil {
+		t.Fatal("stream.Err() = nil, want transport error")
+	}
+	if !errors.Is(stream.Err(), io.EOF) {
+		var transportErr *responses.WebSocketTransportError
+		if !errors.As(stream.Err(), &transportErr) {
+			t.Fatalf("stream.Err() = %T %[1]v, want io.EOF or *responses.WebSocketTransportError", stream.Err())
+		}
+	}
+}
+
+func TestResponseWebSocketDecodeErrorIncludesRawPayload(t *testing.T) {
+	ts := newResponsesWebSocketTestServer(t, func(ctx context.Context, conn *websocket.Conn) {
+		_, _, err := conn.Read(ctx)
+		if err != nil {
+			t.Logf("websocket read failed: %v", err)
+			return
+		}
+		_ = conn.Write(ctx, websocket.MessageText, []byte(`not json`))
+	})
+	conn := connectTestWebSocket(t, ts)
+
+	stream := newTestResponseStream(t, conn)
+	if stream.Next() {
+		t.Fatal("stream.Next() = true, want false")
+	}
+	var decodeErr *responses.WebSocketDecodeError
+	if !errors.As(stream.Err(), &decodeErr) {
+		t.Fatalf("stream.Err() = %T %[1]v, want *responses.WebSocketDecodeError", stream.Err())
+	}
+	if got, want := string(decodeErr.Data), "not json"; got != want {
+		t.Fatalf("Data = %q, want %q", got, want)
+	}
+}
+
+func TestResponseWebSocketUnknownEventIsYieldedWithRawPayload(t *testing.T) {
+	ts := newResponsesWebSocketTestServer(t, func(ctx context.Context, conn *websocket.Conn) {
+		_, _, err := conn.Read(ctx)
+		if err != nil {
+			t.Logf("websocket read failed: %v", err)
+			return
+		}
+		unknown := []byte(`{"type":"response.future_event","sequence_number":99,"new_field":"preserved"}`)
+		if err := conn.Write(ctx, websocket.MessageText, unknown); err != nil {
+			t.Logf("websocket write failed: %v", err)
+			return
+		}
+		completed := []byte(`{"type":"response.completed","sequence_number":100,"response":{"id":"resp_123","created_at":123,"model":"gpt-4o-mini","object":"response","output":[],"parallel_tool_calls":true,"tool_choice":"auto","tools":[]}}`)
+		_ = conn.Write(ctx, websocket.MessageText, completed)
+	})
+	conn := connectTestWebSocket(t, ts)
+
+	stream := newTestResponseStream(t, conn)
+	if !stream.Next() {
+		t.Fatalf("stream.Next() = false, err = %v", stream.Err())
+	}
+	if got, want := stream.Current().Type, "response.future_event"; got != want {
+		t.Fatalf("event.Type = %q, want %q", got, want)
+	}
+	if got := string(stream.CurrentRaw()); !strings.Contains(got, `"new_field":"preserved"`) {
+		t.Fatalf("CurrentRaw() = %q, want unknown event raw payload", got)
+	}
+	if !stream.Next() {
+		t.Fatalf("second stream.Next() = false, err = %v", stream.Err())
+	}
+	if got, want := stream.Current().Type, "response.completed"; got != want {
+		t.Fatalf("event.Type = %q, want %q", got, want)
+	}
+	if err := stream.Err(); err != nil {
+		t.Fatalf("stream.Err() = %v, want nil", err)
+	}
 }
 
 func TestResponseWebSocketCloseIdempotent(t *testing.T) {
@@ -336,5 +745,65 @@ func TestResponseWebSocketCloseIdempotent(t *testing.T) {
 	}
 	if err := conn.Close(); err != nil {
 		t.Fatalf("second Close() error = %v", err)
+	}
+}
+
+func TestResponseWebSocketHandshakeHeader(t *testing.T) {
+	header := http.Header{}
+	header.Set("X-Reasoning-Included", "true")
+	header.Set("OpenAI-Model", "gpt-test")
+	ts := newResponsesWebSocketHeaderTestServer(t, header, func(ctx context.Context, conn *websocket.Conn) {
+		<-ctx.Done()
+	})
+	conn := connectTestWebSocket(t, ts)
+
+	if got, want := conn.HandshakeHeader().Get("X-Reasoning-Included"), "true"; got != want {
+		t.Fatalf("HandshakeHeader().Get(X-Reasoning-Included) = %q, want %q", got, want)
+	}
+	if got, want := conn.HandshakeHeader().Get("OpenAI-Model"), "gpt-test"; got != want {
+		t.Fatalf("HandshakeHeader().Get(OpenAI-Model) = %q, want %q", got, want)
+	}
+	got := conn.HandshakeHeader()
+	got.Set("OpenAI-Model", "mutated")
+	if got, want := conn.HandshakeHeader().Get("OpenAI-Model"), "gpt-test"; got != want {
+		t.Fatalf("mutating returned header changed internal header: got %q, want %q", got, want)
+	}
+}
+
+func TestIsWebSocketRetryableError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "connection closed", err: responses.ErrWebSocketConnectionClosed, want: true},
+		{name: "stream active", err: responses.ErrWebSocketStreamActive, want: false},
+		{name: "context canceled", err: context.Canceled, want: false},
+		{name: "context deadline", err: context.DeadlineExceeded, want: false},
+		{name: "dial transport failure", err: &responses.WebSocketDialError{Err: io.EOF}, want: true},
+		{name: "dial 401", err: &responses.WebSocketDialError{StatusCode: http.StatusUnauthorized}, want: false},
+		{name: "dial 429", err: &responses.WebSocketDialError{StatusCode: http.StatusTooManyRequests}, want: true},
+		{name: "dial 500", err: &responses.WebSocketDialError{StatusCode: http.StatusInternalServerError}, want: true},
+		{name: "close abnormal", err: &responses.WebSocketCloseError{Status: websocket.StatusAbnormalClosure}, want: true},
+		{name: "close normal", err: &responses.WebSocketCloseError{Status: websocket.StatusNormalClosure}, want: false},
+		{name: "transport EOF", err: &responses.WebSocketTransportError{Op: "read", Err: io.EOF}, want: true},
+		{name: "wrapped EOF", err: io.EOF, want: true},
+		{name: "api 400", err: &responses.WebSocketError{Status: http.StatusBadRequest}, want: false},
+		{name: "api 408", err: &responses.WebSocketError{Status: http.StatusRequestTimeout}, want: true},
+		{name: "api 409", err: &responses.WebSocketError{Status: http.StatusConflict}, want: true},
+		{name: "api 429", err: &responses.WebSocketError{Status: http.StatusTooManyRequests}, want: true},
+		{name: "api 500", err: &responses.WebSocketError{Status: http.StatusInternalServerError}, want: true},
+		{name: "api retryable code without status", err: &responses.WebSocketError{Code: "rate_limit_exceeded"}, want: true},
+		{name: "api validation code without status", err: &responses.WebSocketError{Code: "invalid_request_error"}, want: false},
+		{name: "arbitrary", err: errors.New("boom"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := responses.IsWebSocketRetryableError(tt.err); got != tt.want {
+				t.Fatalf("IsWebSocketRetryableError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
 	}
 }

--- a/responses/websocket_test.go
+++ b/responses/websocket_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -45,6 +46,42 @@ func newResponsesWebSocketTestServer(t *testing.T, handler func(context.Context,
 		ts.header = r.Header.Clone()
 		ts.mu.Unlock()
 
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Logf("websocket accept failed: %v", err)
+			return
+		}
+		defer closeServerWebSocket(t, conn)
+		close(ts.accepted)
+
+		if handler != nil {
+			handler(r.Context(), conn)
+		}
+	}))
+	t.Cleanup(ts.server.Close)
+	return ts
+}
+
+func newResponsesWebSocketHeaderTestServer(t *testing.T, header http.Header, handler func(context.Context, *websocket.Conn)) *responsesWebSocketTestServer {
+	t.Helper()
+
+	ts := &responsesWebSocketTestServer{
+		t:        t,
+		accepted: make(chan struct{}),
+		received: make(chan []byte, 1),
+		resume:   make(chan struct{}),
+	}
+	ts.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ts.mu.Lock()
+		ts.path = r.URL.Path
+		ts.header = r.Header.Clone()
+		ts.mu.Unlock()
+
+		for key, values := range header {
+			for _, value := range values {
+				w.Header().Add(key, value)
+			}
+		}
 		conn, err := websocket.Accept(w, r, nil)
 		if err != nil {
 			t.Logf("websocket accept failed: %v", err)
@@ -277,9 +314,17 @@ func TestResponseWebSocketEventsDecode(t *testing.T) {
 	if _, ok := event.AsAny().(responses.ResponseTextDeltaEvent); !ok {
 		t.Fatalf("event.AsAny() = %T, want responses.ResponseTextDeltaEvent", event.AsAny())
 	}
+	if got := string(stream.CurrentRaw()); !strings.Contains(got, `"response.output_text.delta"`) {
+		t.Fatalf("stream.CurrentRaw() = %q, want raw event", got)
+	}
+	raw := stream.CurrentRaw()
+	raw[0] = '!'
+	if got := string(stream.CurrentRaw()); !strings.HasPrefix(got, `{"type"`) {
+		t.Fatalf("mutating CurrentRaw result changed internal raw payload: %q", got)
+	}
 }
 
-func TestResponseWebSocketOneInFlightEnforced(t *testing.T) {
+func TestResponseWebSocketOneInFlightReturnsSentinel(t *testing.T) {
 	var ts *responsesWebSocketTestServer
 	ts = newResponsesWebSocketTestServer(t, func(ctx context.Context, conn *websocket.Conn) {
 		ts.recordOneAndWait(ctx, conn)
@@ -297,10 +342,26 @@ func TestResponseWebSocketOneInFlightEnforced(t *testing.T) {
 	if err == nil {
 		t.Fatal("conn.New() while stream active returned nil error")
 	}
-	if !strings.Contains(err.Error(), "already active") {
-		t.Fatalf("conn.New() error = %q, want already active", err.Error())
+	if !errors.Is(err, responses.ErrWebSocketStreamActive) {
+		t.Fatalf("conn.New() error = %T %[1]v, want ErrWebSocketStreamActive", err)
 	}
 	close(ts.resume)
+}
+
+func TestResponseWebSocketNewOnClosedConnReturnsSentinel(t *testing.T) {
+	ts := newResponsesWebSocketTestServer(t, func(ctx context.Context, conn *websocket.Conn) {
+		<-ctx.Done()
+	})
+	conn := connectTestWebSocket(t, ts)
+	_ = conn.Close()
+
+	_, err := conn.New(context.Background(), responses.ResponseNewParams{
+		Input: responses.ResponseNewParamsInputUnion{OfString: openai.String("second")},
+		Model: openai.ChatModelGPT4oMini,
+	})
+	if !errors.Is(err, responses.ErrWebSocketConnectionClosed) {
+		t.Fatalf("conn.New() error = %T %[1]v, want ErrWebSocketConnectionClosed", err)
+	}
 }
 
 func TestResponseWebSocketDocumentedError(t *testing.T) {
@@ -331,6 +392,354 @@ func TestResponseWebSocketDocumentedError(t *testing.T) {
 	if !strings.Contains(wsErr.Error(), "missing response") {
 		t.Fatalf("WebSocketError.Error() = %q, want message", wsErr.Error())
 	}
+	if got := string(wsErr.Raw); !strings.Contains(got, "previous_response_not_found") {
+		t.Fatalf("WebSocketError.Raw = %q, want raw payload", got)
+	}
+}
+
+func TestResponseWebSocketDocumentedErrorPreservesDetails(t *testing.T) {
+	ts := newResponsesWebSocketTestServer(t, func(ctx context.Context, conn *websocket.Conn) {
+		_, _, err := conn.Read(ctx)
+		if err != nil {
+			t.Logf("websocket read failed: %v", err)
+			return
+		}
+		errEvent := []byte(`{"type":"error","status":429,"headers":{"x-request-id":"req_123","x-ratelimit-reset":["1","2"]},"error":{"code":"rate_limit_exceeded","message":"slow down","param":"input"}}`)
+		if err := conn.Write(ctx, websocket.MessageText, errEvent); err != nil {
+			t.Logf("websocket write failed: %v", err)
+		}
+	})
+	conn := connectTestWebSocket(t, ts)
+
+	stream := newTestResponseStream(t, conn)
+	if stream.Next() {
+		t.Fatal("stream.Next() = true, want false")
+	}
+	var wsErr *responses.WebSocketError
+	if !errors.As(stream.Err(), &wsErr) {
+		t.Fatalf("stream.Err() = %T %[1]v, want *responses.WebSocketError", stream.Err())
+	}
+	if got, want := wsErr.Status, http.StatusTooManyRequests; got != want {
+		t.Fatalf("Status = %d, want %d", got, want)
+	}
+	if got, want := wsErr.Code, "rate_limit_exceeded"; got != want {
+		t.Fatalf("Code = %q, want %q", got, want)
+	}
+	if got, want := wsErr.Message, "slow down"; got != want {
+		t.Fatalf("Message = %q, want %q", got, want)
+	}
+	if got, want := wsErr.Param, "input"; got != want {
+		t.Fatalf("Param = %q, want %q", got, want)
+	}
+	if got, want := wsErr.Header.Get("x-request-id"), "req_123"; got != want {
+		t.Fatalf("Header.Get(x-request-id) = %q, want %q", got, want)
+	}
+	if got, want := wsErr.Header.Values("x-ratelimit-reset"), []string{"1", "2"}; strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("Header.Values(x-ratelimit-reset) = %v, want %v", got, want)
+	}
+	if got := string(wsErr.Raw); !strings.Contains(got, `"status":429`) {
+		t.Fatalf("Raw = %q, want status payload", got)
+	}
+}
+
+func TestResponseWebSocketErrorParsesHeaders(t *testing.T) {
+	ts := newResponsesWebSocketTestServer(t, func(ctx context.Context, conn *websocket.Conn) {
+		_, _, err := conn.Read(ctx)
+		if err != nil {
+			t.Logf("websocket read failed: %v", err)
+			return
+		}
+		errEvent := []byte(`{"type":"error","headers":{"x-request-id":"req_header"},"error":{"code":"bad","message":"bad"}}`)
+		_ = conn.Write(ctx, websocket.MessageText, errEvent)
+	})
+	conn := connectTestWebSocket(t, ts)
+
+	stream := newTestResponseStream(t, conn)
+	if stream.Next() {
+		t.Fatal("stream.Next() = true, want false")
+	}
+	var wsErr *responses.WebSocketError
+	if !errors.As(stream.Err(), &wsErr) {
+		t.Fatalf("stream.Err() = %T %[1]v, want *responses.WebSocketError", stream.Err())
+	}
+	if got, want := wsErr.Header.Get("x-request-id"), "req_header"; got != want {
+		t.Fatalf("Header.Get(x-request-id) = %q, want %q", got, want)
+	}
+}
+
+func TestResponseWebSocketErrorParsesStatusCodeAlias(t *testing.T) {
+	ts := newResponsesWebSocketTestServer(t, func(ctx context.Context, conn *websocket.Conn) {
+		_, _, err := conn.Read(ctx)
+		if err != nil {
+			t.Logf("websocket read failed: %v", err)
+			return
+		}
+		errEvent := []byte(`{"type":"error","status_code":500,"error":{"code":"server_error","message":"try later"}}`)
+		_ = conn.Write(ctx, websocket.MessageText, errEvent)
+	})
+	conn := connectTestWebSocket(t, ts)
+
+	stream := newTestResponseStream(t, conn)
+	if stream.Next() {
+		t.Fatal("stream.Next() = true, want false")
+	}
+	var wsErr *responses.WebSocketError
+	if !errors.As(stream.Err(), &wsErr) {
+		t.Fatalf("stream.Err() = %T %[1]v, want *responses.WebSocketError", stream.Err())
+	}
+	if got, want := wsErr.Status, http.StatusInternalServerError; got != want {
+		t.Fatalf("Status = %d, want %d", got, want)
+	}
+}
+
+func TestResponseWebSocketDialErrorIncludesHandshakeResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Request-ID", "req_123")
+		http.Error(w, `{"error":"bad auth"}`, http.StatusUnauthorized)
+	}))
+	t.Cleanup(server.Close)
+
+	client := openai.NewClient(
+		option.WithBaseURL(server.URL),
+		option.WithAPIKey("test-key"),
+	)
+	_, err := client.Responses.ConnectWebSocket(context.Background())
+	if err == nil {
+		t.Fatal("ConnectWebSocket() error = nil, want error")
+	}
+	var dialErr *responses.WebSocketDialError
+	if !errors.As(err, &dialErr) {
+		t.Fatalf("ConnectWebSocket() error = %T %[1]v, want *responses.WebSocketDialError", err)
+	}
+	if got, want := dialErr.StatusCode, http.StatusUnauthorized; got != want {
+		t.Fatalf("StatusCode = %d, want %d", got, want)
+	}
+	if got, want := dialErr.Header.Get("X-Request-ID"), "req_123"; got != want {
+		t.Fatalf("Header.Get(X-Request-ID) = %q, want %q", got, want)
+	}
+	if !strings.Contains(dialErr.Body, "bad auth") {
+		t.Fatalf("Body = %q, want bad auth", dialErr.Body)
+	}
+	if errors.Unwrap(dialErr) == nil {
+		t.Fatal("errors.Unwrap(dialErr) = nil, want original dial error")
+	}
+}
+
+func TestResponseWebSocketUnexpectedCloseError(t *testing.T) {
+	ts := newResponsesWebSocketTestServer(t, func(ctx context.Context, conn *websocket.Conn) {
+		_, _, err := conn.Read(ctx)
+		if err != nil {
+			t.Logf("websocket read failed: %v", err)
+			return
+		}
+		_ = conn.Close(websocket.StatusPolicyViolation, "keepalive timeout")
+	})
+	conn := connectTestWebSocket(t, ts)
+
+	stream := newTestResponseStream(t, conn)
+	if stream.Next() {
+		t.Fatal("stream.Next() = true, want false")
+	}
+	var closeErr *responses.WebSocketCloseError
+	if !errors.As(stream.Err(), &closeErr) {
+		t.Fatalf("stream.Err() = %T %[1]v, want *responses.WebSocketCloseError", stream.Err())
+	}
+	if got, want := closeErr.Status, websocket.StatusPolicyViolation; got != want {
+		t.Fatalf("Status = %d, want %d", got, want)
+	}
+	if got, want := closeErr.Reason, "keepalive timeout"; got != want {
+		t.Fatalf("Reason = %q, want %q", got, want)
+	}
+}
+
+func TestResponseWebSocketNormalCloseBeforeTerminalEventIsError(t *testing.T) {
+	ts := newResponsesWebSocketTestServer(t, func(ctx context.Context, conn *websocket.Conn) {
+		_, _, err := conn.Read(ctx)
+		if err != nil {
+			t.Logf("websocket read failed: %v", err)
+			return
+		}
+		_ = conn.Close(websocket.StatusNormalClosure, "done early")
+	})
+	conn := connectTestWebSocket(t, ts)
+
+	stream := newTestResponseStream(t, conn)
+	if stream.Next() {
+		t.Fatal("stream.Next() = true, want false")
+	}
+	var closeErr *responses.WebSocketCloseError
+	if !errors.As(stream.Err(), &closeErr) {
+		t.Fatalf("stream.Err() = %T %[1]v, want *responses.WebSocketCloseError", stream.Err())
+	}
+	if got, want := closeErr.Status, websocket.StatusNormalClosure; got != want {
+		t.Fatalf("Status = %d, want %d", got, want)
+	}
+	if got, want := closeErr.Reason, "done early"; got != want {
+		t.Fatalf("Reason = %q, want %q", got, want)
+	}
+}
+
+func TestResponseWebSocketCompletedThenCloseIsClean(t *testing.T) {
+	ts := newResponsesWebSocketTestServer(t, func(ctx context.Context, conn *websocket.Conn) {
+		_, _, err := conn.Read(ctx)
+		if err != nil {
+			t.Logf("websocket read failed: %v", err)
+			return
+		}
+		event := []byte(`{"type":"response.completed","sequence_number":1,"response":{"id":"resp_123","created_at":123,"model":"gpt-4o-mini","object":"response","output":[],"parallel_tool_calls":true,"tool_choice":"auto","tools":[]}}`)
+		if err := conn.Write(ctx, websocket.MessageText, event); err != nil {
+			t.Logf("websocket write failed: %v", err)
+			return
+		}
+		_ = conn.Close(websocket.StatusNormalClosure, "")
+	})
+	conn := connectTestWebSocket(t, ts)
+
+	stream := newTestResponseStream(t, conn)
+	if !stream.Next() {
+		t.Fatalf("stream.Next() = false, err = %v", stream.Err())
+	}
+	if got, want := stream.Current().Type, "response.completed"; got != want {
+		t.Fatalf("event.Type = %q, want %q", got, want)
+	}
+	if stream.Next() {
+		t.Fatal("second stream.Next() = true, want false")
+	}
+	if err := stream.Err(); err != nil {
+		t.Fatalf("stream.Err() = %v, want nil", err)
+	}
+}
+
+func TestResponseWebSocketFailedEventIsTerminalAndReleasesStream(t *testing.T) {
+	ts := newResponsesWebSocketTestServer(t, func(ctx context.Context, conn *websocket.Conn) {
+		if _, _, err := conn.Read(ctx); err != nil {
+			t.Logf("websocket read failed: %v", err)
+			return
+		}
+		failed := []byte(`{"type":"response.failed","sequence_number":1,"response":{"id":"resp_failed","created_at":123,"model":"gpt-4o-mini","object":"response","output":[],"parallel_tool_calls":true,"tool_choice":"auto","tools":[],"status":"failed"}}`)
+		if err := conn.Write(ctx, websocket.MessageText, failed); err != nil {
+			t.Logf("websocket write failed: %v", err)
+			return
+		}
+
+		if _, _, err := conn.Read(ctx); err != nil {
+			t.Logf("second websocket read failed: %v", err)
+			return
+		}
+		completed := []byte(`{"type":"response.completed","sequence_number":2,"response":{"id":"resp_completed","created_at":123,"model":"gpt-4o-mini","object":"response","output":[],"parallel_tool_calls":true,"tool_choice":"auto","tools":[]}}`)
+		_ = conn.Write(ctx, websocket.MessageText, completed)
+	})
+	conn := connectTestWebSocket(t, ts)
+
+	stream := newTestResponseStream(t, conn)
+	if !stream.Next() {
+		t.Fatalf("stream.Next() = false, err = %v", stream.Err())
+	}
+	if got, want := stream.Current().Type, "response.failed"; got != want {
+		t.Fatalf("event.Type = %q, want %q", got, want)
+	}
+	if stream.Next() {
+		t.Fatal("second stream.Next() = true, want false after terminal response.failed")
+	}
+	if err := stream.Err(); err != nil {
+		t.Fatalf("stream.Err() = %v, want nil for response.failed event", err)
+	}
+
+	next := newTestResponseStream(t, conn)
+	if !next.Next() {
+		t.Fatalf("next stream.Next() = false, err = %v", next.Err())
+	}
+	if got, want := next.Current().Type, "response.completed"; got != want {
+		t.Fatalf("next event.Type = %q, want %q", got, want)
+	}
+}
+
+func TestResponseWebSocketDropBeforeTerminalEventIsError(t *testing.T) {
+	ts := newResponsesWebSocketTestServer(t, func(ctx context.Context, conn *websocket.Conn) {
+		_, _, err := conn.Read(ctx)
+		if err != nil {
+			t.Logf("websocket read failed: %v", err)
+			return
+		}
+		_ = conn.CloseNow()
+	})
+	conn := connectTestWebSocket(t, ts)
+
+	stream := newTestResponseStream(t, conn)
+	if stream.Next() {
+		t.Fatal("stream.Next() = true, want false")
+	}
+	if stream.Err() == nil {
+		t.Fatal("stream.Err() = nil, want transport error")
+	}
+	if !errors.Is(stream.Err(), io.EOF) {
+		var transportErr *responses.WebSocketTransportError
+		if !errors.As(stream.Err(), &transportErr) {
+			t.Fatalf("stream.Err() = %T %[1]v, want io.EOF or *responses.WebSocketTransportError", stream.Err())
+		}
+	}
+}
+
+func TestResponseWebSocketDecodeErrorIncludesRawPayload(t *testing.T) {
+	ts := newResponsesWebSocketTestServer(t, func(ctx context.Context, conn *websocket.Conn) {
+		_, _, err := conn.Read(ctx)
+		if err != nil {
+			t.Logf("websocket read failed: %v", err)
+			return
+		}
+		_ = conn.Write(ctx, websocket.MessageText, []byte(`not json`))
+	})
+	conn := connectTestWebSocket(t, ts)
+
+	stream := newTestResponseStream(t, conn)
+	if stream.Next() {
+		t.Fatal("stream.Next() = true, want false")
+	}
+	var decodeErr *responses.WebSocketDecodeError
+	if !errors.As(stream.Err(), &decodeErr) {
+		t.Fatalf("stream.Err() = %T %[1]v, want *responses.WebSocketDecodeError", stream.Err())
+	}
+	if got, want := string(decodeErr.Data), "not json"; got != want {
+		t.Fatalf("Data = %q, want %q", got, want)
+	}
+}
+
+func TestResponseWebSocketUnknownEventIsYieldedWithRawPayload(t *testing.T) {
+	ts := newResponsesWebSocketTestServer(t, func(ctx context.Context, conn *websocket.Conn) {
+		_, _, err := conn.Read(ctx)
+		if err != nil {
+			t.Logf("websocket read failed: %v", err)
+			return
+		}
+		unknown := []byte(`{"type":"response.future_event","sequence_number":99,"new_field":"preserved"}`)
+		if err := conn.Write(ctx, websocket.MessageText, unknown); err != nil {
+			t.Logf("websocket write failed: %v", err)
+			return
+		}
+		completed := []byte(`{"type":"response.completed","sequence_number":100,"response":{"id":"resp_123","created_at":123,"model":"gpt-4o-mini","object":"response","output":[],"parallel_tool_calls":true,"tool_choice":"auto","tools":[]}}`)
+		_ = conn.Write(ctx, websocket.MessageText, completed)
+	})
+	conn := connectTestWebSocket(t, ts)
+
+	stream := newTestResponseStream(t, conn)
+	if !stream.Next() {
+		t.Fatalf("stream.Next() = false, err = %v", stream.Err())
+	}
+	if got, want := stream.Current().Type, "response.future_event"; got != want {
+		t.Fatalf("event.Type = %q, want %q", got, want)
+	}
+	if got := string(stream.CurrentRaw()); !strings.Contains(got, `"new_field":"preserved"`) {
+		t.Fatalf("CurrentRaw() = %q, want unknown event raw payload", got)
+	}
+	if !stream.Next() {
+		t.Fatalf("second stream.Next() = false, err = %v", stream.Err())
+	}
+	if got, want := stream.Current().Type, "response.completed"; got != want {
+		t.Fatalf("event.Type = %q, want %q", got, want)
+	}
+	if err := stream.Err(); err != nil {
+		t.Fatalf("stream.Err() = %v, want nil", err)
+	}
 }
 
 func TestResponseWebSocketCloseIdempotent(t *testing.T) {
@@ -344,5 +753,65 @@ func TestResponseWebSocketCloseIdempotent(t *testing.T) {
 	}
 	if err := conn.Close(); err != nil {
 		t.Fatalf("second Close() error = %v", err)
+	}
+}
+
+func TestResponseWebSocketHandshakeHeader(t *testing.T) {
+	header := http.Header{}
+	header.Set("X-Reasoning-Included", "true")
+	header.Set("OpenAI-Model", "gpt-test")
+	ts := newResponsesWebSocketHeaderTestServer(t, header, func(ctx context.Context, conn *websocket.Conn) {
+		<-ctx.Done()
+	})
+	conn := connectTestWebSocket(t, ts)
+
+	if got, want := conn.HandshakeHeader().Get("X-Reasoning-Included"), "true"; got != want {
+		t.Fatalf("HandshakeHeader().Get(X-Reasoning-Included) = %q, want %q", got, want)
+	}
+	if got, want := conn.HandshakeHeader().Get("OpenAI-Model"), "gpt-test"; got != want {
+		t.Fatalf("HandshakeHeader().Get(OpenAI-Model) = %q, want %q", got, want)
+	}
+	got := conn.HandshakeHeader()
+	got.Set("OpenAI-Model", "mutated")
+	if got, want := conn.HandshakeHeader().Get("OpenAI-Model"), "gpt-test"; got != want {
+		t.Fatalf("mutating returned header changed internal header: got %q, want %q", got, want)
+	}
+}
+
+func TestIsWebSocketRetryableError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "connection closed", err: responses.ErrWebSocketConnectionClosed, want: true},
+		{name: "stream active", err: responses.ErrWebSocketStreamActive, want: false},
+		{name: "context canceled", err: context.Canceled, want: false},
+		{name: "context deadline", err: context.DeadlineExceeded, want: false},
+		{name: "dial transport failure", err: &responses.WebSocketDialError{Err: io.EOF}, want: true},
+		{name: "dial 401", err: &responses.WebSocketDialError{StatusCode: http.StatusUnauthorized}, want: false},
+		{name: "dial 429", err: &responses.WebSocketDialError{StatusCode: http.StatusTooManyRequests}, want: true},
+		{name: "dial 500", err: &responses.WebSocketDialError{StatusCode: http.StatusInternalServerError}, want: true},
+		{name: "close abnormal", err: &responses.WebSocketCloseError{Status: websocket.StatusAbnormalClosure}, want: true},
+		{name: "close normal", err: &responses.WebSocketCloseError{Status: websocket.StatusNormalClosure}, want: false},
+		{name: "transport EOF", err: &responses.WebSocketTransportError{Op: "read", Err: io.EOF}, want: true},
+		{name: "wrapped EOF", err: io.EOF, want: true},
+		{name: "api 400", err: &responses.WebSocketError{Status: http.StatusBadRequest}, want: false},
+		{name: "api 408", err: &responses.WebSocketError{Status: http.StatusRequestTimeout}, want: true},
+		{name: "api 409", err: &responses.WebSocketError{Status: http.StatusConflict}, want: true},
+		{name: "api 429", err: &responses.WebSocketError{Status: http.StatusTooManyRequests}, want: true},
+		{name: "api 500", err: &responses.WebSocketError{Status: http.StatusInternalServerError}, want: true},
+		{name: "api retryable code without status", err: &responses.WebSocketError{Code: "rate_limit_exceeded"}, want: true},
+		{name: "api validation code without status", err: &responses.WebSocketError{Code: "invalid_request_error"}, want: false},
+		{name: "arbitrary", err: errors.New("boom"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := responses.IsWebSocketRetryableError(tt.err); got != tt.want {
+				t.Fatalf("IsWebSocketRetryableError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
 	}
 }

--- a/responses/websocket_test.go
+++ b/responses/websocket_test.go
@@ -1,0 +1,348 @@
+package responses_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+	"github.com/openai/openai-go/v3/responses"
+)
+
+type responsesWebSocketTestServer struct {
+	t      *testing.T
+	server *httptest.Server
+
+	mu     sync.Mutex
+	path   string
+	header http.Header
+
+	accepted chan struct{}
+	received chan []byte
+	resume   chan struct{}
+}
+
+func newResponsesWebSocketTestServer(t *testing.T, handler func(context.Context, *websocket.Conn)) *responsesWebSocketTestServer {
+	t.Helper()
+
+	ts := &responsesWebSocketTestServer{
+		t:        t,
+		accepted: make(chan struct{}),
+		received: make(chan []byte, 1),
+		resume:   make(chan struct{}),
+	}
+	ts.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ts.mu.Lock()
+		ts.path = r.URL.Path
+		ts.header = r.Header.Clone()
+		ts.mu.Unlock()
+
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Logf("websocket accept failed: %v", err)
+			return
+		}
+		defer closeServerWebSocket(t, conn)
+		close(ts.accepted)
+
+		if handler != nil {
+			handler(r.Context(), conn)
+		}
+	}))
+	t.Cleanup(ts.server.Close)
+	return ts
+}
+
+func (ts *responsesWebSocketTestServer) recordOneAndWait(ctx context.Context, conn *websocket.Conn) {
+	_, msg, err := conn.Read(ctx)
+	if err != nil {
+		ts.t.Logf("websocket read failed: %v", err)
+		return
+	}
+	ts.received <- msg
+
+	select {
+	case <-ts.resume:
+	case <-ctx.Done():
+	}
+}
+
+func (ts *responsesWebSocketTestServer) headerValue(key string) string {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.header.Get(key)
+}
+
+func (ts *responsesWebSocketTestServer) requestPath() string {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.path
+}
+
+func (ts *responsesWebSocketTestServer) waitAccepted(t *testing.T) {
+	t.Helper()
+	select {
+	case <-ts.accepted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for websocket accept")
+	}
+}
+
+func (ts *responsesWebSocketTestServer) waitReceived(t *testing.T) []byte {
+	t.Helper()
+	select {
+	case msg := <-ts.received:
+		return msg
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for websocket message")
+		return nil
+	}
+}
+
+func connectTestWebSocket(t *testing.T, ts *responsesWebSocketTestServer, opts ...option.RequestOption) *responses.WebSocketConn {
+	t.Helper()
+	client := openai.NewClient(append([]option.RequestOption{
+		option.WithBaseURL(ts.server.URL),
+		option.WithAPIKey("test-key"),
+	}, opts...)...)
+	conn, err := client.Responses.ConnectWebSocket(context.Background())
+	if err != nil {
+		t.Fatalf("ConnectWebSocket() error = %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}
+
+func newTestResponseStream(t *testing.T, conn *responses.WebSocketConn) *responses.WebSocketStream {
+	t.Helper()
+	stream, err := conn.New(context.Background(), responses.ResponseNewParams{
+		Input: responses.ResponseNewParamsInputUnion{OfString: openai.String("hello")},
+		Model: openai.ChatModelGPT4oMini,
+	})
+	if err != nil {
+		t.Fatalf("conn.New() error = %v", err)
+	}
+	return stream
+}
+
+func closeServerWebSocket(t *testing.T, conn *websocket.Conn) {
+	t.Helper()
+	if err := conn.Close(websocket.StatusNormalClosure, ""); err != nil {
+		t.Logf("server WebSocket close failed: %v", err)
+	}
+}
+
+func closeTestWebSocket(t *testing.T, conn *responses.WebSocketConn) {
+	t.Helper()
+	if err := conn.Close(); err != nil {
+		t.Logf("WebSocket close failed: %v", err)
+	}
+}
+
+func closeTestResponseStream(t *testing.T, stream *responses.WebSocketStream) {
+	t.Helper()
+	if err := stream.Close(); err != nil {
+		t.Logf("WebSocket stream close failed: %v", err)
+	}
+}
+
+func TestResponseWebSocketURLConversion(t *testing.T) {
+	ts := newResponsesWebSocketTestServer(t, func(ctx context.Context, conn *websocket.Conn) {
+		<-ctx.Done()
+	})
+
+	conn := connectTestWebSocket(t, ts)
+	defer closeTestWebSocket(t, conn)
+
+	ts.waitAccepted(t)
+	if got, want := ts.requestPath(), "/responses"; got != want {
+		t.Fatalf("request path = %q, want %q", got, want)
+	}
+}
+
+func TestResponseWebSocketHeadersAndAuth(t *testing.T) {
+	ts := newResponsesWebSocketTestServer(t, func(ctx context.Context, conn *websocket.Conn) {
+		<-ctx.Done()
+	})
+
+	client := openai.NewClient(
+		option.WithBaseURL(ts.server.URL),
+		option.WithAPIKey("test-key"),
+		option.WithOrganization("org_123"),
+		option.WithProject("proj_123"),
+		option.WithHeader("X-Custom-Header", "custom-value"),
+	)
+	conn, err := client.Responses.ConnectWebSocket(context.Background())
+	if err != nil {
+		t.Fatalf("ConnectWebSocket() error = %v", err)
+	}
+	defer closeTestWebSocket(t, conn)
+
+	ts.waitAccepted(t)
+	if got, want := ts.headerValue("Authorization"), "Bearer test-key"; got != want {
+		t.Fatalf("Authorization = %q, want %q", got, want)
+	}
+	if got, want := ts.headerValue("OpenAI-Organization"), "org_123"; got != want {
+		t.Fatalf("OpenAI-Organization = %q, want %q", got, want)
+	}
+	if got, want := ts.headerValue("OpenAI-Project"), "proj_123"; got != want {
+		t.Fatalf("OpenAI-Project = %q, want %q", got, want)
+	}
+	if got, want := ts.headerValue("X-Custom-Header"), "custom-value"; got != want {
+		t.Fatalf("X-Custom-Header = %q, want %q", got, want)
+	}
+}
+
+func TestResponseWebSocketNewSendsResponseCreate(t *testing.T) {
+	var ts *responsesWebSocketTestServer
+	ts = newResponsesWebSocketTestServer(t, func(ctx context.Context, conn *websocket.Conn) {
+		ts.recordOneAndWait(ctx, conn)
+	})
+	conn := connectTestWebSocket(t, ts)
+
+	stream := newTestResponseStream(t, conn)
+	defer closeTestResponseStream(t, stream)
+	msg := ts.waitReceived(t)
+
+	var payload map[string]any
+	if err := json.Unmarshal(msg, &payload); err != nil {
+		t.Fatalf("message was not JSON: %v", err)
+	}
+	if got, want := payload["type"], "response.create"; got != want {
+		t.Fatalf("type = %v, want %q", got, want)
+	}
+	if got, want := payload["model"], string(openai.ChatModelGPT4oMini); got != want {
+		t.Fatalf("model = %v, want %q", got, want)
+	}
+	if got, want := payload["input"], "hello"; got != want {
+		t.Fatalf("input = %v, want %q", got, want)
+	}
+	close(ts.resume)
+}
+
+func TestResponseWebSocketNewDoesNotForceStreamTrue(t *testing.T) {
+	var ts *responsesWebSocketTestServer
+	ts = newResponsesWebSocketTestServer(t, func(ctx context.Context, conn *websocket.Conn) {
+		ts.recordOneAndWait(ctx, conn)
+	})
+	conn := connectTestWebSocket(t, ts)
+
+	stream := newTestResponseStream(t, conn)
+	defer closeTestResponseStream(t, stream)
+	msg := ts.waitReceived(t)
+
+	var payload map[string]any
+	if err := json.Unmarshal(msg, &payload); err != nil {
+		t.Fatalf("message was not JSON: %v", err)
+	}
+	if v, ok := payload["stream"]; ok {
+		t.Fatalf("stream was set to %v; want omitted", v)
+	}
+	close(ts.resume)
+}
+
+func TestResponseWebSocketEventsDecode(t *testing.T) {
+	ts := newResponsesWebSocketTestServer(t, func(ctx context.Context, conn *websocket.Conn) {
+		_, _, err := conn.Read(ctx)
+		if err != nil {
+			t.Logf("websocket read failed: %v", err)
+			return
+		}
+		event := []byte(`{"type":"response.output_text.delta","sequence_number":1,"item_id":"item_123","output_index":0,"content_index":0,"delta":"hi","logprobs":[]}`)
+		if err := conn.Write(ctx, websocket.MessageText, event); err != nil {
+			t.Logf("websocket write failed: %v", err)
+		}
+	})
+	conn := connectTestWebSocket(t, ts)
+
+	stream := newTestResponseStream(t, conn)
+	if !stream.Next() {
+		t.Fatalf("stream.Next() = false, err = %v", stream.Err())
+	}
+	event := stream.Current()
+	if got, want := event.Type, "response.output_text.delta"; got != want {
+		t.Fatalf("event.Type = %q, want %q", got, want)
+	}
+	if got, want := event.Delta, "hi"; got != want {
+		t.Fatalf("event.Delta = %q, want %q", got, want)
+	}
+	if _, ok := event.AsAny().(responses.ResponseTextDeltaEvent); !ok {
+		t.Fatalf("event.AsAny() = %T, want responses.ResponseTextDeltaEvent", event.AsAny())
+	}
+}
+
+func TestResponseWebSocketOneInFlightEnforced(t *testing.T) {
+	var ts *responsesWebSocketTestServer
+	ts = newResponsesWebSocketTestServer(t, func(ctx context.Context, conn *websocket.Conn) {
+		ts.recordOneAndWait(ctx, conn)
+	})
+	conn := connectTestWebSocket(t, ts)
+
+	stream := newTestResponseStream(t, conn)
+	defer closeTestResponseStream(t, stream)
+	ts.waitReceived(t)
+
+	_, err := conn.New(context.Background(), responses.ResponseNewParams{
+		Input: responses.ResponseNewParamsInputUnion{OfString: openai.String("second")},
+		Model: openai.ChatModelGPT4oMini,
+	})
+	if err == nil {
+		t.Fatal("conn.New() while stream active returned nil error")
+	}
+	if !strings.Contains(err.Error(), "already active") {
+		t.Fatalf("conn.New() error = %q, want already active", err.Error())
+	}
+	close(ts.resume)
+}
+
+func TestResponseWebSocketDocumentedError(t *testing.T) {
+	ts := newResponsesWebSocketTestServer(t, func(ctx context.Context, conn *websocket.Conn) {
+		_, _, err := conn.Read(ctx)
+		if err != nil {
+			t.Logf("websocket read failed: %v", err)
+			return
+		}
+		errEvent := []byte(`{"type":"error","status":400,"error":{"code":"previous_response_not_found","message":"missing response","param":"previous_response_id"}}`)
+		if err := conn.Write(ctx, websocket.MessageText, errEvent); err != nil {
+			t.Logf("websocket write failed: %v", err)
+		}
+	})
+	conn := connectTestWebSocket(t, ts)
+
+	stream := newTestResponseStream(t, conn)
+	if stream.Next() {
+		t.Fatal("stream.Next() = true, want false")
+	}
+	var wsErr *responses.WebSocketError
+	if !errors.As(stream.Err(), &wsErr) {
+		t.Fatalf("stream.Err() = %T %[1]v, want *responses.WebSocketError", stream.Err())
+	}
+	if wsErr.Status != 400 || wsErr.Code != "previous_response_not_found" || wsErr.Param != "previous_response_id" {
+		t.Fatalf("unexpected WebSocketError: %+v", wsErr)
+	}
+	if !strings.Contains(wsErr.Error(), "missing response") {
+		t.Fatalf("WebSocketError.Error() = %q, want message", wsErr.Error())
+	}
+}
+
+func TestResponseWebSocketCloseIdempotent(t *testing.T) {
+	ts := newResponsesWebSocketTestServer(t, func(ctx context.Context, conn *websocket.Conn) {
+		_, _, _ = conn.Read(ctx)
+	})
+	conn := connectTestWebSocket(t, ts)
+
+	if err := conn.Close(); err != nil {
+		t.Fatalf("first Close() error = %v", err)
+	}
+	if err := conn.Close(); err != nil {
+		t.Fatalf("second Close() error = %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `ResponseService.ConnectWebSocket`, `WebSocketConn`, and `WebSocketStream` for typed Responses API WebSocket sessions.
- Add typed Responses WebSocket error handling for handshake failures, close frames, read/write transport errors, malformed payloads, documented API/model error events, and stable SDK state errors.
- Expose safe diagnostics via `WebSocketConn.HandshakeHeader()` and `WebSocketStream.CurrentRaw()` with cloned/copy-returned data.
- Add advisory `responses.IsWebSocketRetryableError` so callers can classify retryable WebSocket failures without matching error strings while keeping replay policy application-owned.
- Tighten stream semantics so early close/drop is surfaced, terminal Responses events release the in-flight lock, and `response.failed` remains a terminal event rather than a transport error.
- Raise `coder/websocket`'s per-message read limit from its 32 KiB default to 64 MiB for large Responses tool-call argument events.
- Add env-gated live WebSocket tests covering a simple stream, bad API key handshake classification, invalid model classification, and handshake metadata.

## Testing
- `go test ./... -count=1` (with the repository mock server)
- `go test -race ./responses -run WebSocket -count=1`
- `go -C examples test ./... -count=1`
- `go -C internal/testdata/consumer test -mod=readonly ./... -count=1`
- `./scripts/check-go-mod`
- `env GOFLAGS=-buildvcs=false ./scripts/lint`
- `RUN_LIVE_API_TESTS=0 go test ./responses -tags live -run LiveResponseWebSocket -count=1`
