### PR TITLE
Fix path parameter encoding

### DIFF
--- a/adminorganizationadminapikey.go
+++ b/adminorganizationadminapikey.go
@@ -5,7 +5,6 @@ package openai
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"slices"
@@ -56,7 +55,7 @@ func (r *AdminOrganizationAdminAPIKeyService) Get(ctx context.Context, keyID str
 		err = errors.New("missing required key_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/admin_api_keys/%s", keyID)
+	path := requestconfig.FormatPath("organization/admin_api_keys/%s", keyID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -93,7 +92,7 @@ func (r *AdminOrganizationAdminAPIKeyService) Delete(ctx context.Context, keyID 
 		err = errors.New("missing required key_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/admin_api_keys/%s", keyID)
+	path := requestconfig.FormatPath("organization/admin_api_keys/%s", keyID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/adminorganizationcertificate.go
+++ b/adminorganizationcertificate.go
@@ -5,7 +5,6 @@ package openai
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"slices"
@@ -61,7 +60,7 @@ func (r *AdminOrganizationCertificateService) Get(ctx context.Context, certifica
 		err = errors.New("missing required certificate_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/certificates/%s", certificateID)
+	path := requestconfig.FormatPath("organization/certificates/%s", certificateID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, query, &res, opts...)
 	return res, err
 }
@@ -74,7 +73,7 @@ func (r *AdminOrganizationCertificateService) Update(ctx context.Context, certif
 		err = errors.New("missing required certificate_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/certificates/%s", certificateID)
+	path := requestconfig.FormatPath("organization/certificates/%s", certificateID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -113,7 +112,7 @@ func (r *AdminOrganizationCertificateService) Delete(ctx context.Context, certif
 		err = errors.New("missing required certificate_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/certificates/%s", certificateID)
+	path := requestconfig.FormatPath("organization/certificates/%s", certificateID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/adminorganizationgroup.go
+++ b/adminorganizationgroup.go
@@ -5,7 +5,6 @@ package openai
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"slices"
@@ -60,7 +59,7 @@ func (r *AdminOrganizationGroupService) Update(ctx context.Context, groupID stri
 		err = errors.New("missing required group_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/groups/%s", groupID)
+	path := requestconfig.FormatPath("organization/groups/%s", groupID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -97,7 +96,7 @@ func (r *AdminOrganizationGroupService) Delete(ctx context.Context, groupID stri
 		err = errors.New("missing required group_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/groups/%s", groupID)
+	path := requestconfig.FormatPath("organization/groups/%s", groupID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/adminorganizationgrouprole.go
+++ b/adminorganizationgrouprole.go
@@ -5,7 +5,6 @@ package openai
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"slices"
@@ -47,7 +46,7 @@ func (r *AdminOrganizationGroupRoleService) New(ctx context.Context, groupID str
 		err = errors.New("missing required group_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/groups/%s/roles", groupID)
+	path := requestconfig.FormatPath("organization/groups/%s/roles", groupID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -62,7 +61,7 @@ func (r *AdminOrganizationGroupRoleService) List(ctx context.Context, groupID st
 		err = errors.New("missing required group_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/groups/%s/roles", groupID)
+	path := requestconfig.FormatPath("organization/groups/%s/roles", groupID)
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -92,7 +91,7 @@ func (r *AdminOrganizationGroupRoleService) Delete(ctx context.Context, groupID 
 		err = errors.New("missing required role_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/groups/%s/roles/%s", groupID, roleID)
+	path := requestconfig.FormatPath("organization/groups/%s/roles/%s", groupID, roleID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/adminorganizationgroupuser.go
+++ b/adminorganizationgroupuser.go
@@ -5,7 +5,6 @@ package openai
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"slices"
@@ -47,7 +46,7 @@ func (r *AdminOrganizationGroupUserService) New(ctx context.Context, groupID str
 		err = errors.New("missing required group_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/groups/%s/users", groupID)
+	path := requestconfig.FormatPath("organization/groups/%s/users", groupID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -62,7 +61,7 @@ func (r *AdminOrganizationGroupUserService) List(ctx context.Context, groupID st
 		err = errors.New("missing required group_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/groups/%s/users", groupID)
+	path := requestconfig.FormatPath("organization/groups/%s/users", groupID)
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -92,7 +91,7 @@ func (r *AdminOrganizationGroupUserService) Delete(ctx context.Context, groupID 
 		err = errors.New("missing required user_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/groups/%s/users/%s", groupID, userID)
+	path := requestconfig.FormatPath("organization/groups/%s/users/%s", groupID, userID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/adminorganizationinvite.go
+++ b/adminorganizationinvite.go
@@ -5,7 +5,6 @@ package openai
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"slices"
@@ -57,7 +56,7 @@ func (r *AdminOrganizationInviteService) Get(ctx context.Context, inviteID strin
 		err = errors.New("missing required invite_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/invites/%s", inviteID)
+	path := requestconfig.FormatPath("organization/invites/%s", inviteID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -94,7 +93,7 @@ func (r *AdminOrganizationInviteService) Delete(ctx context.Context, inviteID st
 		err = errors.New("missing required invite_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/invites/%s", inviteID)
+	path := requestconfig.FormatPath("organization/invites/%s", inviteID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/adminorganizationproject.go
+++ b/adminorganizationproject.go
@@ -5,7 +5,6 @@ package openai
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"slices"
@@ -71,7 +70,7 @@ func (r *AdminOrganizationProjectService) Get(ctx context.Context, projectID str
 		err = errors.New("missing required project_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s", projectID)
+	path := requestconfig.FormatPath("organization/projects/%s", projectID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -84,7 +83,7 @@ func (r *AdminOrganizationProjectService) Update(ctx context.Context, projectID 
 		err = errors.New("missing required project_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s", projectID)
+	path := requestconfig.FormatPath("organization/projects/%s", projectID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -122,7 +121,7 @@ func (r *AdminOrganizationProjectService) Archive(ctx context.Context, projectID
 		err = errors.New("missing required project_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/archive", projectID)
+	path := requestconfig.FormatPath("organization/projects/%s/archive", projectID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, nil, &res, opts...)
 	return res, err
 }

--- a/adminorganizationprojectapikey.go
+++ b/adminorganizationprojectapikey.go
@@ -5,7 +5,6 @@ package openai
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"slices"
@@ -51,7 +50,7 @@ func (r *AdminOrganizationProjectAPIKeyService) Get(ctx context.Context, project
 		err = errors.New("missing required api_key_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/api_keys/%s", projectID, apiKeyID)
+	path := requestconfig.FormatPath("organization/projects/%s/api_keys/%s", projectID, apiKeyID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -66,7 +65,7 @@ func (r *AdminOrganizationProjectAPIKeyService) List(ctx context.Context, projec
 		err = errors.New("missing required project_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/api_keys", projectID)
+	path := requestconfig.FormatPath("organization/projects/%s/api_keys", projectID)
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -99,7 +98,7 @@ func (r *AdminOrganizationProjectAPIKeyService) Delete(ctx context.Context, proj
 		err = errors.New("missing required api_key_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/api_keys/%s", projectID, apiKeyID)
+	path := requestconfig.FormatPath("organization/projects/%s/api_keys/%s", projectID, apiKeyID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/adminorganizationprojectcertificate.go
+++ b/adminorganizationprojectcertificate.go
@@ -5,7 +5,6 @@ package openai
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"slices"
@@ -50,7 +49,7 @@ func (r *AdminOrganizationProjectCertificateService) List(ctx context.Context, p
 		err = errors.New("missing required project_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/certificates", projectID)
+	path := requestconfig.FormatPath("organization/projects/%s/certificates", projectID)
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -80,7 +79,7 @@ func (r *AdminOrganizationProjectCertificateService) Activate(ctx context.Contex
 		err = errors.New("missing required project_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/certificates/activate", projectID)
+	path := requestconfig.FormatPath("organization/projects/%s/certificates/activate", projectID)
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodPost, path, body, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -111,7 +110,7 @@ func (r *AdminOrganizationProjectCertificateService) Deactivate(ctx context.Cont
 		err = errors.New("missing required project_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/certificates/deactivate", projectID)
+	path := requestconfig.FormatPath("organization/projects/%s/certificates/deactivate", projectID)
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodPost, path, body, &res, opts...)
 	if err != nil {
 		return nil, err

--- a/adminorganizationprojectgroup.go
+++ b/adminorganizationprojectgroup.go
@@ -5,7 +5,6 @@ package openai
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"slices"
@@ -49,7 +48,7 @@ func (r *AdminOrganizationProjectGroupService) New(ctx context.Context, projectI
 		err = errors.New("missing required project_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/groups", projectID)
+	path := requestconfig.FormatPath("organization/projects/%s/groups", projectID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -64,7 +63,7 @@ func (r *AdminOrganizationProjectGroupService) List(ctx context.Context, project
 		err = errors.New("missing required project_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/groups", projectID)
+	path := requestconfig.FormatPath("organization/projects/%s/groups", projectID)
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -94,7 +93,7 @@ func (r *AdminOrganizationProjectGroupService) Delete(ctx context.Context, proje
 		err = errors.New("missing required group_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/groups/%s", projectID, groupID)
+	path := requestconfig.FormatPath("organization/projects/%s/groups/%s", projectID, groupID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/adminorganizationprojectgrouprole.go
+++ b/adminorganizationprojectgrouprole.go
@@ -5,7 +5,6 @@ package openai
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"slices"
@@ -51,7 +50,7 @@ func (r *AdminOrganizationProjectGroupRoleService) New(ctx context.Context, proj
 		err = errors.New("missing required group_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("projects/%s/groups/%s/roles", projectID, groupID)
+	path := requestconfig.FormatPath("projects/%s/groups/%s/roles", projectID, groupID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -70,7 +69,7 @@ func (r *AdminOrganizationProjectGroupRoleService) List(ctx context.Context, pro
 		err = errors.New("missing required group_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("projects/%s/groups/%s/roles", projectID, groupID)
+	path := requestconfig.FormatPath("projects/%s/groups/%s/roles", projectID, groupID)
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -104,7 +103,7 @@ func (r *AdminOrganizationProjectGroupRoleService) Delete(ctx context.Context, p
 		err = errors.New("missing required role_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("projects/%s/groups/%s/roles/%s", projectID, groupID, roleID)
+	path := requestconfig.FormatPath("projects/%s/groups/%s/roles/%s", projectID, groupID, roleID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/adminorganizationprojectratelimit.go
+++ b/adminorganizationprojectratelimit.go
@@ -5,7 +5,6 @@ package openai
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"slices"
@@ -49,7 +48,7 @@ func (r *AdminOrganizationProjectRateLimitService) ListRateLimits(ctx context.Co
 		err = errors.New("missing required project_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/rate_limits", projectID)
+	path := requestconfig.FormatPath("organization/projects/%s/rate_limits", projectID)
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -79,7 +78,7 @@ func (r *AdminOrganizationProjectRateLimitService) UpdateRateLimit(ctx context.C
 		err = errors.New("missing required rate_limit_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/rate_limits/%s", projectID, rateLimitID)
+	path := requestconfig.FormatPath("organization/projects/%s/rate_limits/%s", projectID, rateLimitID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }

--- a/adminorganizationprojectrole.go
+++ b/adminorganizationprojectrole.go
@@ -5,7 +5,6 @@ package openai
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"slices"
@@ -47,7 +46,7 @@ func (r *AdminOrganizationProjectRoleService) New(ctx context.Context, projectID
 		err = errors.New("missing required project_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("projects/%s/roles", projectID)
+	path := requestconfig.FormatPath("projects/%s/roles", projectID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -64,7 +63,7 @@ func (r *AdminOrganizationProjectRoleService) Update(ctx context.Context, projec
 		err = errors.New("missing required role_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("projects/%s/roles/%s", projectID, roleID)
+	path := requestconfig.FormatPath("projects/%s/roles/%s", projectID, roleID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -79,7 +78,7 @@ func (r *AdminOrganizationProjectRoleService) List(ctx context.Context, projectI
 		err = errors.New("missing required project_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("projects/%s/roles", projectID)
+	path := requestconfig.FormatPath("projects/%s/roles", projectID)
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -109,7 +108,7 @@ func (r *AdminOrganizationProjectRoleService) Delete(ctx context.Context, projec
 		err = errors.New("missing required role_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("projects/%s/roles/%s", projectID, roleID)
+	path := requestconfig.FormatPath("projects/%s/roles/%s", projectID, roleID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/adminorganizationprojectserviceaccount.go
+++ b/adminorganizationprojectserviceaccount.go
@@ -5,7 +5,6 @@ package openai
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"slices"
@@ -49,7 +48,7 @@ func (r *AdminOrganizationProjectServiceAccountService) New(ctx context.Context,
 		err = errors.New("missing required project_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/service_accounts", projectID)
+	path := requestconfig.FormatPath("organization/projects/%s/service_accounts", projectID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -66,7 +65,7 @@ func (r *AdminOrganizationProjectServiceAccountService) Get(ctx context.Context,
 		err = errors.New("missing required service_account_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/service_accounts/%s", projectID, serviceAccountID)
+	path := requestconfig.FormatPath("organization/projects/%s/service_accounts/%s", projectID, serviceAccountID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -81,7 +80,7 @@ func (r *AdminOrganizationProjectServiceAccountService) List(ctx context.Context
 		err = errors.New("missing required project_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/service_accounts", projectID)
+	path := requestconfig.FormatPath("organization/projects/%s/service_accounts", projectID)
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -114,7 +113,7 @@ func (r *AdminOrganizationProjectServiceAccountService) Delete(ctx context.Conte
 		err = errors.New("missing required service_account_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/service_accounts/%s", projectID, serviceAccountID)
+	path := requestconfig.FormatPath("organization/projects/%s/service_accounts/%s", projectID, serviceAccountID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/adminorganizationprojectuser.go
+++ b/adminorganizationprojectuser.go
@@ -5,7 +5,6 @@ package openai
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"slices"
@@ -50,7 +49,7 @@ func (r *AdminOrganizationProjectUserService) New(ctx context.Context, projectID
 		err = errors.New("missing required project_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/users", projectID)
+	path := requestconfig.FormatPath("organization/projects/%s/users", projectID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -67,7 +66,7 @@ func (r *AdminOrganizationProjectUserService) Get(ctx context.Context, projectID
 		err = errors.New("missing required user_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/users/%s", projectID, userID)
+	path := requestconfig.FormatPath("organization/projects/%s/users/%s", projectID, userID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -84,7 +83,7 @@ func (r *AdminOrganizationProjectUserService) Update(ctx context.Context, projec
 		err = errors.New("missing required user_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/users/%s", projectID, userID)
+	path := requestconfig.FormatPath("organization/projects/%s/users/%s", projectID, userID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -99,7 +98,7 @@ func (r *AdminOrganizationProjectUserService) List(ctx context.Context, projectI
 		err = errors.New("missing required project_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/users", projectID)
+	path := requestconfig.FormatPath("organization/projects/%s/users", projectID)
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -132,7 +131,7 @@ func (r *AdminOrganizationProjectUserService) Delete(ctx context.Context, projec
 		err = errors.New("missing required user_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/projects/%s/users/%s", projectID, userID)
+	path := requestconfig.FormatPath("organization/projects/%s/users/%s", projectID, userID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/adminorganizationprojectuserrole.go
+++ b/adminorganizationprojectuserrole.go
@@ -5,7 +5,6 @@ package openai
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"slices"
@@ -51,7 +50,7 @@ func (r *AdminOrganizationProjectUserRoleService) New(ctx context.Context, proje
 		err = errors.New("missing required user_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("projects/%s/users/%s/roles", projectID, userID)
+	path := requestconfig.FormatPath("projects/%s/users/%s/roles", projectID, userID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -70,7 +69,7 @@ func (r *AdminOrganizationProjectUserRoleService) List(ctx context.Context, proj
 		err = errors.New("missing required user_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("projects/%s/users/%s/roles", projectID, userID)
+	path := requestconfig.FormatPath("projects/%s/users/%s/roles", projectID, userID)
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -104,7 +103,7 @@ func (r *AdminOrganizationProjectUserRoleService) Delete(ctx context.Context, pr
 		err = errors.New("missing required role_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("projects/%s/users/%s/roles/%s", projectID, userID, roleID)
+	path := requestconfig.FormatPath("projects/%s/users/%s/roles/%s", projectID, userID, roleID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/adminorganizationrole.go
+++ b/adminorganizationrole.go
@@ -5,7 +5,6 @@ package openai
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"slices"
@@ -56,7 +55,7 @@ func (r *AdminOrganizationRoleService) Update(ctx context.Context, roleID string
 		err = errors.New("missing required role_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/roles/%s", roleID)
+	path := requestconfig.FormatPath("organization/roles/%s", roleID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -93,7 +92,7 @@ func (r *AdminOrganizationRoleService) Delete(ctx context.Context, roleID string
 		err = errors.New("missing required role_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/roles/%s", roleID)
+	path := requestconfig.FormatPath("organization/roles/%s", roleID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/adminorganizationuser.go
+++ b/adminorganizationuser.go
@@ -5,7 +5,6 @@ package openai
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"slices"
@@ -49,7 +48,7 @@ func (r *AdminOrganizationUserService) Get(ctx context.Context, userID string, o
 		err = errors.New("missing required user_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/users/%s", userID)
+	path := requestconfig.FormatPath("organization/users/%s", userID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -62,7 +61,7 @@ func (r *AdminOrganizationUserService) Update(ctx context.Context, userID string
 		err = errors.New("missing required user_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/users/%s", userID)
+	path := requestconfig.FormatPath("organization/users/%s", userID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -99,7 +98,7 @@ func (r *AdminOrganizationUserService) Delete(ctx context.Context, userID string
 		err = errors.New("missing required user_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/users/%s", userID)
+	path := requestconfig.FormatPath("organization/users/%s", userID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/adminorganizationuserrole.go
+++ b/adminorganizationuserrole.go
@@ -5,7 +5,6 @@ package openai
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"slices"
@@ -47,7 +46,7 @@ func (r *AdminOrganizationUserRoleService) New(ctx context.Context, userID strin
 		err = errors.New("missing required user_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/users/%s/roles", userID)
+	path := requestconfig.FormatPath("organization/users/%s/roles", userID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -62,7 +61,7 @@ func (r *AdminOrganizationUserRoleService) List(ctx context.Context, userID stri
 		err = errors.New("missing required user_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/users/%s/roles", userID)
+	path := requestconfig.FormatPath("organization/users/%s/roles", userID)
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -92,7 +91,7 @@ func (r *AdminOrganizationUserRoleService) Delete(ctx context.Context, userID st
 		err = errors.New("missing required role_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("organization/users/%s/roles/%s", userID, roleID)
+	path := requestconfig.FormatPath("organization/users/%s/roles/%s", userID, roleID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/azure/azure.go
+++ b/azure/azure.go
@@ -26,7 +26,6 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -65,7 +64,9 @@ func WithEndpoint(endpoint string, apiVersion string) option.RequestOption {
 			return nil, err
 		}
 
-		r.URL.Path = replacementPath
+		if err := setEscapedPath(r.URL, replacementPath); err != nil {
+			return nil, err
+		}
 		return mn(r)
 	})
 
@@ -185,7 +186,17 @@ func getReplacementPathWithDeployment(req *http.Request) (string, error) {
 	}
 
 	// If route doesn't require deployment ID substitution, just return path with prefix.
-	return path.Join("/openai/", req.URL.Path), nil
+	return "/openai" + req.URL.EscapedPath(), nil
+}
+
+func setEscapedPath(u *url.URL, escapedPath string) error {
+	parsed, err := url.Parse(escapedPath)
+	if err != nil {
+		return err
+	}
+	u.Path = parsed.Path
+	u.RawPath = parsed.RawPath
+	return nil
 }
 
 func getJSONRoute(req *http.Request) (string, error) {
@@ -207,9 +218,8 @@ func getJSONRoute(req *http.Request) (string, error) {
 		return "", err
 	}
 
-	escapedDeployment := url.PathEscape(v.Model)
 	// Convert path from /chat/completions to /openai/deployments/{deployment-id}/chat/completions
-	return "/openai/deployments/" + escapedDeployment + req.URL.Path, nil
+	return requestconfig.FormatPath("/openai/deployments/%s", v.Model) + req.URL.EscapedPath(), nil
 }
 
 func getMultipartRoute(req *http.Request) (string, error) {
@@ -253,9 +263,8 @@ func getMultipartRoute(req *http.Request) (string, error) {
 				return "", err
 			}
 
-			escapedDeployment := url.PathEscape(string(modelBytes))
 			// Convert path from /audio/transcriptions to /openai/deployments/{deployment-id}/audio/transcriptions
-			return "/openai/deployments/" + escapedDeployment + req.URL.Path, nil
+			return requestconfig.FormatPath("/openai/deployments/%s", string(modelBytes)) + req.URL.EscapedPath(), nil
 		}
 	}
 }

--- a/azure/azure_test.go
+++ b/azure/azure_test.go
@@ -2,14 +2,19 @@ package azure
 
 import (
 	"bytes"
+	"context"
+	"io"
 	"mime/multipart"
 	"net/http"
 	"net/url"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/internal/apijson"
 	"github.com/openai/openai-go/v3/internal/requestconfig"
+	"github.com/openai/openai-go/v3/option"
 )
 
 func TestJSONRoute(t *testing.T) {
@@ -124,12 +129,116 @@ func TestJSONRoutePathConstruction(t *testing.T) {
 }
 
 func TestModelWithSpecialCharsIsEscaped(t *testing.T) {
-	req, _ := http.NewRequest("POST", "/chat/completions", bytes.NewReader([]byte(`{"model":"my-model/v1"}`)))
-	got, _ := getReplacementPathWithDeployment(req)
+	tests := map[string]string{
+		"slash":               "my-model/v1",
+		"query and fragment":  "my-model?api-version=old#frag",
+		"bare dot":            ".",
+		"bare dot dot":        "..",
+		"dot dot slash":       "../my-model",
+		"encoded dot segment": "%2e%2e/my-model",
+	}
+	wantDeployment := map[string]string{
+		"slash":               "my-model%2Fv1",
+		"query and fragment":  "my-model%3Fapi-version=old%23frag",
+		"bare dot":            "%2E",
+		"bare dot dot":        "%2E%2E",
+		"dot dot slash":       "..%2Fmy-model",
+		"encoded dot segment": "%252e%252e%2Fmy-model",
+	}
 
-	expected := "/openai/deployments/my-model%2Fv1/chat/completions"
-	if got != expected {
-		t.Errorf("got %q, expected %q", got, expected)
+	for name, model := range tests {
+		t.Run(name, func(t *testing.T) {
+			req, _ := http.NewRequest("POST", "/chat/completions", bytes.NewReader([]byte(`{"model":`+strconv.Quote(model)+`}`)))
+			got, err := getReplacementPathWithDeployment(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			expected := "/openai/deployments/" + wantDeployment[name] + "/chat/completions"
+			if got != expected {
+				t.Errorf("got %q, expected %q", got, expected)
+			}
+		})
+	}
+}
+
+func TestMultipartModelWithSpecialCharsIsEscaped(t *testing.T) {
+	tests := map[string]string{
+		"slash":               "my-model/v1",
+		"query and fragment":  "my-model?api-version=old#frag",
+		"bare dot":            ".",
+		"bare dot dot":        "..",
+		"dot dot slash":       "../my-model",
+		"encoded dot segment": "%2e%2e/my-model",
+	}
+	wantDeployment := map[string]string{
+		"slash":               "my-model%2Fv1",
+		"query and fragment":  "my-model%3Fapi-version=old%23frag",
+		"bare dot":            "%2E",
+		"bare dot dot":        "%2E%2E",
+		"dot dot slash":       "..%2Fmy-model",
+		"encoded dot segment": "%252e%252e%2Fmy-model",
+	}
+
+	for name, model := range tests {
+		t.Run(name, func(t *testing.T) {
+			req := newMultipartRouteRequest(t, "/audio/transcriptions", model)
+			got, err := getReplacementPathWithDeployment(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			expected := "/openai/deployments/" + wantDeployment[name] + "/audio/transcriptions"
+			if got != expected {
+				t.Errorf("got %q, expected %q", got, expected)
+			}
+		})
+	}
+}
+
+func TestWithEndpointPreservesEscapedPathParams(t *testing.T) {
+	tests := map[string]string{
+		"slash traversal":     "../videos/vid_123",
+		"query and fragment":  "vs_123/files/file_456?limit=1#frag",
+		"encoded dot segment": "%2e%2e/videos/vid_123",
+	}
+	wantPaths := map[string]string{
+		"slash traversal":     "https://my-resource.openai.azure.com/openai/vector_stores/..%2Fvideos%2Fvid_123?api-version=2024-10-21",
+		"query and fragment":  "https://my-resource.openai.azure.com/openai/vector_stores/vs_123%2Ffiles%2Ffile_456%3Flimit=1%23frag?api-version=2024-10-21",
+		"encoded dot segment": "https://my-resource.openai.azure.com/openai/vector_stores/%252e%252e%2Fvideos%2Fvid_123?api-version=2024-10-21",
+	}
+
+	for name, input := range tests {
+		t.Run(name, func(t *testing.T) {
+			var captured *http.Request
+			client := openai.NewClient(
+				WithEndpoint("https://my-resource.openai.azure.com", "2024-10-21"),
+				WithAPIKey("sk-test"),
+				option.WithHTTPClient(&http.Client{
+					Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+						captured = req
+						return &http.Response{
+							StatusCode: http.StatusOK,
+							Header: http.Header{
+								"Content-Type": []string{"application/json"},
+							},
+							Body:    io.NopCloser(strings.NewReader(azureVectorStoreResponse)),
+							Request: req,
+						}, nil
+					}),
+				}),
+			)
+
+			if _, err := client.VectorStores.Get(context.Background(), input); err != nil {
+				t.Fatalf("request failed: %s", err)
+			}
+			if captured == nil {
+				t.Fatal("request was not captured")
+			}
+			if got, want := captured.URL.String(), wantPaths[name]; got != want {
+				t.Fatalf("url = %q, want %q", got, want)
+			}
+		})
 	}
 }
 
@@ -204,3 +313,54 @@ func TestWithEndpointBaseURL(t *testing.T) {
 		})
 	}
 }
+
+func newMultipartRouteRequest(t *testing.T, route string, model string) *http.Request {
+	t.Helper()
+
+	buff := &bytes.Buffer{}
+	mw := multipart.NewWriter(buff)
+	fw, err := mw.CreateFormFile("file", "test.mp3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = fw.Write([]byte("ignore me")); err != nil {
+		t.Fatal(err)
+	}
+	if err := mw.WriteField("model", model); err != nil {
+		t.Fatal(err)
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	req, err := http.NewRequest("POST", route, bytes.NewReader(buff.Bytes()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	return req
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+const azureVectorStoreResponse = `{
+	"id": "vs_dummy",
+	"object": "vector_store",
+	"created_at": 0,
+	"file_counts": {
+		"cancelled": 0,
+		"completed": 0,
+		"failed": 0,
+		"in_progress": 0,
+		"total": 0
+	},
+	"last_active_at": 0,
+	"metadata": {},
+	"name": "dummy",
+	"status": "completed",
+	"usage_bytes": 0
+}`

--- a/batch.go
+++ b/batch.go
@@ -5,7 +5,6 @@ package openai
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"slices"
@@ -59,7 +58,7 @@ func (r *BatchService) Get(ctx context.Context, batchID string, opts ...option.R
 		err = errors.New("missing required batch_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("batches/%s", batchID)
+	path := requestconfig.FormatPath("batches/%s", batchID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -98,7 +97,7 @@ func (r *BatchService) Cancel(ctx context.Context, batchID string, opts ...optio
 		err = errors.New("missing required batch_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("batches/%s/cancel", batchID)
+	path := requestconfig.FormatPath("batches/%s/cancel", batchID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, nil, &res, opts...)
 	return res, err
 }

--- a/betaassistant.go
+++ b/betaassistant.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"slices"
@@ -66,7 +65,7 @@ func (r *BetaAssistantService) Get(ctx context.Context, assistantID string, opts
 		err = errors.New("missing required assistant_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("assistants/%s", assistantID)
+	path := requestconfig.FormatPath("assistants/%s", assistantID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -82,7 +81,7 @@ func (r *BetaAssistantService) Update(ctx context.Context, assistantID string, b
 		err = errors.New("missing required assistant_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("assistants/%s", assistantID)
+	path := requestconfig.FormatPath("assistants/%s", assistantID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -126,7 +125,7 @@ func (r *BetaAssistantService) Delete(ctx context.Context, assistantID string, o
 		err = errors.New("missing required assistant_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("assistants/%s", assistantID)
+	path := requestconfig.FormatPath("assistants/%s", assistantID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/betachatkitsession.go
+++ b/betachatkitsession.go
@@ -5,7 +5,6 @@ package openai
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"slices"
 
@@ -55,7 +54,7 @@ func (r *BetaChatKitSessionService) Cancel(ctx context.Context, sessionID string
 		err = errors.New("missing required session_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("chatkit/sessions/%s/cancel", sessionID)
+	path := requestconfig.FormatPath("chatkit/sessions/%s/cancel", sessionID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, nil, &res, opts...)
 	return res, err
 }

--- a/betachatkitthread.go
+++ b/betachatkitthread.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"slices"
@@ -49,7 +48,7 @@ func (r *BetaChatKitThreadService) Get(ctx context.Context, threadID string, opt
 		err = errors.New("missing required thread_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("chatkit/threads/%s", threadID)
+	path := requestconfig.FormatPath("chatkit/threads/%s", threadID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -87,7 +86,7 @@ func (r *BetaChatKitThreadService) Delete(ctx context.Context, threadID string, 
 		err = errors.New("missing required thread_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("chatkit/threads/%s", threadID)
+	path := requestconfig.FormatPath("chatkit/threads/%s", threadID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }
@@ -102,7 +101,7 @@ func (r *BetaChatKitThreadService) ListItems(ctx context.Context, threadID strin
 		err = errors.New("missing required thread_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("chatkit/threads/%s/items", threadID)
+	path := requestconfig.FormatPath("chatkit/threads/%s/items", threadID)
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err

--- a/betathread.go
+++ b/betathread.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"slices"
 
@@ -76,7 +75,7 @@ func (r *BetaThreadService) Get(ctx context.Context, threadID string, opts ...op
 		err = errors.New("missing required thread_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("threads/%s", threadID)
+	path := requestconfig.FormatPath("threads/%s", threadID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -92,7 +91,7 @@ func (r *BetaThreadService) Update(ctx context.Context, threadID string, body Be
 		err = errors.New("missing required thread_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("threads/%s", threadID)
+	path := requestconfig.FormatPath("threads/%s", threadID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -108,7 +107,7 @@ func (r *BetaThreadService) Delete(ctx context.Context, threadID string, opts ..
 		err = errors.New("missing required thread_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("threads/%s", threadID)
+	path := requestconfig.FormatPath("threads/%s", threadID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/betathreadmessage.go
+++ b/betathreadmessage.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"slices"
@@ -56,7 +55,7 @@ func (r *BetaThreadMessageService) New(ctx context.Context, threadID string, bod
 		err = errors.New("missing required thread_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("threads/%s/messages", threadID)
+	path := requestconfig.FormatPath("threads/%s/messages", threadID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -76,7 +75,7 @@ func (r *BetaThreadMessageService) Get(ctx context.Context, threadID string, mes
 		err = errors.New("missing required message_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("threads/%s/messages/%s", threadID, messageID)
+	path := requestconfig.FormatPath("threads/%s/messages/%s", threadID, messageID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -96,7 +95,7 @@ func (r *BetaThreadMessageService) Update(ctx context.Context, threadID string, 
 		err = errors.New("missing required message_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("threads/%s/messages/%s", threadID, messageID)
+	path := requestconfig.FormatPath("threads/%s/messages/%s", threadID, messageID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -113,7 +112,7 @@ func (r *BetaThreadMessageService) List(ctx context.Context, threadID string, qu
 		err = errors.New("missing required thread_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("threads/%s/messages", threadID)
+	path := requestconfig.FormatPath("threads/%s/messages", threadID)
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -148,7 +147,7 @@ func (r *BetaThreadMessageService) Delete(ctx context.Context, threadID string, 
 		err = errors.New("missing required message_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("threads/%s/messages/%s", threadID, messageID)
+	path := requestconfig.FormatPath("threads/%s/messages/%s", threadID, messageID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/betathreadrun.go
+++ b/betathreadrun.go
@@ -5,7 +5,6 @@ package openai
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"slices"
@@ -61,7 +60,7 @@ func (r *BetaThreadRunService) New(ctx context.Context, threadID string, params 
 		err = errors.New("missing required thread_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("threads/%s/runs", threadID)
+	path := requestconfig.FormatPath("threads/%s/runs", threadID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, params, &res, opts...)
 	return res, err
 }
@@ -82,7 +81,7 @@ func (r *BetaThreadRunService) NewStreaming(ctx context.Context, threadID string
 		err = errors.New("missing required thread_id parameter")
 		return ssestream.NewStream[AssistantStreamEventUnion](nil, err)
 	}
-	path := fmt.Sprintf("threads/%s/runs", threadID)
+	path := requestconfig.FormatPath("threads/%s/runs", threadID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, params, &raw, opts...)
 	return ssestream.NewStreamWithSynthesizeEventData[AssistantStreamEventUnion](ssestream.NewDecoder(raw), err)
 }
@@ -102,7 +101,7 @@ func (r *BetaThreadRunService) Get(ctx context.Context, threadID string, runID s
 		err = errors.New("missing required run_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("threads/%s/runs/%s", threadID, runID)
+	path := requestconfig.FormatPath("threads/%s/runs/%s", threadID, runID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -122,7 +121,7 @@ func (r *BetaThreadRunService) Update(ctx context.Context, threadID string, runI
 		err = errors.New("missing required run_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("threads/%s/runs/%s", threadID, runID)
+	path := requestconfig.FormatPath("threads/%s/runs/%s", threadID, runID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -139,7 +138,7 @@ func (r *BetaThreadRunService) List(ctx context.Context, threadID string, query 
 		err = errors.New("missing required thread_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("threads/%s/runs", threadID)
+	path := requestconfig.FormatPath("threads/%s/runs", threadID)
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -174,7 +173,7 @@ func (r *BetaThreadRunService) Cancel(ctx context.Context, threadID string, runI
 		err = errors.New("missing required run_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("threads/%s/runs/%s/cancel", threadID, runID)
+	path := requestconfig.FormatPath("threads/%s/runs/%s/cancel", threadID, runID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, nil, &res, opts...)
 	return res, err
 }
@@ -197,7 +196,7 @@ func (r *BetaThreadRunService) SubmitToolOutputs(ctx context.Context, threadID s
 		err = errors.New("missing required run_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("threads/%s/runs/%s/submit_tool_outputs", threadID, runID)
+	path := requestconfig.FormatPath("threads/%s/runs/%s/submit_tool_outputs", threadID, runID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -225,7 +224,7 @@ func (r *BetaThreadRunService) SubmitToolOutputsStreaming(ctx context.Context, t
 		err = errors.New("missing required run_id parameter")
 		return ssestream.NewStream[AssistantStreamEventUnion](nil, err)
 	}
-	path := fmt.Sprintf("threads/%s/runs/%s/submit_tool_outputs", threadID, runID)
+	path := requestconfig.FormatPath("threads/%s/runs/%s/submit_tool_outputs", threadID, runID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &raw, opts...)
 	return ssestream.NewStreamWithSynthesizeEventData[AssistantStreamEventUnion](ssestream.NewDecoder(raw), err)
 }

--- a/betathreadrunstep.go
+++ b/betathreadrunstep.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"slices"
@@ -64,7 +63,7 @@ func (r *BetaThreadRunStepService) Get(ctx context.Context, threadID string, run
 		err = errors.New("missing required step_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("threads/%s/runs/%s/steps/%s", threadID, runID, stepID)
+	path := requestconfig.FormatPath("threads/%s/runs/%s/steps/%s", threadID, runID, stepID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, query, &res, opts...)
 	return res, err
 }
@@ -85,7 +84,7 @@ func (r *BetaThreadRunStepService) List(ctx context.Context, threadID string, ru
 		err = errors.New("missing required run_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("threads/%s/runs/%s/steps", threadID, runID)
+	path := requestconfig.FormatPath("threads/%s/runs/%s/steps", threadID, runID)
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err

--- a/chatcompletion.go
+++ b/chatcompletion.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"slices"
@@ -119,7 +118,7 @@ func (r *ChatCompletionService) Get(ctx context.Context, completionID string, op
 		err = errors.New("missing required completion_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("chat/completions/%s", completionID)
+	path := requestconfig.FormatPath("chat/completions/%s", completionID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -134,7 +133,7 @@ func (r *ChatCompletionService) Update(ctx context.Context, completionID string,
 		err = errors.New("missing required completion_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("chat/completions/%s", completionID)
+	path := requestconfig.FormatPath("chat/completions/%s", completionID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -174,7 +173,7 @@ func (r *ChatCompletionService) Delete(ctx context.Context, completionID string,
 		err = errors.New("missing required completion_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("chat/completions/%s", completionID)
+	path := requestconfig.FormatPath("chat/completions/%s", completionID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/chatcompletionmessage.go
+++ b/chatcompletionmessage.go
@@ -5,7 +5,6 @@ package openai
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"slices"
@@ -50,7 +49,7 @@ func (r *ChatCompletionMessageService) List(ctx context.Context, completionID st
 		err = errors.New("missing required completion_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("chat/completions/%s/messages", completionID)
+	path := requestconfig.FormatPath("chat/completions/%s/messages", completionID)
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err

--- a/container.go
+++ b/container.go
@@ -5,7 +5,6 @@ package openai
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"slices"
@@ -58,7 +57,7 @@ func (r *ContainerService) Get(ctx context.Context, containerID string, opts ...
 		err = errors.New("missing required container_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("containers/%s", containerID)
+	path := requestconfig.FormatPath("containers/%s", containerID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -96,7 +95,7 @@ func (r *ContainerService) Delete(ctx context.Context, containerID string, opts 
 		err = errors.New("missing required container_id parameter")
 		return err
 	}
-	path := fmt.Sprintf("containers/%s", containerID)
+	path := requestconfig.FormatPath("containers/%s", containerID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, nil, opts...)
 	return err
 }

--- a/containerfile.go
+++ b/containerfile.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -56,7 +55,7 @@ func (r *ContainerFileService) New(ctx context.Context, containerID string, body
 		err = errors.New("missing required container_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("containers/%s/files", containerID)
+	path := requestconfig.FormatPath("containers/%s/files", containerID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -73,7 +72,7 @@ func (r *ContainerFileService) Get(ctx context.Context, containerID string, file
 		err = errors.New("missing required file_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("containers/%s/files/%s", containerID, fileID)
+	path := requestconfig.FormatPath("containers/%s/files/%s", containerID, fileID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -88,7 +87,7 @@ func (r *ContainerFileService) List(ctx context.Context, containerID string, que
 		err = errors.New("missing required container_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("containers/%s/files", containerID)
+	path := requestconfig.FormatPath("containers/%s/files", containerID)
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -119,7 +118,7 @@ func (r *ContainerFileService) Delete(ctx context.Context, containerID string, f
 		err = errors.New("missing required file_id parameter")
 		return err
 	}
-	path := fmt.Sprintf("containers/%s/files/%s", containerID, fileID)
+	path := requestconfig.FormatPath("containers/%s/files/%s", containerID, fileID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, nil, opts...)
 	return err
 }

--- a/containerfilecontent.go
+++ b/containerfilecontent.go
@@ -5,7 +5,6 @@ package openai
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"slices"
 
@@ -45,7 +44,7 @@ func (r *ContainerFileContentService) Get(ctx context.Context, containerID strin
 		err = errors.New("missing required file_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("containers/%s/files/%s/content", containerID, fileID)
+	path := requestconfig.FormatPath("containers/%s/files/%s/content", containerID, fileID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }

--- a/conversations/conversation.go
+++ b/conversations/conversation.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"slices"
 
@@ -61,7 +60,7 @@ func (r *ConversationService) Get(ctx context.Context, conversationID string, op
 		err = errors.New("missing required conversation_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("conversations/%s", conversationID)
+	path := requestconfig.FormatPath("conversations/%s", conversationID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -74,7 +73,7 @@ func (r *ConversationService) Update(ctx context.Context, conversationID string,
 		err = errors.New("missing required conversation_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("conversations/%s", conversationID)
+	path := requestconfig.FormatPath("conversations/%s", conversationID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -87,7 +86,7 @@ func (r *ConversationService) Delete(ctx context.Context, conversationID string,
 		err = errors.New("missing required conversation_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("conversations/%s", conversationID)
+	path := requestconfig.FormatPath("conversations/%s", conversationID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/conversations/item.go
+++ b/conversations/item.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"slices"
@@ -51,7 +50,7 @@ func (r *ItemService) New(ctx context.Context, conversationID string, params Ite
 		err = errors.New("missing required conversation_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("conversations/%s/items", conversationID)
+	path := requestconfig.FormatPath("conversations/%s/items", conversationID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, params, &res, opts...)
 	return res, err
 }
@@ -68,7 +67,7 @@ func (r *ItemService) Get(ctx context.Context, conversationID string, itemID str
 		err = errors.New("missing required item_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("conversations/%s/items/%s", conversationID, itemID)
+	path := requestconfig.FormatPath("conversations/%s/items/%s", conversationID, itemID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, query, &res, opts...)
 	return res, err
 }
@@ -83,7 +82,7 @@ func (r *ItemService) List(ctx context.Context, conversationID string, query Ite
 		err = errors.New("missing required conversation_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("conversations/%s/items", conversationID)
+	path := requestconfig.FormatPath("conversations/%s/items", conversationID)
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -113,7 +112,7 @@ func (r *ItemService) Delete(ctx context.Context, conversationID string, itemID 
 		err = errors.New("missing required item_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("conversations/%s/items/%s", conversationID, itemID)
+	path := requestconfig.FormatPath("conversations/%s/items/%s", conversationID, itemID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/file.go
+++ b/file.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -89,7 +88,7 @@ func (r *FileService) Get(ctx context.Context, fileID string, opts ...option.Req
 		err = errors.New("missing required file_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("files/%s", fileID)
+	path := requestconfig.FormatPath("files/%s", fileID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -126,7 +125,7 @@ func (r *FileService) Delete(ctx context.Context, fileID string, opts ...option.
 		err = errors.New("missing required file_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("files/%s", fileID)
+	path := requestconfig.FormatPath("files/%s", fileID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }
@@ -140,7 +139,7 @@ func (r *FileService) Content(ctx context.Context, fileID string, opts ...option
 		err = errors.New("missing required file_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("files/%s/content", fileID)
+	path := requestconfig.FormatPath("files/%s/content", fileID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }

--- a/finetuningcheckpointpermission.go
+++ b/finetuningcheckpointpermission.go
@@ -5,7 +5,6 @@ package openai
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"slices"
@@ -54,7 +53,7 @@ func (r *FineTuningCheckpointPermissionService) New(ctx context.Context, fineTun
 		err = errors.New("missing required fine_tuned_model_checkpoint parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("fine_tuning/checkpoints/%s/permissions", fineTunedModelCheckpoint)
+	path := requestconfig.FormatPath("fine_tuning/checkpoints/%s/permissions", fineTunedModelCheckpoint)
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodPost, path, body, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -89,7 +88,7 @@ func (r *FineTuningCheckpointPermissionService) Get(ctx context.Context, fineTun
 		err = errors.New("missing required fine_tuned_model_checkpoint parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("fine_tuning/checkpoints/%s/permissions", fineTunedModelCheckpoint)
+	path := requestconfig.FormatPath("fine_tuning/checkpoints/%s/permissions", fineTunedModelCheckpoint)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, query, &res, opts...)
 	return res, err
 }
@@ -107,7 +106,7 @@ func (r *FineTuningCheckpointPermissionService) List(ctx context.Context, fineTu
 		err = errors.New("missing required fine_tuned_model_checkpoint parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("fine_tuning/checkpoints/%s/permissions", fineTunedModelCheckpoint)
+	path := requestconfig.FormatPath("fine_tuning/checkpoints/%s/permissions", fineTunedModelCheckpoint)
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -143,7 +142,7 @@ func (r *FineTuningCheckpointPermissionService) Delete(ctx context.Context, fine
 		err = errors.New("missing required permission_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("fine_tuning/checkpoints/%s/permissions/%s", fineTunedModelCheckpoint, permissionID)
+	path := requestconfig.FormatPath("fine_tuning/checkpoints/%s/permissions/%s", fineTunedModelCheckpoint, permissionID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/finetuningjob.go
+++ b/finetuningjob.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"slices"
@@ -71,7 +70,7 @@ func (r *FineTuningJobService) Get(ctx context.Context, fineTuningJobID string, 
 		err = errors.New("missing required fine_tuning_job_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("fine_tuning/jobs/%s", fineTuningJobID)
+	path := requestconfig.FormatPath("fine_tuning/jobs/%s", fineTuningJobID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -108,7 +107,7 @@ func (r *FineTuningJobService) Cancel(ctx context.Context, fineTuningJobID strin
 		err = errors.New("missing required fine_tuning_job_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("fine_tuning/jobs/%s/cancel", fineTuningJobID)
+	path := requestconfig.FormatPath("fine_tuning/jobs/%s/cancel", fineTuningJobID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, nil, &res, opts...)
 	return res, err
 }
@@ -123,7 +122,7 @@ func (r *FineTuningJobService) ListEvents(ctx context.Context, fineTuningJobID s
 		err = errors.New("missing required fine_tuning_job_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("fine_tuning/jobs/%s/events", fineTuningJobID)
+	path := requestconfig.FormatPath("fine_tuning/jobs/%s/events", fineTuningJobID)
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -149,7 +148,7 @@ func (r *FineTuningJobService) Pause(ctx context.Context, fineTuningJobID string
 		err = errors.New("missing required fine_tuning_job_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("fine_tuning/jobs/%s/pause", fineTuningJobID)
+	path := requestconfig.FormatPath("fine_tuning/jobs/%s/pause", fineTuningJobID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, nil, &res, opts...)
 	return res, err
 }
@@ -162,7 +161,7 @@ func (r *FineTuningJobService) Resume(ctx context.Context, fineTuningJobID strin
 		err = errors.New("missing required fine_tuning_job_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("fine_tuning/jobs/%s/resume", fineTuningJobID)
+	path := requestconfig.FormatPath("fine_tuning/jobs/%s/resume", fineTuningJobID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, nil, &res, opts...)
 	return res, err
 }

--- a/finetuningjobcheckpoint.go
+++ b/finetuningjobcheckpoint.go
@@ -5,7 +5,6 @@ package openai
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"slices"
@@ -51,7 +50,7 @@ func (r *FineTuningJobCheckpointService) List(ctx context.Context, fineTuningJob
 		err = errors.New("missing required fine_tuning_job_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("fine_tuning/jobs/%s/checkpoints", fineTuningJobID)
+	path := requestconfig.FormatPath("fine_tuning/jobs/%s/checkpoints", fineTuningJobID)
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err

--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -31,6 +31,25 @@ func getDefaultHeaders() map[string]string {
 	}
 }
 
+func encodePathParam(value string) string {
+	switch value {
+	case ".":
+		return "%2E"
+	case "..":
+		return "%2E%2E"
+	}
+	return url.PathEscape(value)
+}
+
+// FormatPath escapes path parameters and inserts them into a request path.
+func FormatPath(format string, params ...string) string {
+	args := make([]any, len(params))
+	for i, param := range params {
+		args[i] = encodePathParam(param)
+	}
+	return fmt.Sprintf(format, args...)
+}
+
 func getNormalizedOS() string {
 	switch runtime.GOOS {
 	case "ios":

--- a/internal/requestconfig/requestconfig_test.go
+++ b/internal/requestconfig/requestconfig_test.go
@@ -1,0 +1,50 @@
+package requestconfig
+
+import "testing"
+
+func TestFormatPathEscapesPathParams(t *testing.T) {
+	tests := map[string]struct {
+		format string
+		params []string
+		want   string
+	}{
+		"slash": {
+			format: "vector_stores/%s",
+			params: []string{"../videos/vid_123"},
+			want:   "vector_stores/..%2Fvideos%2Fvid_123",
+		},
+		"query and fragment": {
+			format: "vector_stores/%s",
+			params: []string{"vs_123/files/file_456?limit=1#frag"},
+			want:   "vector_stores/vs_123%2Ffiles%2Ffile_456%3Flimit=1%23frag",
+		},
+		"encoded dot segments": {
+			format: "vector_stores/%s",
+			params: []string{"%2e%2e/videos/vid_123"},
+			want:   "vector_stores/%252e%252e%2Fvideos%2Fvid_123",
+		},
+		"bare dot": {
+			format: "vector_stores/%s",
+			params: []string{"."},
+			want:   "vector_stores/%2E",
+		},
+		"bare dot dot": {
+			format: "vector_stores/%s",
+			params: []string{".."},
+			want:   "vector_stores/%2E%2E",
+		},
+		"multiple params": {
+			format: "organization/projects/%s/api_keys/%s",
+			params: []string{"proj_123/../../admin_api_keys/key_456?", "ignored"},
+			want:   "organization/projects/proj_123%2F..%2F..%2Fadmin_api_keys%2Fkey_456%3F/api_keys/ignored",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := FormatPath(test.format, test.params...); got != test.want {
+				t.Fatalf("FormatPath() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}

--- a/model.go
+++ b/model.go
@@ -5,7 +5,6 @@ package openai
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"slices"
 
@@ -47,7 +46,7 @@ func (r *ModelService) Get(ctx context.Context, model string, opts ...option.Req
 		err = errors.New("missing required model parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("models/%s", model)
+	path := requestconfig.FormatPath("models/%s", model)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -87,7 +86,7 @@ func (r *ModelService) Delete(ctx context.Context, model string, opts ...option.
 		err = errors.New("missing required model parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("models/%s", model)
+	path := requestconfig.FormatPath("models/%s", model)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/pathparam_static_test.go
+++ b/pathparam_static_test.go
@@ -1,0 +1,228 @@
+package openai_test
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+type requestPathKind int
+
+const (
+	requestPathLiteral requestPathKind = 1 << iota
+	requestPathFormatPath
+	requestPathUnknown
+)
+
+const requestconfigImportPath = "github.com/openai/openai-go/v3/internal/requestconfig"
+
+func TestGeneratedPathsUseFormatPath(t *testing.T) {
+	var violations []string
+	fset := token.NewFileSet()
+
+	err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", ".github", ".codex", "examples":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		source, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if !isGeneratedServiceSource(path, source) {
+			return nil
+		}
+
+		file, err := parser.ParseFile(fset, path, source, 0)
+		if err != nil {
+			return err
+		}
+		requestconfigNames := requestconfigImportNames(file)
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			reviewRequestPathFunction(fset, fn, requestconfigNames, &violations)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(violations) > 0 {
+		t.Fatalf("generated request paths with parameters must use requestconfig.FormatPath:\n%s", strings.Join(violations, "\n"))
+	}
+}
+
+func isGeneratedServiceSource(path string, source []byte) bool {
+	if path == "client.go" {
+		return false
+	}
+	return strings.HasPrefix(string(source), "// File generated from our OpenAPI spec by Stainless.")
+}
+
+func requestconfigImportNames(file *ast.File) map[string]bool {
+	names := map[string]bool{}
+	for _, importSpec := range file.Imports {
+		importPath, err := strconv.Unquote(importSpec.Path.Value)
+		if err != nil || importPath != requestconfigImportPath {
+			continue
+		}
+		if importSpec.Name != nil && importSpec.Name.Name != "." && importSpec.Name.Name != "_" {
+			names[importSpec.Name.Name] = true
+			continue
+		}
+		names["requestconfig"] = true
+	}
+	return names
+}
+
+func reviewRequestPathFunction(fset *token.FileSet, fn *ast.FuncDecl, requestconfigNames map[string]bool, violations *[]string) {
+	values := map[string]requestPathKind{}
+
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		switch n := node.(type) {
+		case *ast.AssignStmt:
+			for i, lhs := range n.Lhs {
+				ident, ok := lhs.(*ast.Ident)
+				if !ok || ident.Name == "_" || i >= len(n.Rhs) {
+					continue
+				}
+				values[ident.Name] |= classifyRequestPathExpr(fset, n.Rhs[i], requestconfigNames, violations)
+			}
+		case *ast.ValueSpec:
+			for i, name := range n.Names {
+				if i >= len(n.Values) {
+					continue
+				}
+				values[name.Name] |= classifyRequestPathExpr(fset, n.Values[i], requestconfigNames, violations)
+			}
+		case *ast.CallExpr:
+			if !isRequestConfigCall(n, requestconfigNames, "ExecuteNewRequest") && !isRequestConfigCall(n, requestconfigNames, "NewRequestConfig") {
+				return true
+			}
+			if len(n.Args) < 3 {
+				*violations = append(*violations, fmt.Sprintf("%s: requestconfig call is missing request path argument", fset.Position(n.Pos())))
+				return true
+			}
+			if !classifyRequestPathArg(fset, n.Args[2], values, requestconfigNames, violations).safe() {
+				*violations = append(*violations, fmt.Sprintf("%s: dynamic request path must come from requestconfig.FormatPath", fset.Position(n.Args[2].Pos())))
+			}
+		}
+		return true
+	})
+}
+
+func classifyRequestPathArg(fset *token.FileSet, expr ast.Expr, values map[string]requestPathKind, requestconfigNames map[string]bool, violations *[]string) requestPathKind {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return values[e.Name]
+	default:
+		return classifyRequestPathExpr(fset, expr, requestconfigNames, violations)
+	}
+}
+
+func classifyRequestPathExpr(fset *token.FileSet, expr ast.Expr, requestconfigNames map[string]bool, violations *[]string) requestPathKind {
+	switch e := expr.(type) {
+	case *ast.BasicLit:
+		if e.Kind == token.STRING {
+			if literalRequestPathHasPlaceholder(e) {
+				return requestPathUnknown
+			}
+			return requestPathLiteral
+		}
+	case *ast.CallExpr:
+		if isRequestConfigCall(e, requestconfigNames, "FormatPath") {
+			validateFormatPathCall(fset, e, violations)
+			return requestPathFormatPath
+		}
+	}
+	return requestPathUnknown
+}
+
+func literalRequestPathHasPlaceholder(lit *ast.BasicLit) bool {
+	value, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		return true
+	}
+	return strings.Contains(value, "%s") || strings.Contains(value, "{") || strings.Contains(value, "}")
+}
+
+func (kind requestPathKind) safe() bool {
+	return kind != 0 && kind&requestPathUnknown == 0
+}
+
+func validateFormatPathCall(fset *token.FileSet, call *ast.CallExpr, violations *[]string) {
+	if len(call.Args) == 0 {
+		*violations = append(*violations, fmt.Sprintf("%s: requestconfig.FormatPath is missing a format string", fset.Position(call.Pos())))
+		return
+	}
+
+	formatLit, ok := call.Args[0].(*ast.BasicLit)
+	if !ok || formatLit.Kind != token.STRING {
+		*violations = append(*violations, fmt.Sprintf("%s: requestconfig.FormatPath format must be a string literal", fset.Position(call.Args[0].Pos())))
+		return
+	}
+	format, err := strconv.Unquote(formatLit.Value)
+	if err != nil {
+		*violations = append(*violations, fmt.Sprintf("%s: requestconfig.FormatPath format is not a valid string literal", fset.Position(formatLit.Pos())))
+		return
+	}
+
+	placeholders, unsupported := countStringPlaceholders(format)
+	if unsupported != "" {
+		*violations = append(*violations, fmt.Sprintf("%s: requestconfig.FormatPath only supports %%s placeholders, found %%%s", fset.Position(formatLit.Pos()), unsupported))
+	}
+	if placeholders != len(call.Args)-1 {
+		*violations = append(*violations, fmt.Sprintf("%s: requestconfig.FormatPath has %d %%s placeholders but %d path params", fset.Position(formatLit.Pos()), placeholders, len(call.Args)-1))
+	}
+}
+
+func countStringPlaceholders(format string) (int, string) {
+	count := 0
+	for i := 0; i < len(format); i++ {
+		if format[i] != '%' {
+			continue
+		}
+		if i+1 >= len(format) {
+			return count, "EOF"
+		}
+		i++
+		switch format[i] {
+		case '%':
+			continue
+		case 's':
+			count++
+		default:
+			return count, string(format[i])
+		}
+	}
+	return count, ""
+}
+
+func isRequestConfigCall(call *ast.CallExpr, requestconfigNames map[string]bool, name string) bool {
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || selector.Sel.Name != name {
+		return false
+	}
+	pkg, ok := selector.X.(*ast.Ident)
+	return ok && requestconfigNames[pkg.Name]
+}

--- a/pathparam_test.go
+++ b/pathparam_test.go
@@ -1,0 +1,136 @@
+package openai_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+)
+
+func TestPathParamsAreEscaped(t *testing.T) {
+	t.Run("path traversal stays inside vector store id segment", func(t *testing.T) {
+		req := captureRequest(t, func(client openai.Client) error {
+			_, err := client.VectorStores.Get(context.Background(), "../videos/vid_123")
+			return err
+		}, vectorStoreResponse)
+
+		if req.Method != http.MethodGet {
+			t.Fatalf("method = %q, want GET", req.Method)
+		}
+		if got, want := req.URL.String(), "https://api.openai.com/v1/vector_stores/..%2Fvideos%2Fvid_123"; got != want {
+			t.Fatalf("url = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("slash query and fragment stay inside vector store id segment", func(t *testing.T) {
+		req := captureRequest(t, func(client openai.Client) error {
+			_, err := client.VectorStores.Get(context.Background(), "vs_123/files/file_456?limit=1#frag")
+			return err
+		}, vectorStoreResponse)
+
+		if got, want := req.URL.String(), "https://api.openai.com/v1/vector_stores/vs_123%2Ffiles%2Ffile_456%3Flimit=1%23frag"; got != want {
+			t.Fatalf("url = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("encoded dot segments stay encoded", func(t *testing.T) {
+		req := captureRequest(t, func(client openai.Client) error {
+			_, err := client.VectorStores.Get(context.Background(), "%2e%2e/videos/vid_123")
+			return err
+		}, vectorStoreResponse)
+
+		if got, want := req.URL.String(), "https://api.openai.com/v1/vector_stores/%252e%252e%2Fvideos%2Fvid_123"; got != want {
+			t.Fatalf("url = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("bare dot segments stay inside vector store id segment", func(t *testing.T) {
+		for input, wantURL := range map[string]string{
+			".":  "https://api.openai.com/v1/vector_stores/%2E",
+			"..": "https://api.openai.com/v1/vector_stores/%2E%2E",
+		} {
+			req := captureRequest(t, func(client openai.Client) error {
+				_, err := client.VectorStores.Get(context.Background(), input)
+				return err
+			}, vectorStoreResponse)
+
+			if got := req.URL.String(); got != wantURL {
+				t.Fatalf("url = %q, want %q", got, wantURL)
+			}
+		}
+	})
+
+	t.Run("admin path traversal stays inside project id segment", func(t *testing.T) {
+		req := captureRequest(t, func(client openai.Client) error {
+			_, err := client.Admin.Organization.Projects.APIKeys.Delete(context.Background(), "proj_123/../../admin_api_keys/key_456?", "ignored")
+			return err
+		}, adminAPIKeyDeletedResponse)
+
+		if req.Method != http.MethodDelete {
+			t.Fatalf("method = %q, want DELETE", req.Method)
+		}
+		if got, want := req.URL.String(), "https://api.openai.com/v1/organization/projects/proj_123%2F..%2F..%2Fadmin_api_keys%2Fkey_456%3F/api_keys/ignored"; got != want {
+			t.Fatalf("url = %q, want %q", got, want)
+		}
+	})
+}
+
+func captureRequest(t *testing.T, call func(openai.Client) error, responseBody string) *http.Request {
+	t.Helper()
+
+	var captured *http.Request
+	client := openai.NewClient(
+		option.WithBaseURL("https://api.openai.com/v1/"),
+		option.WithAPIKey("sk-test"),
+		option.WithAdminAPIKey("sk-admin-test"),
+		option.WithHTTPClient(&http.Client{
+			Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+				captured = req
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header: http.Header{
+						"Content-Type": []string{"application/json"},
+					},
+					Body:    io.NopCloser(strings.NewReader(responseBody)),
+					Request: req,
+				}, nil
+			}},
+		}),
+	)
+
+	if err := call(client); err != nil {
+		t.Fatalf("request failed: %s", err)
+	}
+	if captured == nil {
+		t.Fatal("request was not captured")
+	}
+	return captured
+}
+
+const vectorStoreResponse = `{
+	"id": "vs_dummy",
+	"object": "vector_store",
+	"created_at": 0,
+	"file_counts": {
+		"cancelled": 0,
+		"completed": 0,
+		"failed": 0,
+		"in_progress": 0,
+		"total": 0
+	},
+	"last_active_at": 0,
+	"metadata": {},
+	"name": "dummy",
+	"status": "completed",
+	"usage_bytes": 0
+}`
+
+const adminAPIKeyDeletedResponse = `{
+	"id": "key",
+	"object": "organization.project.api_key.deleted",
+	"deleted": true
+}`

--- a/realtime/call.go
+++ b/realtime/call.go
@@ -5,7 +5,6 @@ package realtime
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"slices"
 
@@ -45,7 +44,7 @@ func (r *CallService) Accept(ctx context.Context, callID string, body CallAccept
 		err = errors.New("missing required call_id parameter")
 		return err
 	}
-	path := fmt.Sprintf("realtime/calls/%s/accept", callID)
+	path := requestconfig.FormatPath("realtime/calls/%s/accept", callID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, nil, opts...)
 	return err
 }
@@ -59,7 +58,7 @@ func (r *CallService) Hangup(ctx context.Context, callID string, opts ...option.
 		err = errors.New("missing required call_id parameter")
 		return err
 	}
-	path := fmt.Sprintf("realtime/calls/%s/hangup", callID)
+	path := requestconfig.FormatPath("realtime/calls/%s/hangup", callID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, nil, nil, opts...)
 	return err
 }
@@ -73,7 +72,7 @@ func (r *CallService) Refer(ctx context.Context, callID string, body CallReferPa
 		err = errors.New("missing required call_id parameter")
 		return err
 	}
-	path := fmt.Sprintf("realtime/calls/%s/refer", callID)
+	path := requestconfig.FormatPath("realtime/calls/%s/refer", callID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, nil, opts...)
 	return err
 }
@@ -87,7 +86,7 @@ func (r *CallService) Reject(ctx context.Context, callID string, body CallReject
 		err = errors.New("missing required call_id parameter")
 		return err
 	}
-	path := fmt.Sprintf("realtime/calls/%s/reject", callID)
+	path := requestconfig.FormatPath("realtime/calls/%s/reject", callID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, nil, opts...)
 	return err
 }

--- a/responses/inputitem.go
+++ b/responses/inputitem.go
@@ -5,7 +5,6 @@ package responses
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"slices"
@@ -49,7 +48,7 @@ func (r *InputItemService) List(ctx context.Context, responseID string, query In
 		err = errors.New("missing required response_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("responses/%s/input_items", responseID)
+	path := requestconfig.FormatPath("responses/%s/input_items", responseID)
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err

--- a/responses/response.go
+++ b/responses/response.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"slices"
@@ -98,7 +97,7 @@ func (r *ResponseService) Get(ctx context.Context, responseID string, query Resp
 		err = errors.New("missing required response_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("responses/%s", responseID)
+	path := requestconfig.FormatPath("responses/%s", responseID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, query, &res, opts...)
 	return res, err
 }
@@ -116,7 +115,7 @@ func (r *ResponseService) GetStreaming(ctx context.Context, responseID string, q
 		err = errors.New("missing required response_id parameter")
 		return ssestream.NewStream[ResponseStreamEventUnion](nil, err)
 	}
-	path := fmt.Sprintf("responses/%s", responseID)
+	path := requestconfig.FormatPath("responses/%s", responseID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, query, &raw, opts...)
 	return ssestream.NewStream[ResponseStreamEventUnion](ssestream.NewDecoder(raw), err)
 }
@@ -130,7 +129,7 @@ func (r *ResponseService) Delete(ctx context.Context, responseID string, opts ..
 		err = errors.New("missing required response_id parameter")
 		return err
 	}
-	path := fmt.Sprintf("responses/%s", responseID)
+	path := requestconfig.FormatPath("responses/%s", responseID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, nil, opts...)
 	return err
 }
@@ -145,7 +144,7 @@ func (r *ResponseService) Cancel(ctx context.Context, responseID string, opts ..
 		err = errors.New("missing required response_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("responses/%s/cancel", responseID)
+	path := requestconfig.FormatPath("responses/%s/cancel", responseID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, nil, &res, opts...)
 	return res, err
 }

--- a/skill.go
+++ b/skill.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -64,7 +63,7 @@ func (r *SkillService) Get(ctx context.Context, skillID string, opts ...option.R
 		err = errors.New("missing required skill_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("skills/%s", skillID)
+	path := requestconfig.FormatPath("skills/%s", skillID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -77,7 +76,7 @@ func (r *SkillService) Update(ctx context.Context, skillID string, body SkillUpd
 		err = errors.New("missing required skill_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("skills/%s", skillID)
+	path := requestconfig.FormatPath("skills/%s", skillID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -114,7 +113,7 @@ func (r *SkillService) Delete(ctx context.Context, skillID string, opts ...optio
 		err = errors.New("missing required skill_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("skills/%s", skillID)
+	path := requestconfig.FormatPath("skills/%s", skillID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/skillcontent.go
+++ b/skillcontent.go
@@ -5,7 +5,6 @@ package openai
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"slices"
 
@@ -41,7 +40,7 @@ func (r *SkillContentService) Get(ctx context.Context, skillID string, opts ...o
 		err = errors.New("missing required skill_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("skills/%s/content", skillID)
+	path := requestconfig.FormatPath("skills/%s/content", skillID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }

--- a/skillversion.go
+++ b/skillversion.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -53,7 +52,7 @@ func (r *SkillVersionService) New(ctx context.Context, skillID string, body Skil
 		err = errors.New("missing required skill_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("skills/%s/versions", skillID)
+	path := requestconfig.FormatPath("skills/%s/versions", skillID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -70,7 +69,7 @@ func (r *SkillVersionService) Get(ctx context.Context, skillID string, version s
 		err = errors.New("missing required version parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("skills/%s/versions/%s", skillID, version)
+	path := requestconfig.FormatPath("skills/%s/versions/%s", skillID, version)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -85,7 +84,7 @@ func (r *SkillVersionService) List(ctx context.Context, skillID string, query Sk
 		err = errors.New("missing required skill_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("skills/%s/versions", skillID)
+	path := requestconfig.FormatPath("skills/%s/versions", skillID)
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -115,7 +114,7 @@ func (r *SkillVersionService) Delete(ctx context.Context, skillID string, versio
 		err = errors.New("missing required version parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("skills/%s/versions/%s", skillID, version)
+	path := requestconfig.FormatPath("skills/%s/versions/%s", skillID, version)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }

--- a/skillversioncontent.go
+++ b/skillversioncontent.go
@@ -5,7 +5,6 @@ package openai
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"slices"
 
@@ -45,7 +44,7 @@ func (r *SkillVersionContentService) Get(ctx context.Context, skillID string, ve
 		err = errors.New("missing required version parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("skills/%s/versions/%s/content", skillID, version)
+	path := requestconfig.FormatPath("skills/%s/versions/%s/content", skillID, version)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }

--- a/upload.go
+++ b/upload.go
@@ -5,7 +5,6 @@ package openai
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"slices"
 
@@ -80,7 +79,7 @@ func (r *UploadService) Cancel(ctx context.Context, uploadID string, opts ...opt
 		err = errors.New("missing required upload_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("uploads/%s/cancel", uploadID)
+	path := requestconfig.FormatPath("uploads/%s/cancel", uploadID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, nil, &res, opts...)
 	return res, err
 }
@@ -107,7 +106,7 @@ func (r *UploadService) Complete(ctx context.Context, uploadID string, body Uplo
 		err = errors.New("missing required upload_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("uploads/%s/complete", uploadID)
+	path := requestconfig.FormatPath("uploads/%s/complete", uploadID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }

--- a/uploadpart.go
+++ b/uploadpart.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -59,7 +58,7 @@ func (r *UploadPartService) New(ctx context.Context, uploadID string, body Uploa
 		err = errors.New("missing required upload_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("uploads/%s/parts", uploadID)
+	path := requestconfig.FormatPath("uploads/%s/parts", uploadID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }

--- a/vectorstore.go
+++ b/vectorstore.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"slices"
@@ -64,7 +63,7 @@ func (r *VectorStoreService) Get(ctx context.Context, vectorStoreID string, opts
 		err = errors.New("missing required vector_store_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("vector_stores/%s", vectorStoreID)
+	path := requestconfig.FormatPath("vector_stores/%s", vectorStoreID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -78,7 +77,7 @@ func (r *VectorStoreService) Update(ctx context.Context, vectorStoreID string, b
 		err = errors.New("missing required vector_store_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("vector_stores/%s", vectorStoreID)
+	path := requestconfig.FormatPath("vector_stores/%s", vectorStoreID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -116,7 +115,7 @@ func (r *VectorStoreService) Delete(ctx context.Context, vectorStoreID string, o
 		err = errors.New("missing required vector_store_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("vector_stores/%s", vectorStoreID)
+	path := requestconfig.FormatPath("vector_stores/%s", vectorStoreID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }
@@ -132,7 +131,7 @@ func (r *VectorStoreService) Search(ctx context.Context, vectorStoreID string, b
 		err = errors.New("missing required vector_store_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("vector_stores/%s/search", vectorStoreID)
+	path := requestconfig.FormatPath("vector_stores/%s/search", vectorStoreID)
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodPost, path, body, &res, opts...)
 	if err != nil {
 		return nil, err

--- a/vectorstorefile.go
+++ b/vectorstorefile.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"slices"
@@ -51,7 +50,7 @@ func (r *VectorStoreFileService) New(ctx context.Context, vectorStoreID string, 
 		err = errors.New("missing required vector_store_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("vector_stores/%s/files", vectorStoreID)
+	path := requestconfig.FormatPath("vector_stores/%s/files", vectorStoreID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -108,7 +107,7 @@ func (r *VectorStoreFileService) Get(ctx context.Context, vectorStoreID string, 
 		err = errors.New("missing required file_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("vector_stores/%s/files/%s", vectorStoreID, fileID)
+	path := requestconfig.FormatPath("vector_stores/%s/files/%s", vectorStoreID, fileID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -126,7 +125,7 @@ func (r *VectorStoreFileService) Update(ctx context.Context, vectorStoreID strin
 		err = errors.New("missing required file_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("vector_stores/%s/files/%s", vectorStoreID, fileID)
+	path := requestconfig.FormatPath("vector_stores/%s/files/%s", vectorStoreID, fileID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -141,7 +140,7 @@ func (r *VectorStoreFileService) List(ctx context.Context, vectorStoreID string,
 		err = errors.New("missing required vector_store_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("vector_stores/%s/files", vectorStoreID)
+	path := requestconfig.FormatPath("vector_stores/%s/files", vectorStoreID)
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err
@@ -175,7 +174,7 @@ func (r *VectorStoreFileService) Delete(ctx context.Context, vectorStoreID strin
 		err = errors.New("missing required file_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("vector_stores/%s/files/%s", vectorStoreID, fileID)
+	path := requestconfig.FormatPath("vector_stores/%s/files/%s", vectorStoreID, fileID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }
@@ -194,7 +193,7 @@ func (r *VectorStoreFileService) Content(ctx context.Context, vectorStoreID stri
 		err = errors.New("missing required file_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("vector_stores/%s/files/%s/content", vectorStoreID, fileID)
+	path := requestconfig.FormatPath("vector_stores/%s/files/%s/content", vectorStoreID, fileID)
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, nil, &res, opts...)
 	if err != nil {
 		return nil, err

--- a/vectorstorefilebatch.go
+++ b/vectorstorefilebatch.go
@@ -5,7 +5,6 @@ package openai
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"slices"
@@ -49,7 +48,7 @@ func (r *VectorStoreFileBatchService) New(ctx context.Context, vectorStoreID str
 		err = errors.New("missing required vector_store_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("vector_stores/%s/file_batches", vectorStoreID)
+	path := requestconfig.FormatPath("vector_stores/%s/file_batches", vectorStoreID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }
@@ -126,7 +125,7 @@ func (r *VectorStoreFileBatchService) Get(ctx context.Context, vectorStoreID str
 		err = errors.New("missing required batch_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("vector_stores/%s/file_batches/%s", vectorStoreID, batchID)
+	path := requestconfig.FormatPath("vector_stores/%s/file_batches/%s", vectorStoreID, batchID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -145,7 +144,7 @@ func (r *VectorStoreFileBatchService) Cancel(ctx context.Context, vectorStoreID 
 		err = errors.New("missing required batch_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("vector_stores/%s/file_batches/%s/cancel", vectorStoreID, batchID)
+	path := requestconfig.FormatPath("vector_stores/%s/file_batches/%s/cancel", vectorStoreID, batchID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, nil, &res, opts...)
 	return res, err
 }
@@ -164,7 +163,7 @@ func (r *VectorStoreFileBatchService) ListFiles(ctx context.Context, vectorStore
 		err = errors.New("missing required batch_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("vector_stores/%s/file_batches/%s/files", vectorStoreID, batchID)
+	path := requestconfig.FormatPath("vector_stores/%s/file_batches/%s/files", vectorStoreID, batchID)
 	cfg, err := requestconfig.NewRequestConfig(ctx, http.MethodGet, path, query, &res, opts...)
 	if err != nil {
 		return nil, err

--- a/video.go
+++ b/video.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -72,7 +71,7 @@ func (r *VideoService) Get(ctx context.Context, videoID string, opts ...option.R
 		err = errors.New("missing required video_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("videos/%s", videoID)
+	path := requestconfig.FormatPath("videos/%s", videoID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -109,7 +108,7 @@ func (r *VideoService) Delete(ctx context.Context, videoID string, opts ...optio
 		err = errors.New("missing required video_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("videos/%s", videoID)
+	path := requestconfig.FormatPath("videos/%s", videoID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodDelete, path, nil, &res, opts...)
 	return res, err
 }
@@ -134,7 +133,7 @@ func (r *VideoService) DownloadContent(ctx context.Context, videoID string, quer
 		err = errors.New("missing required video_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("videos/%s/content", videoID)
+	path := requestconfig.FormatPath("videos/%s/content", videoID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, query, &res, opts...)
 	return res, err
 }
@@ -166,7 +165,7 @@ func (r *VideoService) GetCharacter(ctx context.Context, characterID string, opt
 		err = errors.New("missing required character_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("videos/characters/%s", characterID)
+	path := requestconfig.FormatPath("videos/characters/%s", characterID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, nil, &res, opts...)
 	return res, err
 }
@@ -179,7 +178,7 @@ func (r *VideoService) Remix(ctx context.Context, videoID string, body VideoRemi
 		err = errors.New("missing required video_id parameter")
 		return nil, err
 	}
-	path := fmt.Sprintf("videos/%s/remix", videoID)
+	path := requestconfig.FormatPath("videos/%s/remix", videoID)
 	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPost, path, body, &res, opts...)
 	return res, err
 }


### PR DESCRIPTION
## Summary
Fix path parameter encoding.

## Validation
- SKIP_MOCK_TESTS=true go test ./...
- ./scripts/lint (existing example compile issue)