### PR TITLE
fix(client): encode generated URL path parameters

### DIFF
--- a/adminorganizationadminapikey.go
+++ b/adminorganizationadminapikey.go
@@ -56,7 +56,7 @@ func (r *AdminOrganizationAdminAPIKeyService) Get(ctx context.Context, keyID str
 		err = errors.New("missing required key_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/admin_api_keys/%s", keyID)
+	path := fmt.Sprintf("organization/admin_api_keys/%s", pathSegment(keyID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -93,7 +93,7 @@ func (r *AdminOrganizationAdminAPIKeyService) Delete(ctx context.Context, keyID 
 		err = errors.New("missing required key_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/admin_api_keys/%s", keyID)
+	path := fmt.Sprintf("organization/admin_api_keys/%s", pathSegment(keyID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/adminorganizationcertificate.go
+++ b/adminorganizationcertificate.go
@@ -61,7 +61,7 @@ func (r *AdminOrganizationCertificateService) Get(ctx context.Context, certifica
 		err = errors.New("missing required certificate_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/certificates/%s", certificateID)
+	path := fmt.Sprintf("organization/certificates/%s", pathSegment(certificateID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, query, &res, opts...)
 	return res, err
 }
@@ -74,7 +74,7 @@ func (r *AdminOrganizationCertificateService) Update(ctx context.Context, certif
 		err = errors.New("missing required certificate_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/certificates/%s", certificateID)
+	path := fmt.Sprintf("organization/certificates/%s", pathSegment(certificateID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -113,7 +113,7 @@ func (r *AdminOrganizationCertificateService) Delete(ctx context.Context, certif
 		err = errors.New("missing required certificate_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/certificates/%s", certificateID)
+	path := fmt.Sprintf("organization/certificates/%s", pathSegment(certificateID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/adminorganizationgroup.go
+++ b/adminorganizationgroup.go
@@ -60,7 +60,7 @@ func (r *AdminOrganizationGroupService) Update(ctx context.Context, groupID stri
 		err = errors.New("missing required group_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/groups/%s", groupID)
+	path := fmt.Sprintf("organization/groups/%s", pathSegment(groupID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -97,7 +97,7 @@ func (r *AdminOrganizationGroupService) Delete(ctx context.Context, groupID stri
 		err = errors.New("missing required group_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/groups/%s", groupID)
+	path := fmt.Sprintf("organization/groups/%s", pathSegment(groupID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/adminorganizationgrouprole.go
+++ b/adminorganizationgrouprole.go
@@ -47,7 +47,7 @@ func (r *AdminOrganizationGroupRoleService) New(ctx context.Context, groupID str
 		err = errors.New("missing required group_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/groups/%s/roles", groupID)
+	path := fmt.Sprintf("organization/groups/%s/roles", pathSegment(groupID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -62,7 +62,7 @@ func (r *AdminOrganizationGroupRoleService) List(ctx context.Context, groupID st
 		err = errors.New("missing required group_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/groups/%s/roles", groupID)
+	path := fmt.Sprintf("organization/groups/%s/roles", pathSegment(groupID))
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -92,7 +92,7 @@ func (r *AdminOrganizationGroupRoleService) Delete(ctx context.Context, groupID 
 		err = errors.New("missing required role_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/groups/%s/roles/%s", groupID, roleID)
+	path := fmt.Sprintf("organization/groups/%s/roles/%s", pathSegment(groupID), pathSegment(roleID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/adminorganizationgroupuser.go
+++ b/adminorganizationgroupuser.go
@@ -47,7 +47,7 @@ func (r *AdminOrganizationGroupUserService) New(ctx context.Context, groupID str
 		err = errors.New("missing required group_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/groups/%s/users", groupID)
+	path := fmt.Sprintf("organization/groups/%s/users", pathSegment(groupID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -62,7 +62,7 @@ func (r *AdminOrganizationGroupUserService) List(ctx context.Context, groupID st
 		err = errors.New("missing required group_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/groups/%s/users", groupID)
+	path := fmt.Sprintf("organization/groups/%s/users", pathSegment(groupID))
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -92,7 +92,7 @@ func (r *AdminOrganizationGroupUserService) Delete(ctx context.Context, groupID 
 		err = errors.New("missing required user_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/groups/%s/users/%s", groupID, userID)
+	path := fmt.Sprintf("organization/groups/%s/users/%s", pathSegment(groupID), pathSegment(userID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/adminorganizationinvite.go
+++ b/adminorganizationinvite.go
@@ -57,7 +57,7 @@ func (r *AdminOrganizationInviteService) Get(ctx context.Context, inviteID strin
 		err = errors.New("missing required invite_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/invites/%s", inviteID)
+	path := fmt.Sprintf("organization/invites/%s", pathSegment(inviteID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -94,7 +94,7 @@ func (r *AdminOrganizationInviteService) Delete(ctx context.Context, inviteID st
 		err = errors.New("missing required invite_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/invites/%s", inviteID)
+	path := fmt.Sprintf("organization/invites/%s", pathSegment(inviteID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/adminorganizationproject.go
+++ b/adminorganizationproject.go
@@ -71,7 +71,7 @@ func (r *AdminOrganizationProjectService) Get(ctx context.Context, projectID str
 		err = errors.New("missing required project_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s", projectID)
+	path := fmt.Sprintf("organization/projects/%s", pathSegment(projectID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -84,7 +84,7 @@ func (r *AdminOrganizationProjectService) Update(ctx context.Context, projectID 
 		err = errors.New("missing required project_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s", projectID)
+	path := fmt.Sprintf("organization/projects/%s", pathSegment(projectID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -122,7 +122,7 @@ func (r *AdminOrganizationProjectService) Archive(ctx context.Context, projectID
 		err = errors.New("missing required project_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/archive", projectID)
+	path := fmt.Sprintf("organization/projects/%s/archive", pathSegment(projectID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, nil, &res, opts...)
 	return res, err
 }

--- a/adminorganizationprojectapikey.go
+++ b/adminorganizationprojectapikey.go
@@ -51,7 +51,7 @@ func (r *AdminOrganizationProjectAPIKeyService) Get(ctx context.Context, project
 		err = errors.New("missing required api_key_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/api_keys/%s", projectID, apiKeyID)
+	path := fmt.Sprintf("organization/projects/%s/api_keys/%s", pathSegment(projectID), pathSegment(apiKeyID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -66,7 +66,7 @@ func (r *AdminOrganizationProjectAPIKeyService) List(ctx context.Context, projec
 		err = errors.New("missing required project_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/api_keys", projectID)
+	path := fmt.Sprintf("organization/projects/%s/api_keys", pathSegment(projectID))
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -99,7 +99,7 @@ func (r *AdminOrganizationProjectAPIKeyService) Delete(ctx context.Context, proj
 		err = errors.New("missing required api_key_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/api_keys/%s", projectID, apiKeyID)
+	path := fmt.Sprintf("organization/projects/%s/api_keys/%s", pathSegment(projectID), pathSegment(apiKeyID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/adminorganizationprojectcertificate.go
+++ b/adminorganizationprojectcertificate.go
@@ -50,7 +50,7 @@ func (r *AdminOrganizationProjectCertificateService) List(ctx context.Context, p
 		err = errors.New("missing required project_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/certificates", projectID)
+	path := fmt.Sprintf("organization/projects/%s/certificates", pathSegment(projectID))
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -80,7 +80,7 @@ func (r *AdminOrganizationProjectCertificateService) Activate(ctx context.Contex
 		err = errors.New("missing required project_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/certificates/activate", projectID)
+	path := fmt.Sprintf("organization/projects/%s/certificates/activate", pathSegment(projectID))
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodPost, path, body, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -111,7 +111,7 @@ func (r *AdminOrganizationProjectCertificateService) Deactivate(ctx context.Cont
 		err = errors.New("missing required project_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/certificates/deactivate", projectID)
+	path := fmt.Sprintf("organization/projects/%s/certificates/deactivate", pathSegment(projectID))
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodPost, path, body, &res, opts...)
 	if err != nil {
 		return nil, err

--- a/adminorganizationprojectgroup.go
+++ b/adminorganizationprojectgroup.go
@@ -49,7 +49,7 @@ func (r *AdminOrganizationProjectGroupService) New(ctx context.Context, projectI
 		err = errors.New("missing required project_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/groups", projectID)
+	path := fmt.Sprintf("organization/projects/%s/groups", pathSegment(projectID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -64,7 +64,7 @@ func (r *AdminOrganizationProjectGroupService) List(ctx context.Context, project
 		err = errors.New("missing required project_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/groups", projectID)
+	path := fmt.Sprintf("organization/projects/%s/groups", pathSegment(projectID))
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -94,7 +94,7 @@ func (r *AdminOrganizationProjectGroupService) Delete(ctx context.Context, proje
 		err = errors.New("missing required group_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/groups/%s", projectID, groupID)
+	path := fmt.Sprintf("organization/projects/%s/groups/%s", pathSegment(projectID), pathSegment(groupID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/adminorganizationprojectgrouprole.go
+++ b/adminorganizationprojectgrouprole.go
@@ -51,7 +51,7 @@ func (r *AdminOrganizationProjectGroupRoleService) New(ctx context.Context, proj
 		err = errors.New("missing required group_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("projects/%s/groups/%s/roles", projectID, groupID)
+	path := fmt.Sprintf("projects/%s/groups/%s/roles", pathSegment(projectID), pathSegment(groupID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -70,7 +70,7 @@ func (r *AdminOrganizationProjectGroupRoleService) List(ctx context.Context, pro
 		err = errors.New("missing required group_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("projects/%s/groups/%s/roles", projectID, groupID)
+	path := fmt.Sprintf("projects/%s/groups/%s/roles", pathSegment(projectID), pathSegment(groupID))
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -104,7 +104,7 @@ func (r *AdminOrganizationProjectGroupRoleService) Delete(ctx context.Context, p
 		err = errors.New("missing required role_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("projects/%s/groups/%s/roles/%s", projectID, groupID, roleID)
+	path := fmt.Sprintf("projects/%s/groups/%s/roles/%s", pathSegment(projectID), pathSegment(groupID), pathSegment(roleID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/adminorganizationprojectratelimit.go
+++ b/adminorganizationprojectratelimit.go
@@ -49,7 +49,7 @@ func (r *AdminOrganizationProjectRateLimitService) ListRateLimits(ctx context.Co
 		err = errors.New("missing required project_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/rate_limits", projectID)
+	path := fmt.Sprintf("organization/projects/%s/rate_limits", pathSegment(projectID))
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -79,7 +79,7 @@ func (r *AdminOrganizationProjectRateLimitService) UpdateRateLimit(ctx context.C
 		err = errors.New("missing required rate_limit_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/rate_limits/%s", projectID, rateLimitID)
+	path := fmt.Sprintf("organization/projects/%s/rate_limits/%s", pathSegment(projectID), pathSegment(rateLimitID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }

--- a/adminorganizationprojectrole.go
+++ b/adminorganizationprojectrole.go
@@ -47,7 +47,7 @@ func (r *AdminOrganizationProjectRoleService) New(ctx context.Context, projectID
 		err = errors.New("missing required project_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("projects/%s/roles", projectID)
+	path := fmt.Sprintf("projects/%s/roles", pathSegment(projectID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -64,7 +64,7 @@ func (r *AdminOrganizationProjectRoleService) Update(ctx context.Context, projec
 		err = errors.New("missing required role_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("projects/%s/roles/%s", projectID, roleID)
+	path := fmt.Sprintf("projects/%s/roles/%s", pathSegment(projectID), pathSegment(roleID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -79,7 +79,7 @@ func (r *AdminOrganizationProjectRoleService) List(ctx context.Context, projectI
 		err = errors.New("missing required project_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("projects/%s/roles", projectID)
+	path := fmt.Sprintf("projects/%s/roles", pathSegment(projectID))
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -109,7 +109,7 @@ func (r *AdminOrganizationProjectRoleService) Delete(ctx context.Context, projec
 		err = errors.New("missing required role_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("projects/%s/roles/%s", projectID, roleID)
+	path := fmt.Sprintf("projects/%s/roles/%s", pathSegment(projectID), pathSegment(roleID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/adminorganizationprojectserviceaccount.go
+++ b/adminorganizationprojectserviceaccount.go
@@ -49,7 +49,7 @@ func (r *AdminOrganizationProjectServiceAccountService) New(ctx context.Context,
 		err = errors.New("missing required project_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/service_accounts", projectID)
+	path := fmt.Sprintf("organization/projects/%s/service_accounts", pathSegment(projectID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -66,7 +66,7 @@ func (r *AdminOrganizationProjectServiceAccountService) Get(ctx context.Context,
 		err = errors.New("missing required service_account_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/service_accounts/%s", projectID, serviceAccountID)
+	path := fmt.Sprintf("organization/projects/%s/service_accounts/%s", pathSegment(projectID), pathSegment(serviceAccountID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -81,7 +81,7 @@ func (r *AdminOrganizationProjectServiceAccountService) List(ctx context.Context
 		err = errors.New("missing required project_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/service_accounts", projectID)
+	path := fmt.Sprintf("organization/projects/%s/service_accounts", pathSegment(projectID))
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -114,7 +114,7 @@ func (r *AdminOrganizationProjectServiceAccountService) Delete(ctx context.Conte
 		err = errors.New("missing required service_account_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/service_accounts/%s", projectID, serviceAccountID)
+	path := fmt.Sprintf("organization/projects/%s/service_accounts/%s", pathSegment(projectID), pathSegment(serviceAccountID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/adminorganizationprojectuser.go
+++ b/adminorganizationprojectuser.go
@@ -50,7 +50,7 @@ func (r *AdminOrganizationProjectUserService) New(ctx context.Context, projectID
 		err = errors.New("missing required project_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/users", projectID)
+	path := fmt.Sprintf("organization/projects/%s/users", pathSegment(projectID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -67,7 +67,7 @@ func (r *AdminOrganizationProjectUserService) Get(ctx context.Context, projectID
 		err = errors.New("missing required user_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/users/%s", projectID, userID)
+	path := fmt.Sprintf("organization/projects/%s/users/%s", pathSegment(projectID), pathSegment(userID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -84,7 +84,7 @@ func (r *AdminOrganizationProjectUserService) Update(ctx context.Context, projec
 		err = errors.New("missing required user_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/users/%s", projectID, userID)
+	path := fmt.Sprintf("organization/projects/%s/users/%s", pathSegment(projectID), pathSegment(userID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -99,7 +99,7 @@ func (r *AdminOrganizationProjectUserService) List(ctx context.Context, projectI
 		err = errors.New("missing required project_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/users", projectID)
+	path := fmt.Sprintf("organization/projects/%s/users", pathSegment(projectID))
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -132,7 +132,7 @@ func (r *AdminOrganizationProjectUserService) Delete(ctx context.Context, projec
 		err = errors.New("missing required user_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/users/%s", projectID, userID)
+	path := fmt.Sprintf("organization/projects/%s/users/%s", pathSegment(projectID), pathSegment(userID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/adminorganizationprojectuserrole.go
+++ b/adminorganizationprojectuserrole.go
@@ -51,7 +51,7 @@ func (r *AdminOrganizationProjectUserRoleService) New(ctx context.Context, proje
 		err = errors.New("missing required user_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("projects/%s/users/%s/roles", projectID, userID)
+	path := fmt.Sprintf("projects/%s/users/%s/roles", pathSegment(projectID), pathSegment(userID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -70,7 +70,7 @@ func (r *AdminOrganizationProjectUserRoleService) List(ctx context.Context, proj
 		err = errors.New("missing required user_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("projects/%s/users/%s/roles", projectID, userID)
+	path := fmt.Sprintf("projects/%s/users/%s/roles", pathSegment(projectID), pathSegment(userID))
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -104,7 +104,7 @@ func (r *AdminOrganizationProjectUserRoleService) Delete(ctx context.Context, pr
 		err = errors.New("missing required role_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("projects/%s/users/%s/roles/%s", projectID, userID, roleID)
+	path := fmt.Sprintf("projects/%s/users/%s/roles/%s", pathSegment(projectID), pathSegment(userID), pathSegment(roleID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/adminorganizationrole.go
+++ b/adminorganizationrole.go
@@ -56,7 +56,7 @@ func (r *AdminOrganizationRoleService) Update(ctx context.Context, roleID string
 		err = errors.New("missing required role_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/roles/%s", roleID)
+	path := fmt.Sprintf("organization/roles/%s", pathSegment(roleID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -93,7 +93,7 @@ func (r *AdminOrganizationRoleService) Delete(ctx context.Context, roleID string
 		err = errors.New("missing required role_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/roles/%s", roleID)
+	path := fmt.Sprintf("organization/roles/%s", pathSegment(roleID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/adminorganizationuser.go
+++ b/adminorganizationuser.go
@@ -49,7 +49,7 @@ func (r *AdminOrganizationUserService) Get(ctx context.Context, userID string, o
 		err = errors.New("missing required user_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/users/%s", userID)
+	path := fmt.Sprintf("organization/users/%s", pathSegment(userID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -62,7 +62,7 @@ func (r *AdminOrganizationUserService) Update(ctx context.Context, userID string
 		err = errors.New("missing required user_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/users/%s", userID)
+	path := fmt.Sprintf("organization/users/%s", pathSegment(userID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -99,7 +99,7 @@ func (r *AdminOrganizationUserService) Delete(ctx context.Context, userID string
 		err = errors.New("missing required user_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/users/%s", userID)
+	path := fmt.Sprintf("organization/users/%s", pathSegment(userID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/adminorganizationuserrole.go
+++ b/adminorganizationuserrole.go
@@ -47,7 +47,7 @@ func (r *AdminOrganizationUserRoleService) New(ctx context.Context, userID strin
 		err = errors.New("missing required user_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/users/%s/roles", userID)
+	path := fmt.Sprintf("organization/users/%s/roles", pathSegment(userID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -62,7 +62,7 @@ func (r *AdminOrganizationUserRoleService) List(ctx context.Context, userID stri
 		err = errors.New("missing required user_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/users/%s/roles", userID)
+	path := fmt.Sprintf("organization/users/%s/roles", pathSegment(userID))
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -92,7 +92,7 @@ func (r *AdminOrganizationUserRoleService) Delete(ctx context.Context, userID st
 		err = errors.New("missing required role_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/users/%s/roles/%s", userID, roleID)
+	path := fmt.Sprintf("organization/users/%s/roles/%s", pathSegment(userID), pathSegment(roleID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/batch.go
+++ b/batch.go
@@ -59,7 +59,7 @@ func (r *BatchService) Get(ctx context.Context, batchID string, opts ...option.R
 		err = errors.New("missing required batch_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("batches/%s", batchID)
+	path := fmt.Sprintf("batches/%s", pathSegment(batchID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -98,7 +98,7 @@ func (r *BatchService) Cancel(ctx context.Context, batchID string, opts ...optio
 		err = errors.New("missing required batch_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("batches/%s/cancel", batchID)
+	path := fmt.Sprintf("batches/%s/cancel", pathSegment(batchID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, nil, &res, opts...)
 	return res, err
 }

--- a/betaassistant.go
+++ b/betaassistant.go
@@ -66,7 +66,7 @@ func (r *BetaAssistantService) Get(ctx context.Context, assistantID string, opts
 		err = errors.New("missing required assistant_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("assistants/%s", assistantID)
+	path := fmt.Sprintf("assistants/%s", pathSegment(assistantID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -82,7 +82,7 @@ func (r *BetaAssistantService) Update(ctx context.Context, assistantID string, b
 		err = errors.New("missing required assistant_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("assistants/%s", assistantID)
+	path := fmt.Sprintf("assistants/%s", pathSegment(assistantID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -126,7 +126,7 @@ func (r *BetaAssistantService) Delete(ctx context.Context, assistantID string, o
 		err = errors.New("missing required assistant_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("assistants/%s", assistantID)
+	path := fmt.Sprintf("assistants/%s", pathSegment(assistantID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/betachatkitsession.go
+++ b/betachatkitsession.go
@@ -55,7 +55,7 @@ func (r *BetaChatKitSessionService) Cancel(ctx context.Context, sessionID string
 		err = errors.New("missing required session_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("chatkit/sessions/%s/cancel", sessionID)
+	path := fmt.Sprintf("chatkit/sessions/%s/cancel", pathSegment(sessionID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, nil, &res, opts...)
 	return res, err
 }

--- a/betachatkitthread.go
+++ b/betachatkitthread.go
@@ -49,7 +49,7 @@ func (r *BetaChatKitThreadService) Get(ctx context.Context, threadID string, opt
 		err = errors.New("missing required thread_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("chatkit/threads/%s", threadID)
+	path := fmt.Sprintf("chatkit/threads/%s", pathSegment(threadID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -87,7 +87,7 @@ func (r *BetaChatKitThreadService) Delete(ctx context.Context, threadID string, 
 		err = errors.New("missing required thread_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("chatkit/threads/%s", threadID)
+	path := fmt.Sprintf("chatkit/threads/%s", pathSegment(threadID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }
@@ -102,7 +102,7 @@ func (r *BetaChatKitThreadService) ListItems(ctx context.Context, threadID strin
 		err = errors.New("missing required thread_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("chatkit/threads/%s/items", threadID)
+	path := fmt.Sprintf("chatkit/threads/%s/items", pathSegment(threadID))
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err

--- a/betathread.go
+++ b/betathread.go
@@ -76,7 +76,7 @@ func (r *BetaThreadService) Get(ctx context.Context, threadID string, opts ...op
 		err = errors.New("missing required thread_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("threads/%s", threadID)
+	path := fmt.Sprintf("threads/%s", pathSegment(threadID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -92,7 +92,7 @@ func (r *BetaThreadService) Update(ctx context.Context, threadID string, body Be
 		err = errors.New("missing required thread_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("threads/%s", threadID)
+	path := fmt.Sprintf("threads/%s", pathSegment(threadID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -108,7 +108,7 @@ func (r *BetaThreadService) Delete(ctx context.Context, threadID string, opts ..
 		err = errors.New("missing required thread_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("threads/%s", threadID)
+	path := fmt.Sprintf("threads/%s", pathSegment(threadID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/betathreadmessage.go
+++ b/betathreadmessage.go
@@ -56,7 +56,7 @@ func (r *BetaThreadMessageService) New(ctx context.Context, threadID string, bod
 		err = errors.New("missing required thread_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("threads/%s/messages", threadID)
+	path := fmt.Sprintf("threads/%s/messages", pathSegment(threadID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -76,7 +76,7 @@ func (r *BetaThreadMessageService) Get(ctx context.Context, threadID string, mes
 		err = errors.New("missing required message_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("threads/%s/messages/%s", threadID, messageID)
+	path := fmt.Sprintf("threads/%s/messages/%s", pathSegment(threadID), pathSegment(messageID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -96,7 +96,7 @@ func (r *BetaThreadMessageService) Update(ctx context.Context, threadID string, 
 		err = errors.New("missing required message_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("threads/%s/messages/%s", threadID, messageID)
+	path := fmt.Sprintf("threads/%s/messages/%s", pathSegment(threadID), pathSegment(messageID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -113,7 +113,7 @@ func (r *BetaThreadMessageService) List(ctx context.Context, threadID string, qu
 		err = errors.New("missing required thread_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("threads/%s/messages", threadID)
+	path := fmt.Sprintf("threads/%s/messages", pathSegment(threadID))
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -148,7 +148,7 @@ func (r *BetaThreadMessageService) Delete(ctx context.Context, threadID string, 
 		err = errors.New("missing required message_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("threads/%s/messages/%s", threadID, messageID)
+	path := fmt.Sprintf("threads/%s/messages/%s", pathSegment(threadID), pathSegment(messageID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/betathreadrun.go
+++ b/betathreadrun.go
@@ -61,7 +61,7 @@ func (r *BetaThreadRunService) New(ctx context.Context, threadID string, params 
 		err = errors.New("missing required thread_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("threads/%s/runs", threadID)
+	path := fmt.Sprintf("threads/%s/runs", pathSegment(threadID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, params, &res, opts...)
 	return res, err
 }
@@ -82,7 +82,7 @@ func (r *BetaThreadRunService) NewStreaming(ctx context.Context, threadID string
 		err = errors.New("missing required thread_id parameter")
 		return ssestream.NewStream[AssistantStreamEventUnion](nil, err)
 	}
-	path := fmt.Sprintf("threads/%s/runs", threadID)
+	path := fmt.Sprintf("threads/%s/runs", pathSegment(threadID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, params, &raw, opts...)
 	return ssestream.NewStreamWithSynthesizeEventData[AssistantStreamEventUnion](ssestream.NewDecoder(raw), err)
 }
@@ -102,7 +102,7 @@ func (r *BetaThreadRunService) Get(ctx context.Context, threadID string, runID s
 		err = errors.New("missing required run_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("threads/%s/runs/%s", threadID, runID)
+	path := fmt.Sprintf("threads/%s/runs/%s", pathSegment(threadID), pathSegment(runID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -122,7 +122,7 @@ func (r *BetaThreadRunService) Update(ctx context.Context, threadID string, runI
 		err = errors.New("missing required run_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("threads/%s/runs/%s", threadID, runID)
+	path := fmt.Sprintf("threads/%s/runs/%s", pathSegment(threadID), pathSegment(runID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -139,7 +139,7 @@ func (r *BetaThreadRunService) List(ctx context.Context, threadID string, query 
 		err = errors.New("missing required thread_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("threads/%s/runs", threadID)
+	path := fmt.Sprintf("threads/%s/runs", pathSegment(threadID))
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -174,7 +174,7 @@ func (r *BetaThreadRunService) Cancel(ctx context.Context, threadID string, runI
 		err = errors.New("missing required run_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("threads/%s/runs/%s/cancel", threadID, runID)
+	path := fmt.Sprintf("threads/%s/runs/%s/cancel", pathSegment(threadID), pathSegment(runID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, nil, &res, opts...)
 	return res, err
 }
@@ -197,7 +197,7 @@ func (r *BetaThreadRunService) SubmitToolOutputs(ctx context.Context, threadID s
 		err = errors.New("missing required run_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("threads/%s/runs/%s/submit_tool_outputs", threadID, runID)
+	path := fmt.Sprintf("threads/%s/runs/%s/submit_tool_outputs", pathSegment(threadID), pathSegment(runID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -225,7 +225,7 @@ func (r *BetaThreadRunService) SubmitToolOutputsStreaming(ctx context.Context, t
 		err = errors.New("missing required run_id parameter")
 		return ssestream.NewStream[AssistantStreamEventUnion](nil, err)
 	}
-	path := fmt.Sprintf("threads/%s/runs/%s/submit_tool_outputs", threadID, runID)
+	path := fmt.Sprintf("threads/%s/runs/%s/submit_tool_outputs", pathSegment(threadID), pathSegment(runID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &raw, opts...)
 	return ssestream.NewStreamWithSynthesizeEventData[AssistantStreamEventUnion](ssestream.NewDecoder(raw), err)
 }

--- a/betathreadrunstep.go
+++ b/betathreadrunstep.go
@@ -64,7 +64,7 @@ func (r *BetaThreadRunStepService) Get(ctx context.Context, threadID string, run
 		err = errors.New("missing required step_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("threads/%s/runs/%s/steps/%s", threadID, runID, stepID)
+	path := fmt.Sprintf("threads/%s/runs/%s/steps/%s", pathSegment(threadID), pathSegment(runID), pathSegment(stepID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, query, &res, opts...)
 	return res, err
 }
@@ -85,7 +85,7 @@ func (r *BetaThreadRunStepService) List(ctx context.Context, threadID string, ru
 		err = errors.New("missing required run_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("threads/%s/runs/%s/steps", threadID, runID)
+	path := fmt.Sprintf("threads/%s/runs/%s/steps", pathSegment(threadID), pathSegment(runID))
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err

--- a/chatcompletion.go
+++ b/chatcompletion.go
@@ -119,7 +119,7 @@ func (r *ChatCompletionService) Get(ctx context.Context, completionID string, op
 		err = errors.New("missing required completion_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("chat/completions/%s", completionID)
+	path := fmt.Sprintf("chat/completions/%s", pathSegment(completionID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -134,7 +134,7 @@ func (r *ChatCompletionService) Update(ctx context.Context, completionID string,
 		err = errors.New("missing required completion_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("chat/completions/%s", completionID)
+	path := fmt.Sprintf("chat/completions/%s", pathSegment(completionID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -174,7 +174,7 @@ func (r *ChatCompletionService) Delete(ctx context.Context, completionID string,
 		err = errors.New("missing required completion_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("chat/completions/%s", completionID)
+	path := fmt.Sprintf("chat/completions/%s", pathSegment(completionID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/chatcompletionmessage.go
+++ b/chatcompletionmessage.go
@@ -50,7 +50,7 @@ func (r *ChatCompletionMessageService) List(ctx context.Context, completionID st
 		err = errors.New("missing required completion_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("chat/completions/%s/messages", completionID)
+	path := fmt.Sprintf("chat/completions/%s/messages", pathSegment(completionID))
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err

--- a/container.go
+++ b/container.go
@@ -58,7 +58,7 @@ func (r *ContainerService) Get(ctx context.Context, containerID string, opts ...
 		err = errors.New("missing required container_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("containers/%s", containerID)
+	path := fmt.Sprintf("containers/%s", pathSegment(containerID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -96,7 +96,7 @@ func (r *ContainerService) Delete(ctx context.Context, containerID string, opts 
 		err = errors.New("missing required container_id parameter")
 		return err
 	}
-	path := fmt.Sprintf("containers/%s", containerID)
+	path := fmt.Sprintf("containers/%s", pathSegment(containerID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, nil, opts...)
 	return err
 }

--- a/containerfile.go
+++ b/containerfile.go
@@ -56,7 +56,7 @@ func (r *ContainerFileService) New(ctx context.Context, containerID string, body
 		err = errors.New("missing required container_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("containers/%s/files", containerID)
+	path := fmt.Sprintf("containers/%s/files", pathSegment(containerID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -73,7 +73,7 @@ func (r *ContainerFileService) Get(ctx context.Context, containerID string, file
 		err = errors.New("missing required file_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("containers/%s/files/%s", containerID, fileID)
+	path := fmt.Sprintf("containers/%s/files/%s", pathSegment(containerID), pathSegment(fileID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -88,7 +88,7 @@ func (r *ContainerFileService) List(ctx context.Context, containerID string, que
 		err = errors.New("missing required container_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("containers/%s/files", containerID)
+	path := fmt.Sprintf("containers/%s/files", pathSegment(containerID))
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -119,7 +119,7 @@ func (r *ContainerFileService) Delete(ctx context.Context, containerID string, f
 		err = errors.New("missing required file_id parameter")
 		return err
 	}
-	path := fmt.Sprintf("containers/%s/files/%s", containerID, fileID)
+	path := fmt.Sprintf("containers/%s/files/%s", pathSegment(containerID), pathSegment(fileID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, nil, opts...)
 	return err
 }

--- a/containerfilecontent.go
+++ b/containerfilecontent.go
@@ -45,7 +45,7 @@ func (r *ContainerFileContentService) Get(ctx context.Context, containerID strin
 		err = errors.New("missing required file_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("containers/%s/files/%s/content", containerID, fileID)
+	path := fmt.Sprintf("containers/%s/files/%s/content", pathSegment(containerID), pathSegment(fileID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }

--- a/file.go
+++ b/file.go
@@ -89,7 +89,7 @@ func (r *FileService) Get(ctx context.Context, fileID string, opts ...option.Req
 		err = errors.New("missing required file_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("files/%s", fileID)
+	path := fmt.Sprintf("files/%s", pathSegment(fileID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -126,7 +126,7 @@ func (r *FileService) Delete(ctx context.Context, fileID string, opts ...option.
 		err = errors.New("missing required file_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("files/%s", fileID)
+	path := fmt.Sprintf("files/%s", pathSegment(fileID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }
@@ -140,7 +140,7 @@ func (r *FileService) Content(ctx context.Context, fileID string, opts ...option
 		err = errors.New("missing required file_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("files/%s/content", fileID)
+	path := fmt.Sprintf("files/%s/content", pathSegment(fileID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }

--- a/finetuningcheckpointpermission.go
+++ b/finetuningcheckpointpermission.go
@@ -54,7 +54,7 @@ func (r *FineTuningCheckpointPermissionService) New(ctx context.Context, fineTun
 		err = errors.New("missing required fine_tuned_model_checkpoint parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("fine_tuning/checkpoints/%s/permissions", fineTunedModelCheckpoint)
+	path := fmt.Sprintf("fine_tuning/checkpoints/%s/permissions", pathSegment(fineTunedModelCheckpoint))
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodPost, path, body, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -89,7 +89,7 @@ func (r *FineTuningCheckpointPermissionService) Get(ctx context.Context, fineTun
 		err = errors.New("missing required fine_tuned_model_checkpoint parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("fine_tuning/checkpoints/%s/permissions", fineTunedModelCheckpoint)
+	path := fmt.Sprintf("fine_tuning/checkpoints/%s/permissions", pathSegment(fineTunedModelCheckpoint))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, query, &res, opts...)
 	return res, err
 }
@@ -107,7 +107,7 @@ func (r *FineTuningCheckpointPermissionService) List(ctx context.Context, fineTu
 		err = errors.New("missing required fine_tuned_model_checkpoint parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("fine_tuning/checkpoints/%s/permissions", fineTunedModelCheckpoint)
+	path := fmt.Sprintf("fine_tuning/checkpoints/%s/permissions", pathSegment(fineTunedModelCheckpoint))
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -143,7 +143,7 @@ func (r *FineTuningCheckpointPermissionService) Delete(ctx context.Context, fine
 		err = errors.New("missing required permission_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("fine_tuning/checkpoints/%s/permissions/%s", fineTunedModelCheckpoint, permissionID)
+	path := fmt.Sprintf("fine_tuning/checkpoints/%s/permissions/%s", pathSegment(fineTunedModelCheckpoint), pathSegment(permissionID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/finetuningjob.go
+++ b/finetuningjob.go
@@ -71,7 +71,7 @@ func (r *FineTuningJobService) Get(ctx context.Context, fineTuningJobID string, 
 		err = errors.New("missing required fine_tuning_job_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("fine_tuning/jobs/%s", fineTuningJobID)
+	path := fmt.Sprintf("fine_tuning/jobs/%s", pathSegment(fineTuningJobID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -108,7 +108,7 @@ func (r *FineTuningJobService) Cancel(ctx context.Context, fineTuningJobID strin
 		err = errors.New("missing required fine_tuning_job_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("fine_tuning/jobs/%s/cancel", fineTuningJobID)
+	path := fmt.Sprintf("fine_tuning/jobs/%s/cancel", pathSegment(fineTuningJobID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, nil, &res, opts...)
 	return res, err
 }
@@ -123,7 +123,7 @@ func (r *FineTuningJobService) ListEvents(ctx context.Context, fineTuningJobID s
 		err = errors.New("missing required fine_tuning_job_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("fine_tuning/jobs/%s/events", fineTuningJobID)
+	path := fmt.Sprintf("fine_tuning/jobs/%s/events", pathSegment(fineTuningJobID))
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -149,7 +149,7 @@ func (r *FineTuningJobService) Pause(ctx context.Context, fineTuningJobID string
 		err = errors.New("missing required fine_tuning_job_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("fine_tuning/jobs/%s/pause", fineTuningJobID)
+	path := fmt.Sprintf("fine_tuning/jobs/%s/pause", pathSegment(fineTuningJobID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, nil, &res, opts...)
 	return res, err
 }
@@ -162,7 +162,7 @@ func (r *FineTuningJobService) Resume(ctx context.Context, fineTuningJobID strin
 		err = errors.New("missing required fine_tuning_job_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("fine_tuning/jobs/%s/resume", fineTuningJobID)
+	path := fmt.Sprintf("fine_tuning/jobs/%s/resume", pathSegment(fineTuningJobID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, nil, &res, opts...)
 	return res, err
 }

--- a/finetuningjobcheckpoint.go
+++ b/finetuningjobcheckpoint.go
@@ -51,7 +51,7 @@ func (r *FineTuningJobCheckpointService) List(ctx context.Context, fineTuningJob
 		err = errors.New("missing required fine_tuning_job_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("fine_tuning/jobs/%s/checkpoints", fineTuningJobID)
+	path := fmt.Sprintf("fine_tuning/jobs/%s/checkpoints", pathSegment(fineTuningJobID))
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err

--- a/model.go
+++ b/model.go
@@ -47,7 +47,7 @@ func (r *ModelService) Get(ctx context.Context, model string, opts ...option.Req
 		err = errors.New("missing required model parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("models/%s", model)
+	path := fmt.Sprintf("models/%s", pathSegment(model))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -87,7 +87,7 @@ func (r *ModelService) Delete(ctx context.Context, model string, opts ...option.
 		err = errors.New("missing required model parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("models/%s", model)
+	path := fmt.Sprintf("models/%s", pathSegment(model))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/pathparam.go
+++ b/pathparam.go
@@ -1,0 +1,23 @@
+// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+package openai
+
+import (
+	"net/url"
+	"strings"
+)
+
+func pathSegment(value string) string {
+	segments := strings.Split(value, "/")
+	for i, segment := range segments {
+		switch segment {
+		case ".":
+			segments[i] = "%2E"
+		case "..":
+			segments[i] = "%2E%2E"
+		default:
+			segments[i] = url.PathEscape(segment)
+		}
+	}
+	return strings.Join(segments, "%2F")
+}

--- a/pathparam_test.go
+++ b/pathparam_test.go
@@ -1,0 +1,65 @@
+// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+package openai
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/openai/openai-go/v3/option"
+)
+
+func TestPathSegment(t *testing.T) {
+	tests := map[string]string{
+		"id/with/slash":          "id%2Fwith%2Fslash",
+		"id?query=injected":      "id%3Fquery=injected",
+		"id#fragment":            "id%23fragment",
+		"../videos/vid_123":      "%2E%2E%2Fvideos%2Fvid_123",
+		"%2e%2e/videos/vid_123": "%252e%252e%2Fvideos%2Fvid_123",
+		".":                      "%2E",
+		"..":                     "%2E%2E",
+	}
+
+	for value, want := range tests {
+		if got := pathSegment(value); got != want {
+			t.Fatalf("pathSegment(%q) = %q, want %q", value, got, want)
+		}
+	}
+}
+
+func TestPathParamsAreEscapedInRequests(t *testing.T) {
+	tests := map[string]string{
+		"id/with/slash":          "/vector_stores/id%2Fwith%2Fslash",
+		"id?query=injected":      "/vector_stores/id%3Fquery=injected",
+		"id#fragment":            "/vector_stores/id%23fragment",
+		"../videos/vid_123":      "/vector_stores/%2E%2E%2Fvideos%2Fvid_123",
+		"%2e%2e/videos/vid_123": "/vector_stores/%252e%252e%2Fvideos%2Fvid_123",
+	}
+
+	for vectorStoreID, wantPath := range tests {
+		t.Run(vectorStoreID, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.EscapedPath() != wantPath {
+					t.Fatalf("request path = %q, want %q", r.URL.EscapedPath(), wantPath)
+				}
+				if r.URL.RawQuery != "" {
+					t.Fatalf("request query = %q, want empty", r.URL.RawQuery)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"id":"vs_123","created_at":0,"file_counts":{},"last_active_at":0,"metadata":{},"name":"test","object":"vector_store","status":"completed","usage_bytes":0}`))
+			}))
+			defer server.Close()
+
+			client := NewClient(
+				option.WithBaseURL(server.URL),
+				option.WithAPIKey("My API Key"),
+			)
+			_, err := client.VectorStores.Get(context.TODO(), vectorStoreID)
+			if err != nil {
+				t.Fatalf("err should be nil: %s", err.Error())
+			}
+		})
+	}
+}

--- a/skill.go
+++ b/skill.go
@@ -64,7 +64,7 @@ func (r *SkillService) Get(ctx context.Context, skillID string, opts ...option.R
 		err = errors.New("missing required skill_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("skills/%s", skillID)
+	path := fmt.Sprintf("skills/%s", pathSegment(skillID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -77,7 +77,7 @@ func (r *SkillService) Update(ctx context.Context, skillID string, body SkillUpd
 		err = errors.New("missing required skill_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("skills/%s", skillID)
+	path := fmt.Sprintf("skills/%s", pathSegment(skillID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -114,7 +114,7 @@ func (r *SkillService) Delete(ctx context.Context, skillID string, opts ...optio
 		err = errors.New("missing required skill_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("skills/%s", skillID)
+	path := fmt.Sprintf("skills/%s", pathSegment(skillID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/skillcontent.go
+++ b/skillcontent.go
@@ -41,7 +41,7 @@ func (r *SkillContentService) Get(ctx context.Context, skillID string, opts ...o
 		err = errors.New("missing required skill_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("skills/%s/content", skillID)
+	path := fmt.Sprintf("skills/%s/content", pathSegment(skillID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }

--- a/skillversion.go
+++ b/skillversion.go
@@ -53,7 +53,7 @@ func (r *SkillVersionService) New(ctx context.Context, skillID string, body Skil
 		err = errors.New("missing required skill_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("skills/%s/versions", skillID)
+	path := fmt.Sprintf("skills/%s/versions", pathSegment(skillID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -70,7 +70,7 @@ func (r *SkillVersionService) Get(ctx context.Context, skillID string, version s
 		err = errors.New("missing required version parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("skills/%s/versions/%s", skillID, version)
+	path := fmt.Sprintf("skills/%s/versions/%s", pathSegment(skillID), pathSegment(version))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -85,7 +85,7 @@ func (r *SkillVersionService) List(ctx context.Context, skillID string, query Sk
 		err = errors.New("missing required skill_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("skills/%s/versions", skillID)
+	path := fmt.Sprintf("skills/%s/versions", pathSegment(skillID))
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -115,7 +115,7 @@ func (r *SkillVersionService) Delete(ctx context.Context, skillID string, versio
 		err = errors.New("missing required version parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("skills/%s/versions/%s", skillID, version)
+	path := fmt.Sprintf("skills/%s/versions/%s", pathSegment(skillID), pathSegment(version))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/skillversioncontent.go
+++ b/skillversioncontent.go
@@ -45,7 +45,7 @@ func (r *SkillVersionContentService) Get(ctx context.Context, skillID string, ve
 		err = errors.New("missing required version parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("skills/%s/versions/%s/content", skillID, version)
+	path := fmt.Sprintf("skills/%s/versions/%s/content", pathSegment(skillID), pathSegment(version))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }

--- a/upload.go
+++ b/upload.go
@@ -80,7 +80,7 @@ func (r *UploadService) Cancel(ctx context.Context, uploadID string, opts ...opt
 		err = errors.New("missing required upload_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("uploads/%s/cancel", uploadID)
+	path := fmt.Sprintf("uploads/%s/cancel", pathSegment(uploadID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, nil, &res, opts...)
 	return res, err
 }
@@ -107,7 +107,7 @@ func (r *UploadService) Complete(ctx context.Context, uploadID string, body Uplo
 		err = errors.New("missing required upload_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("uploads/%s/complete", uploadID)
+	path := fmt.Sprintf("uploads/%s/complete", pathSegment(uploadID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }

--- a/uploadpart.go
+++ b/uploadpart.go
@@ -59,7 +59,7 @@ func (r *UploadPartService) New(ctx context.Context, uploadID string, body Uploa
 		err = errors.New("missing required upload_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("uploads/%s/parts", uploadID)
+	path := fmt.Sprintf("uploads/%s/parts", pathSegment(uploadID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }

--- a/vectorstore.go
+++ b/vectorstore.go
@@ -64,7 +64,7 @@ func (r *VectorStoreService) Get(ctx context.Context, vectorStoreID string, opts
 		err = errors.New("missing required vector_store_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("vector_stores/%s", vectorStoreID)
+	path := fmt.Sprintf("vector_stores/%s", pathSegment(vectorStoreID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -78,7 +78,7 @@ func (r *VectorStoreService) Update(ctx context.Context, vectorStoreID string, b
 		err = errors.New("missing required vector_store_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("vector_stores/%s", vectorStoreID)
+	path := fmt.Sprintf("vector_stores/%s", pathSegment(vectorStoreID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -116,7 +116,7 @@ func (r *VectorStoreService) Delete(ctx context.Context, vectorStoreID string, o
 		err = errors.New("missing required vector_store_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("vector_stores/%s", vectorStoreID)
+	path := fmt.Sprintf("vector_stores/%s", pathSegment(vectorStoreID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }
@@ -132,7 +132,7 @@ func (r *VectorStoreService) Search(ctx context.Context, vectorStoreID string, b
 		err = errors.New("missing required vector_store_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("vector_stores/%s/search", vectorStoreID)
+	path := fmt.Sprintf("vector_stores/%s/search", pathSegment(vectorStoreID))
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodPost, path, body, &res, opts...)
 	if err != nil {
 		return nil, err

--- a/vectorstorefile.go
+++ b/vectorstorefile.go
@@ -51,7 +51,7 @@ func (r *VectorStoreFileService) New(ctx context.Context, vectorStoreID string, 
 		err = errors.New("missing required vector_store_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("vector_stores/%s/files", vectorStoreID)
+	path := fmt.Sprintf("vector_stores/%s/files", pathSegment(vectorStoreID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -108,7 +108,7 @@ func (r *VectorStoreFileService) Get(ctx context.Context, vectorStoreID string, 
 		err = errors.New("missing required file_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("vector_stores/%s/files/%s", vectorStoreID, fileID)
+	path := fmt.Sprintf("vector_stores/%s/files/%s", pathSegment(vectorStoreID), pathSegment(fileID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -126,7 +126,7 @@ func (r *VectorStoreFileService) Update(ctx context.Context, vectorStoreID strin
 		err = errors.New("missing required file_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("vector_stores/%s/files/%s", vectorStoreID, fileID)
+	path := fmt.Sprintf("vector_stores/%s/files/%s", pathSegment(vectorStoreID), pathSegment(fileID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -141,7 +141,7 @@ func (r *VectorStoreFileService) List(ctx context.Context, vectorStoreID string,
 		err = errors.New("missing required vector_store_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("vector_stores/%s/files", vectorStoreID)
+	path := fmt.Sprintf("vector_stores/%s/files", pathSegment(vectorStoreID))
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -175,7 +175,7 @@ func (r *VectorStoreFileService) Delete(ctx context.Context, vectorStoreID strin
 		err = errors.New("missing required file_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("vector_stores/%s/files/%s", vectorStoreID, fileID)
+	path := fmt.Sprintf("vector_stores/%s/files/%s", pathSegment(vectorStoreID), pathSegment(fileID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }
@@ -194,7 +194,7 @@ func (r *VectorStoreFileService) Content(ctx context.Context, vectorStoreID stri
 		err = errors.New("missing required file_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("vector_stores/%s/files/%s/content", vectorStoreID, fileID)
+	path := fmt.Sprintf("vector_stores/%s/files/%s/content", pathSegment(vectorStoreID), pathSegment(fileID))
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, nil, &res, opts...)
 	if err != nil {
 		return nil, err

--- a/vectorstorefilebatch.go
+++ b/vectorstorefilebatch.go
@@ -49,7 +49,7 @@ func (r *VectorStoreFileBatchService) New(ctx context.Context, vectorStoreID str
 		err = errors.New("missing required vector_store_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("vector_stores/%s/file_batches", vectorStoreID)
+	path := fmt.Sprintf("vector_stores/%s/file_batches", pathSegment(vectorStoreID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -126,7 +126,7 @@ func (r *VectorStoreFileBatchService) Get(ctx context.Context, vectorStoreID str
 		err = errors.New("missing required batch_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("vector_stores/%s/file_batches/%s", vectorStoreID, batchID)
+	path := fmt.Sprintf("vector_stores/%s/file_batches/%s", pathSegment(vectorStoreID), pathSegment(batchID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -145,7 +145,7 @@ func (r *VectorStoreFileBatchService) Cancel(ctx context.Context, vectorStoreID 
 		err = errors.New("missing required batch_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("vector_stores/%s/file_batches/%s/cancel", vectorStoreID, batchID)
+	path := fmt.Sprintf("vector_stores/%s/file_batches/%s/cancel", pathSegment(vectorStoreID), pathSegment(batchID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, nil, &res, opts...)
 	return res, err
 }
@@ -164,7 +164,7 @@ func (r *VectorStoreFileBatchService) ListFiles(ctx context.Context, vectorStore
 		err = errors.New("missing required batch_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("vector_stores/%s/file_batches/%s/files", vectorStoreID, batchID)
+	path := fmt.Sprintf("vector_stores/%s/file_batches/%s/files", pathSegment(vectorStoreID), pathSegment(batchID))
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err

--- a/video.go
+++ b/video.go
@@ -72,7 +72,7 @@ func (r *VideoService) Get(ctx context.Context, videoID string, opts ...option.R
 		err = errors.New("missing required video_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("videos/%s", videoID)
+	path := fmt.Sprintf("videos/%s", pathSegment(videoID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -109,7 +109,7 @@ func (r *VideoService) Delete(ctx context.Context, videoID string, opts ...optio
 		err = errors.New("missing required video_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("videos/%s", videoID)
+	path := fmt.Sprintf("videos/%s", pathSegment(videoID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }
@@ -134,7 +134,7 @@ func (r *VideoService) DownloadContent(ctx context.Context, videoID string, quer
 		err = errors.New("missing required video_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("videos/%s/content", videoID)
+	path := fmt.Sprintf("videos/%s/content", pathSegment(videoID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, query, &res, opts...)
 	return res, err
 }
@@ -166,7 +166,7 @@ func (r *VideoService) GetCharacter(ctx context.Context, characterID string, opt
 		err = errors.New("missing required character_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("videos/characters/%s", characterID)
+	path := fmt.Sprintf("videos/characters/%s", pathSegment(characterID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -179,7 +179,7 @@ func (r *VideoService) Remix(ctx context.Context, videoID string, body VideoRemi
 		err = errors.New("missing required video_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("videos/%s/remix", videoID)
+	path := fmt.Sprintf("videos/%s/remix", pathSegment(videoID))
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }


### PR DESCRIPTION
## Summary
- encode generated URL path parameters as individual URL path segments before formatting request paths
- preserve reserved URL characters such as `/`, `?`, and `#` as path parameter data instead of URL syntax
- percent-encode dot-only path segments (`.` and `..`) inside path parameter values
- add focused coverage for path segment encoding and `VectorStores.Get` request paths

## Related issue
- N/A

## Guideline alignment
- Reviewed `CONTRIBUTING.md`; generated code changes are allowed, but may need to be carried through code generation by maintainers
- Keeps the change focused on generated request path construction and a small shared helper

## Testing
- `git diff --check`