### PR TITLE
feat(responses): add function tool helper with description

### DIFF
--- a/responses/response.go
+++ b/responses/response.go
@@ -19419,6 +19419,15 @@ func ToolParamOfFunction(name string, parameters map[string]any, strict bool) To
 	return ToolUnionParam{OfFunction: &function}
 }
 
+func ToolParamOfFunctionWithDescription(name string, description string, parameters map[string]any, strict bool) ToolUnionParam {
+	var function FunctionToolParam
+	function.Name = name
+	function.Description = param.NewOpt(description)
+	function.Parameters = parameters
+	function.Strict = param.NewOpt(strict)
+	return ToolUnionParam{OfFunction: &function}
+}
+
 func ToolParamOfFileSearch(vectorStoreIDs []string) ToolUnionParam {
 	var fileSearch FileSearchToolParam
 	fileSearch.VectorStoreIDs = vectorStoreIDs

--- a/responses/tool_param_test.go
+++ b/responses/tool_param_test.go
@@ -1,0 +1,37 @@
+package responses_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/openai/openai-go/v3/responses"
+)
+
+func TestToolParamOfFunctionWithDescription(t *testing.T) {
+	tool := responses.ToolParamOfFunctionWithDescription(
+		"search_docs",
+		"Search the documentation",
+		map[string]any{"type": "object"},
+		true,
+	)
+
+	data, err := json.Marshal(tool)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(data, &body); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	if body["name"] != "search_docs" {
+		t.Fatalf("name = %v, want %q", body["name"], "search_docs")
+	}
+	if body["description"] != "Search the documentation" {
+		t.Fatalf("description = %v, want %q", body["description"], "Search the documentation")
+	}
+	if body["strict"] != true {
+		t.Fatalf("strict = %v, want true", body["strict"])
+	}
+}


### PR DESCRIPTION
## Summary
- add ToolParamOfFunctionWithDescription for constructing function tools with descriptions
- preserve the existing ToolParamOfFunction signature for backwards compatibility
- add a marshal regression test covering the description field

Fixes #583

## Testing
- go test ./responses -run TestToolParamOfFunctionWithDescription -count=1
- go test ./... -run TestToolParamOfFunctionWithDescription -count=1