### PR TITLE
fix(requestconfig): parse top-level API error payloads

### DIFF
--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -508,10 +508,15 @@ func (cfg *RequestConfig) Execute() (err error) {
 		// utilities can conveniently dump the response without issue.
 		res.Body = io.NopCloser(bytes.NewBuffer(contents))
 
-		// Load the contents into the error format if it is provided.
+		// Load the contents into the error format.
+		// Some providers return OpenAI-style {"error": {...}}, while others return
+		// top-level {"code": "...", "message": "..."}.
 		aerr := apierror.Error{Request: cfg.Request, Response: res, StatusCode: res.StatusCode}
-		unwrapped := gjson.GetBytes(contents, "error").Raw
-		err = aerr.UnmarshalJSON([]byte(unwrapped))
+		payload := contents
+		if unwrapped := gjson.GetBytes(contents, "error"); unwrapped.Exists() && unwrapped.Type == gjson.JSON {
+			payload = []byte(unwrapped.Raw)
+		}
+		err = aerr.UnmarshalJSON(payload)
 		if err != nil {
 			return err
 		}

--- a/internal/requestconfig/requestconfig_test.go
+++ b/internal/requestconfig/requestconfig_test.go
@@ -1,0 +1,77 @@
+package requestconfig
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/openai/openai-go/v3/internal/apierror"
+)
+
+func TestExecuteParsesTopLevelErrorPayload(t *testing.T) {
+	t.Parallel()
+
+	err := executeErrorRequest(t, http.StatusNotFound, `{"code":"not_found","message":"missing resource"}`)
+	var apiErr *apierror.Error
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected apierror.Error, got %T", err)
+	}
+	if apiErr.Code != "not_found" {
+		t.Fatalf("expected code %q, got %q", "not_found", apiErr.Code)
+	}
+	if apiErr.Message != "missing resource" {
+		t.Fatalf("expected message %q, got %q", "missing resource", apiErr.Message)
+	}
+}
+
+func TestExecuteParsesNestedErrorPayload(t *testing.T) {
+	t.Parallel()
+
+	err := executeErrorRequest(t, http.StatusBadRequest, `{"error":{"code":"bad_request","message":"invalid input"}}`)
+	var apiErr *apierror.Error
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected apierror.Error, got %T", err)
+	}
+	if apiErr.Code != "bad_request" {
+		t.Fatalf("expected code %q, got %q", "bad_request", apiErr.Code)
+	}
+	if apiErr.Message != "invalid input" {
+		t.Fatalf("expected message %q, got %q", "invalid input", apiErr.Message)
+	}
+}
+
+func executeErrorRequest(t *testing.T, statusCode int, payload string) error {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		_, _ = io.WriteString(w, payload)
+	}))
+	defer server.Close()
+
+	cfg, err := NewRequestConfig(context.Background(), http.MethodGet, "/test", nil, nil)
+	if err != nil {
+		t.Fatalf("NewRequestConfig() error = %v", err)
+	}
+
+	baseURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("url.Parse() error = %v", err)
+	}
+
+	cfg.BaseURL = baseURL
+	cfg.HTTPClient = server.Client()
+	cfg.MaxRetries = 0
+
+	err = cfg.Execute()
+	if err == nil {
+		t.Fatal("expected Execute() to return an error")
+	}
+
+	return err
+}


### PR DESCRIPTION
## Summary
- fall back to decoding the full response body when a downstream provider returns top-level code / message error JSON
- keep preferring nested error objects when present in OpenAI-style payloads
- add focused regression tests for both top-level and nested error payloads

Closes #644

## Testing
- Not run locally: go is not installed in this environment