### PR TITLE
docs(examples): decode responses stream text

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,9 @@ stream := client.Responses.NewStreaming(ctx, responses.ResponseNewParams{
 
 for stream.Next() {
 	event := stream.Current()
-	print(event.Delta)
+	if data, ok := event.AsAny().(responses.ResponseTextDeltaEvent); ok {
+		print(data.Delta)
+	}
 }
 
 if stream.Err() != nil {

--- a/examples/responses-streaming/main.go
+++ b/examples/responses-streaming/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/responses"
@@ -21,13 +22,14 @@ func main() {
 	var completeText string
 
 	for stream.Next() {
-		data := stream.Current()
-		print(data.Delta)
-		if data.JSON.Text.Valid() {
+		event := stream.Current()
+		switch data := event.AsAny().(type) {
+		case responses.ResponseTextDeltaEvent:
+			print(data.Delta)
+		case responses.ResponseTextDoneEvent:
 			println()
-			println("Finished Content")
+			fmt.Println("Finished content")
 			completeText = data.Text
-			break
 		}
 	}
 


### PR DESCRIPTION
## Summary
- add an example for decoding text from a Responses API stream

## Testing
- Not run (docs/example update from local branch).