### PR TITLE
fix(chatcompletion): support file_url in FileContentPart

### DIFF
--- a/chatcompletion.go
+++ b/chatcompletion.go
@@ -1033,6 +1033,8 @@ type ChatCompletionContentPartFileFileParam struct {
 	FileData param.Opt[string] `json:"file_data,omitzero"`
 	// The ID of an uploaded file to use as input.
 	FileID param.Opt[string] `json:"file_id,omitzero"`
+	// The URL of the file to use as input.
+	FileURL param.Opt[string] `json:"file_url,omitzero"`
 	// The name of the file, used when passing the file to the model as a string.
 	Filename param.Opt[string] `json:"filename,omitzero"`
 	paramObj

--- a/chatcompletion_test.go
+++ b/chatcompletion_test.go
@@ -4,8 +4,10 @@ package openai_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/openai/openai-go/v3"
@@ -13,6 +15,25 @@ import (
 	"github.com/openai/openai-go/v3/option"
 	"github.com/openai/openai-go/v3/shared"
 )
+
+func TestFileContentPartSupportsFileURL(t *testing.T) {
+	part := openai.FileContentPart(openai.ChatCompletionContentPartFileFileParam{
+		FileURL: openai.String("https://example.com/document.pdf"),
+	})
+
+	raw, err := json.Marshal(part)
+	if err != nil {
+		t.Fatalf("marshal should succeed: %v", err)
+	}
+
+	serialized := string(raw)
+	if !strings.Contains(serialized, "\"type\":\"file\"") {
+		t.Fatalf("serialized content part should contain file type, got: %s", serialized)
+	}
+	if !strings.Contains(serialized, "\"file_url\":\"https://example.com/document.pdf\"") {
+		t.Fatalf("serialized content part should contain file_url, got: %s", serialized)
+	}
+}
 
 func TestChatCompletionNewWithOptionalParams(t *testing.T) {
 	baseURL := "http://localhost:4010"


### PR DESCRIPTION
## Summary
- add ile_url to ChatCompletionContentPartFileFileParam
- allow FileContentPart to represent URL-based file inputs documented for chat completions
- add a focused test that verifies ile_url is serialized in the content part payload

## Testing
- unable to run go test in this environment because go is not installed (go command not found)

Closes #588