### PR TITLE
fix(chat): omit empty streaming delta role

### DIFF
--- a/chatcompletion.go
+++ b/chatcompletion.go
@@ -758,7 +758,7 @@ type ChatCompletionChunkChoiceDelta struct {
 	// The role of the author of this message.
 	//
 	// Any of "developer", "system", "user", "assistant", "tool".
-	Role      string                                   `json:"role"`
+	Role      string                                   `json:"role,omitempty" api:"nullable"`
 	ToolCalls []ChatCompletionChunkChoiceDeltaToolCall `json:"tool_calls"`
 	// JSON contains metadata for fields, check presence with [respjson.Field.Valid].
 	JSON struct {

--- a/chatcompletion_test.go
+++ b/chatcompletion_test.go
@@ -4,8 +4,10 @@ package openai_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/openai/openai-go/v3"
@@ -13,6 +15,19 @@ import (
 	"github.com/openai/openai-go/v3/option"
 	"github.com/openai/openai-go/v3/shared"
 )
+
+func TestChatCompletionChunkChoiceDeltaMarshalOmitsEmptyRole(t *testing.T) {
+	data, err := json.Marshal(openai.ChatCompletionChunkChoiceDelta{
+		Content: "Hello",
+	})
+	if err != nil {
+		t.Fatalf("json.Marshal returned error: %s", err)
+	}
+
+	if strings.Contains(string(data), `"role"`) {
+		t.Fatalf("expected empty role to be omitted, got %s", data)
+	}
+}
 
 func TestChatCompletionNewWithOptionalParams(t *testing.T) {
 	baseURL := "http://localhost:4010"


### PR DESCRIPTION
Fixes #564.
Fixes #589.

Summary:
- omit the chat completion streaming delta role when it is the zero value during JSON marshaling
- mark the role field as nullable in SDK metadata
- add regression coverage for marshaling content-only stream deltas

Tests:
- go test . -run TestChatCompletionChunkChoiceDeltaMarshalOmitsEmptyRole -count=1