### PR TITLE
ci: declare contents:read on detect-breaking-changes workflow

### DIFF
--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -5,6 +5,9 @@ on:
       - main
       - next
 
+permissions:
+  contents: read
+
 jobs:
   detect_breaking_changes:
     runs-on: 'ubuntu-latest'


### PR DESCRIPTION
The `detect_breaking_changes` job currently inherits the repo default token scope. It only runs `actions/checkout` (with `fetch-depth: commits + 1` so it can reach the PR base), `actions/setup-go`, and `./scripts/detect-breaking-changes` against the base SHA. No GitHub API write, no comment-on-PR, no registry push.

Worth declaring even if the repo-default is already read: the in-file block survives any future change to the Settings > Actions > General token-permissions toggle, and the [OpenSSF Scorecard Token-Permissions check](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) counts only per-workflow declarations (the implicit default doesn't move the score).

The defense-in-depth motivation is the [CVE-2025-30066](https://github.com/advisories/GHSA-mrrh-fwg8-r2c3) shape: a compromised third-party action (`actions/setup-go` in this case) runs inside the existing job context and exfiltrates the `GITHUB_TOKEN` via build logs. The blast radius equals the token's scope at issue time; pinning the workflow to `contents: read` bounds it independent of what a YAML author with repo-write access could have done (that's a different attack vector).

Style matches the per-job permission block already declared in `ci.yml` (`contents: read` + `id-token: write` for the stainless-sdks variant). `create-releases.yml` is intentionally left out of this PR because the `stainless-api/trigger-release-please` step there needs broader scope.