### PR TITLE
fix(responses): add top-level ResponseNewParams alias

### DIFF
--- a/response_aliases.go
+++ b/response_aliases.go
@@ -1,0 +1,6 @@
+package openai
+
+import "github.com/openai/openai-go/v3/responses"
+
+// ResponseNewParams is an alias for [responses.ResponseNewParams].
+type ResponseNewParams = responses.ResponseNewParams

--- a/response_aliases_test.go
+++ b/response_aliases_test.go
@@ -1,0 +1,22 @@
+package openai_test
+
+import (
+	"testing"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/responses"
+)
+
+func TestResponseNewParamsTopLevelAlias(t *testing.T) {
+	params := openai.ResponseNewParams{
+		Model: "gpt-5.2",
+		Input: responses.ResponseNewParamsInputUnion{
+			OfString: openai.String("Say this is a test"),
+		},
+	}
+	var _ responses.ResponseNewParams = params
+
+	if !params.Input.OfString.Valid() || params.Input.OfString.Or("") != "Say this is a test" {
+		t.Fatalf("expected input string to round trip, got %#v", params.Input.OfString)
+	}
+}


### PR DESCRIPTION
Fixes #607.

## Summary
- add a root-package alias for `responses.ResponseNewParams` so examples using `openai.ResponseNewParams` compile
- add a regression test covering the issue sample shape without making a network call

## Tests
- `go test . -run TestResponseNewParamsTopLevelAlias -count=1`
- `go test . -count=1` (fails locally because the existing generated integration tests require a localhost:4010 mock server)