### PR TITLE
ci: declare contents:read on create-releases and detect-breaking-changes

### DIFF
--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   release:
     name: release

--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -5,6 +5,9 @@ on:
       - main
       - next
 
+permissions:
+  contents: read
+
 jobs:
   detect_breaking_changes:
     runs-on: 'ubuntu-latest'


### PR DESCRIPTION
Two workflows currently leave the workflow `GITHUB_TOKEN` scope implicit:

- `.github/workflows/create-releases.yml` -- runs `stainless-api/trigger-release-please@v1.4.0` with `STAINLESS_API_KEY` (external secret) and, when a release is created, curls `pkg.go.dev/fetch/...` to warm the Go module proxy. Neither path uses the workflow's `GITHUB_TOKEN`.
- `.github/workflows/detect-breaking-changes.yml` -- runs scripts against the PR base SHA + HEAD to fail on breaking changes. No GitHub API write.

This patch pins both to `permissions: contents: read` at workflow scope, matching the per-job block in `ci.yml` (`contents: read` + `id-token: write` for trusted publishing).

With explicit scope:

- the workflow token can't be widened by a future change to the repo default
- the SLSA / OpenSSF Scorecard `Token-Permissions` check passes for both files
- third-party action exposure (`stainless-api/trigger-release-please`, `actions/setup-go`, `actions/checkout`) is bounded to read

No behavioural change.