### PR TITLE
fix(azure): strip model from image generation body

### DIFF
--- a/azure/azure.go
+++ b/azure/azure.go
@@ -33,6 +33,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/openai/openai-go/v3/internal/requestconfig"
 	"github.com/openai/openai-go/v3/option"
+	"github.com/tidwall/sjson"
 )
 
 // WithEndpoint configures this client to connect to an Azure OpenAI endpoint.
@@ -208,7 +209,7 @@ func getJSONRoute(req *http.Request) (string, error) {
 	}
 
 	// make sure we restore the body so it can be used in later middlewares.
-	req.Body = io.NopCloser(bytes.NewReader(jsonBytes))
+	setRequestBody(req, jsonBytes)
 
 	var v *struct {
 		Model string `json:"model"`
@@ -218,8 +219,24 @@ func getJSONRoute(req *http.Request) (string, error) {
 		return "", err
 	}
 
+	if req.URL.Path == "/images/generations" {
+		body, err := sjson.DeleteBytes(jsonBytes, "model")
+		if err != nil {
+			return "", err
+		}
+		setRequestBody(req, body)
+	}
+
 	// Convert path from /chat/completions to /openai/deployments/{deployment-id}/chat/completions
 	return requestconfig.FormatPath("/openai/deployments/%s", v.Model) + req.URL.EscapedPath(), nil
+}
+
+func setRequestBody(req *http.Request, body []byte) {
+	req.ContentLength = int64(len(body))
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(body)), nil
+	}
+	req.Body, _ = req.GetBody()
 }
 
 func getMultipartRoute(req *http.Request) (string, error) {

--- a/azure/azure_test.go
+++ b/azure/azure_test.go
@@ -3,6 +3,7 @@ package azure
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -46,6 +47,44 @@ func TestJSONRoute(t *testing.T) {
 
 	if replacementPath != "/openai/deployments/arbitraryDeployment/chat/completions" {
 		t.Fatalf("replacementpath didn't match: %s", replacementPath)
+	}
+}
+
+func TestImageGenerationJSONRouteStripsModelFromBody(t *testing.T) {
+	req, err := http.NewRequest(
+		"POST",
+		"/images/generations",
+		bytes.NewReader([]byte(`{"model":"azure-image-deployment","prompt":"a cat"}`)),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	replacementPath, err := getReplacementPathWithDeployment(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if replacementPath != "/openai/deployments/azure-image-deployment/images/generations" {
+		t.Fatalf("replacementpath didn't match: %s", replacementPath)
+	}
+
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := payload["model"]; ok {
+		t.Fatalf("expected model to be removed from image generation body, got %s", body)
+	}
+	if payload["prompt"] != "a cat" {
+		t.Fatalf("expected prompt to remain, got %s", body)
+	}
+	if req.ContentLength != int64(len(body)) {
+		t.Fatalf("ContentLength: got %d, expected %d", req.ContentLength, len(body))
 	}
 }
 


### PR DESCRIPTION
Fixes #641.

Summary:
- keep using `model` to derive the Azure deployment path for `/images/generations`
- remove `model` from the image generation JSON body before sending the request to Azure
- restore request body metadata after Azure middleware reads or mutates JSON bodies
- add regression coverage for Azure image generation routing/body shaping

Tests:
- `go test ./azure -count=1`