### PR TITLE
feat(responses): add shell call command delta stream event

### DIFF
--- a/responses/api.md
+++ b/responses/api.md
@@ -187,6 +187,7 @@ Response Types:
 - <a href="https://pkg.go.dev/github.com/openai/openai-go/v3/responses">responses</a>.<a href="https://pkg.go.dev/github.com/openai/openai-go/v3/responses#ResponseReasoningTextDoneEvent">ResponseReasoningTextDoneEvent</a>
 - <a href="https://pkg.go.dev/github.com/openai/openai-go/v3/responses">responses</a>.<a href="https://pkg.go.dev/github.com/openai/openai-go/v3/responses#ResponseRefusalDeltaEvent">ResponseRefusalDeltaEvent</a>
 - <a href="https://pkg.go.dev/github.com/openai/openai-go/v3/responses">responses</a>.<a href="https://pkg.go.dev/github.com/openai/openai-go/v3/responses#ResponseRefusalDoneEvent">ResponseRefusalDoneEvent</a>
+- <a href="https://pkg.go.dev/github.com/openai/openai-go/v3/responses">responses</a>.<a href="https://pkg.go.dev/github.com/openai/openai-go/v3/responses#ResponseShellCallCommandDeltaEvent">ResponseShellCallCommandDeltaEvent</a>
 - <a href="https://pkg.go.dev/github.com/openai/openai-go/v3/responses">responses</a>.<a href="https://pkg.go.dev/github.com/openai/openai-go/v3/responses#ResponseStatus">ResponseStatus</a>
 - <a href="https://pkg.go.dev/github.com/openai/openai-go/v3/responses">responses</a>.<a href="https://pkg.go.dev/github.com/openai/openai-go/v3/responses#ResponseStreamEventUnion">ResponseStreamEventUnion</a>
 - <a href="https://pkg.go.dev/github.com/openai/openai-go/v3/responses">responses</a>.<a href="https://pkg.go.dev/github.com/openai/openai-go/v3/responses#ResponseTextConfig">ResponseTextConfig</a>

--- a/responses/response.go
+++ b/responses/response.go
@@ -17126,6 +17126,36 @@ func (r *ResponseRefusalDoneEvent) UnmarshalJSON(data []byte) error {
 	return apijson.UnmarshalRoot(data, r)
 }
 
+// Emitted when there is a partial shell command response.
+type ResponseShellCallCommandDeltaEvent struct {
+	// The command delta that is added.
+	Delta string `json:"delta" api:"required"`
+	// The ID of the output item that the command delta is added to.
+	ItemID string `json:"item_id" api:"required"`
+	// The index of the output item that the command delta is added to.
+	OutputIndex int64 `json:"output_index" api:"required"`
+	// The sequence number of this event.
+	SequenceNumber int64 `json:"sequence_number" api:"required"`
+	// The type of the event. Always `response.shell_call_command.delta`.
+	Type constant.ResponseShellCallCommandDelta `json:"type" default:"response.shell_call_command.delta"`
+	// JSON contains metadata for fields, check presence with [respjson.Field.Valid].
+	JSON struct {
+		Delta          respjson.Field
+		ItemID         respjson.Field
+		OutputIndex    respjson.Field
+		SequenceNumber respjson.Field
+		Type           respjson.Field
+		ExtraFields    map[string]respjson.Field
+		raw            string
+	} `json:"-"`
+}
+
+// Returns the unmodified JSON received from the API
+func (r ResponseShellCallCommandDeltaEvent) RawJSON() string { return r.JSON.raw }
+func (r *ResponseShellCallCommandDeltaEvent) UnmarshalJSON(data []byte) error {
+	return apijson.UnmarshalRoot(data, r)
+}
+
 // The status of the response generation. One of `completed`, `failed`,
 // `in_progress`, `cancelled`, `queued`, or `incomplete`.
 type ResponseStatus string
@@ -17160,7 +17190,8 @@ const (
 // [ResponseReasoningSummaryTextDeltaEvent],
 // [ResponseReasoningSummaryTextDoneEvent], [ResponseReasoningTextDeltaEvent],
 // [ResponseReasoningTextDoneEvent], [ResponseRefusalDeltaEvent],
-// [ResponseRefusalDoneEvent], [ResponseTextDeltaEvent], [ResponseTextDoneEvent],
+// [ResponseRefusalDoneEvent], [ResponseShellCallCommandDeltaEvent],
+// [ResponseTextDeltaEvent], [ResponseTextDoneEvent],
 // [ResponseWebSearchCallCompletedEvent], [ResponseWebSearchCallInProgressEvent],
 // [ResponseWebSearchCallSearchingEvent], [ResponseImageGenCallCompletedEvent],
 // [ResponseImageGenCallGeneratingEvent], [ResponseImageGenCallInProgressEvent],
@@ -17195,7 +17226,8 @@ type ResponseStreamEventUnion struct {
 	// "response.reasoning_summary_part.done", "response.reasoning_summary_text.delta",
 	// "response.reasoning_summary_text.done", "response.reasoning_text.delta",
 	// "response.reasoning_text.done", "response.refusal.delta",
-	// "response.refusal.done", "response.output_text.delta",
+	// "response.refusal.done", "response.shell_call_command.delta",
+	// "response.output_text.delta",
 	// "response.output_text.done", "response.web_search_call.completed",
 	// "response.web_search_call.in_progress", "response.web_search_call.searching",
 	// "response.image_generation_call.completed",
@@ -17313,6 +17345,7 @@ func (ResponseReasoningTextDeltaEvent) implResponseStreamEventUnion()           
 func (ResponseReasoningTextDoneEvent) implResponseStreamEventUnion()               {}
 func (ResponseRefusalDeltaEvent) implResponseStreamEventUnion()                    {}
 func (ResponseRefusalDoneEvent) implResponseStreamEventUnion()                     {}
+func (ResponseShellCallCommandDeltaEvent) implResponseStreamEventUnion()           {}
 func (ResponseTextDeltaEvent) implResponseStreamEventUnion()                       {}
 func (ResponseTextDoneEvent) implResponseStreamEventUnion()                        {}
 func (ResponseWebSearchCallCompletedEvent) implResponseStreamEventUnion()          {}
@@ -17370,6 +17403,7 @@ func (ResponseCustomToolCallInputDoneEvent) implResponseStreamEventUnion()      
 //	case responses.ResponseReasoningTextDoneEvent:
 //	case responses.ResponseRefusalDeltaEvent:
 //	case responses.ResponseRefusalDoneEvent:
+//	case responses.ResponseShellCallCommandDeltaEvent:
 //	case responses.ResponseTextDeltaEvent:
 //	case responses.ResponseTextDoneEvent:
 //	case responses.ResponseWebSearchCallCompletedEvent:
@@ -17460,6 +17494,8 @@ func (u ResponseStreamEventUnion) AsAny() anyResponseStreamEvent {
 		return u.AsResponseRefusalDelta()
 	case "response.refusal.done":
 		return u.AsResponseRefusalDone()
+	case "response.shell_call_command.delta":
+		return u.AsResponseShellCallCommandDelta()
 	case "response.output_text.delta":
 		return u.AsResponseOutputTextDelta()
 	case "response.output_text.done":
@@ -17662,6 +17698,11 @@ func (u ResponseStreamEventUnion) AsResponseRefusalDelta() (v ResponseRefusalDel
 }
 
 func (u ResponseStreamEventUnion) AsResponseRefusalDone() (v ResponseRefusalDoneEvent) {
+	apijson.UnmarshalRoot(json.RawMessage(u.JSON.raw), &v)
+	return
+}
+
+func (u ResponseStreamEventUnion) AsResponseShellCallCommandDelta() (v ResponseShellCallCommandDeltaEvent) {
 	apijson.UnmarshalRoot(json.RawMessage(u.JSON.raw), &v)
 	return
 }

--- a/responses/response_stream_event_test.go
+++ b/responses/response_stream_event_test.go
@@ -1,0 +1,40 @@
+package responses_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/openai/openai-go/v3/responses"
+)
+
+func TestResponseStreamEventShellCallCommandDelta(t *testing.T) {
+	raw := []byte(`{
+		"type": "response.shell_call_command.delta",
+		"delta": "echo hello",
+		"item_id": "rs_123",
+		"output_index": 0,
+		"sequence_number": 1
+	}`)
+
+	var event responses.ResponseStreamEventUnion
+	if err := json.Unmarshal(raw, &event); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	variant, ok := event.AsAny().(responses.ResponseShellCallCommandDeltaEvent)
+	if !ok {
+		t.Fatalf("AsAny() = %T, want ResponseShellCallCommandDeltaEvent", event.AsAny())
+	}
+	if variant.Delta != "echo hello" {
+		t.Fatalf("Delta = %q, want %q", variant.Delta, "echo hello")
+	}
+	if variant.ItemID != "rs_123" {
+		t.Fatalf("ItemID = %q, want %q", variant.ItemID, "rs_123")
+	}
+	if variant.OutputIndex != 0 {
+		t.Fatalf("OutputIndex = %d, want 0", variant.OutputIndex)
+	}
+	if variant.SequenceNumber != 1 {
+		t.Fatalf("SequenceNumber = %d, want 1", variant.SequenceNumber)
+	}
+}

--- a/shared/constant/constants.go
+++ b/shared/constant/constants.go
@@ -284,6 +284,7 @@ type ResponseReasoningTextDelta string                       // Always "response
 type ResponseReasoningTextDone string                        // Always "response.reasoning_text.done"
 type ResponseRefusalDelta string                             // Always "response.refusal.delta"
 type ResponseRefusalDone string                              // Always "response.refusal.done"
+type ResponseShellCallCommandDelta string                    // Always "response.shell_call_command.delta"
 type ResponseWebSearchCallCompleted string                   // Always "response.web_search_call.completed"
 type ResponseWebSearchCallInProgress string                  // Always "response.web_search_call.in_progress"
 type ResponseWebSearchCallSearching string                   // Always "response.web_search_call.searching"
@@ -829,6 +830,9 @@ func (c ResponseReasoningTextDone) Default() ResponseReasoningTextDone {
 }
 func (c ResponseRefusalDelta) Default() ResponseRefusalDelta { return "response.refusal.delta" }
 func (c ResponseRefusalDone) Default() ResponseRefusalDone   { return "response.refusal.done" }
+func (c ResponseShellCallCommandDelta) Default() ResponseShellCallCommandDelta {
+	return "response.shell_call_command.delta"
+}
 func (c ResponseWebSearchCallCompleted) Default() ResponseWebSearchCallCompleted {
 	return "response.web_search_call.completed"
 }
@@ -1252,6 +1256,7 @@ func (c ResponseReasoningTextDelta) MarshalJSON() ([]byte, error)         { retu
 func (c ResponseReasoningTextDone) MarshalJSON() ([]byte, error)          { return marshalString(c) }
 func (c ResponseRefusalDelta) MarshalJSON() ([]byte, error)               { return marshalString(c) }
 func (c ResponseRefusalDone) MarshalJSON() ([]byte, error)                { return marshalString(c) }
+func (c ResponseShellCallCommandDelta) MarshalJSON() ([]byte, error)      { return marshalString(c) }
 func (c ResponseWebSearchCallCompleted) MarshalJSON() ([]byte, error)     { return marshalString(c) }
 func (c ResponseWebSearchCallInProgress) MarshalJSON() ([]byte, error)    { return marshalString(c) }
 func (c ResponseWebSearchCallSearching) MarshalJSON() ([]byte, error)     { return marshalString(c) }


### PR DESCRIPTION
## Summary
- add ResponseShellCallCommandDeltaEvent for response.shell_call_command.delta stream events
- wire the event into ResponseStreamEventUnion.AsAny and constants
- add a unit test covering JSON decoding into the typed variant

Fixes #662

## Testing
- go test ./responses -run TestResponseStreamEventShellCallCommandDelta -count=1
- go test ./... -run TestResponseStreamEventShellCallCommandDelta -count=1

Note: go test ./responses without a running localhost:4010 test server fails in existing server-backed tests with connection refused.