### PR TITLE
responses: expose image generation output metadata

### DIFF
--- a/conversations/item.go
+++ b/conversations/item.go
@@ -683,10 +683,22 @@ func (r *ConversationItemUnionTools) UnmarshalJSON(data []byte) error {
 
 // An image generation request made by the model.
 type ConversationItemImageGenerationCall struct {
+	// The action that produced the generated image.
+	Action string `json:"action"`
+	// The background setting for the generated image.
+	Background string `json:"background"`
 	// The unique ID of the image generation call.
 	ID string `json:"id" api:"required"`
+	// The output format of the generated image.
+	OutputFormat string `json:"output_format"`
+	// The quality setting for the generated image.
+	Quality string `json:"quality"`
 	// The generated image encoded in base64.
 	Result string `json:"result" api:"required"`
+	// The revised prompt used to generate the image.
+	RevisedPrompt string `json:"revised_prompt"`
+	// The size of the generated image.
+	Size string `json:"size"`
 	// The status of the image generation call.
 	//
 	// Any of "in_progress", "completed", "generating", "failed".
@@ -695,12 +707,18 @@ type ConversationItemImageGenerationCall struct {
 	Type constant.ImageGenerationCall `json:"type" default:"image_generation_call"`
 	// JSON contains metadata for fields, check presence with [respjson.Field.Valid].
 	JSON struct {
-		ID          respjson.Field
-		Result      respjson.Field
-		Status      respjson.Field
-		Type        respjson.Field
-		ExtraFields map[string]respjson.Field
-		raw         string
+		Action        respjson.Field
+		Background    respjson.Field
+		ID            respjson.Field
+		OutputFormat  respjson.Field
+		Quality       respjson.Field
+		Result        respjson.Field
+		RevisedPrompt respjson.Field
+		Size          respjson.Field
+		Status        respjson.Field
+		Type          respjson.Field
+		ExtraFields   map[string]respjson.Field
+		raw           string
 	} `json:"-"`
 }
 

--- a/responses/image_generation_call_test.go
+++ b/responses/image_generation_call_test.go
@@ -1,0 +1,48 @@
+package responses_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/openai/openai-go/v3/responses"
+)
+
+func TestResponseOutputItemImageGenerationCallFields(t *testing.T) {
+	const payload = `{
+		"id": "ig_123",
+		"type": "image_generation_call",
+		"status": "completed",
+		"result": "iVBORw0KGgo=",
+		"action": "generate",
+		"background": "opaque",
+		"output_format": "png",
+		"quality": "high",
+		"revised_prompt": "Draw a small red fox.",
+		"size": "1024x1024"
+	}`
+
+	var item responses.ResponseOutputItemUnion
+	if err := json.Unmarshal([]byte(payload), &item); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	image := item.AsImageGenerationCall()
+	if image.Action != "generate" {
+		t.Errorf("Action = %q, want %q", image.Action, "generate")
+	}
+	if image.Background != "opaque" {
+		t.Errorf("Background = %q, want %q", image.Background, "opaque")
+	}
+	if image.OutputFormat != "png" {
+		t.Errorf("OutputFormat = %q, want %q", image.OutputFormat, "png")
+	}
+	if image.Quality != "high" {
+		t.Errorf("Quality = %q, want %q", image.Quality, "high")
+	}
+	if image.RevisedPrompt != "Draw a small red fox." {
+		t.Errorf("RevisedPrompt = %q, want %q", image.RevisedPrompt, "Draw a small red fox.")
+	}
+	if image.Size != "1024x1024" {
+		t.Errorf("Size = %q, want %q", image.Size, "1024x1024")
+	}
+}

--- a/responses/response.go
+++ b/responses/response.go
@@ -10539,10 +10539,22 @@ func (r *ResponseInputItemToolSearchCall) UnmarshalJSON(data []byte) error {
 
 // An image generation request made by the model.
 type ResponseInputItemImageGenerationCall struct {
+	// The action that produced the generated image.
+	Action string `json:"action"`
+	// The background setting for the generated image.
+	Background string `json:"background"`
 	// The unique ID of the image generation call.
 	ID string `json:"id" api:"required"`
+	// The output format of the generated image.
+	OutputFormat string `json:"output_format"`
+	// The quality setting for the generated image.
+	Quality string `json:"quality"`
 	// The generated image encoded in base64.
 	Result string `json:"result" api:"required"`
+	// The revised prompt used to generate the image.
+	RevisedPrompt string `json:"revised_prompt"`
+	// The size of the generated image.
+	Size string `json:"size"`
 	// The status of the image generation call.
 	//
 	// Any of "in_progress", "completed", "generating", "failed".
@@ -10551,12 +10563,18 @@ type ResponseInputItemImageGenerationCall struct {
 	Type constant.ImageGenerationCall `json:"type" default:"image_generation_call"`
 	// JSON contains metadata for fields, check presence with [respjson.Field.Valid].
 	JSON struct {
-		ID          respjson.Field
-		Result      respjson.Field
-		Status      respjson.Field
-		Type        respjson.Field
-		ExtraFields map[string]respjson.Field
-		raw         string
+		Action        respjson.Field
+		Background    respjson.Field
+		ID            respjson.Field
+		OutputFormat  respjson.Field
+		Quality       respjson.Field
+		Result        respjson.Field
+		RevisedPrompt respjson.Field
+		Size          respjson.Field
+		Status        respjson.Field
+		Type          respjson.Field
+		ExtraFields   map[string]respjson.Field
+		raw           string
 	} `json:"-"`
 }
 
@@ -14091,10 +14109,22 @@ func (r *ResponseItemUnionTools) UnmarshalJSON(data []byte) error {
 
 // An image generation request made by the model.
 type ResponseItemImageGenerationCall struct {
+	// The action that produced the generated image.
+	Action string `json:"action"`
+	// The background setting for the generated image.
+	Background string `json:"background"`
 	// The unique ID of the image generation call.
 	ID string `json:"id" api:"required"`
+	// The output format of the generated image.
+	OutputFormat string `json:"output_format"`
+	// The quality setting for the generated image.
+	Quality string `json:"quality"`
 	// The generated image encoded in base64.
 	Result string `json:"result" api:"required"`
+	// The revised prompt used to generate the image.
+	RevisedPrompt string `json:"revised_prompt"`
+	// The size of the generated image.
+	Size string `json:"size"`
 	// The status of the image generation call.
 	//
 	// Any of "in_progress", "completed", "generating", "failed".
@@ -14103,12 +14133,18 @@ type ResponseItemImageGenerationCall struct {
 	Type constant.ImageGenerationCall `json:"type" default:"image_generation_call"`
 	// JSON contains metadata for fields, check presence with [respjson.Field.Valid].
 	JSON struct {
-		ID          respjson.Field
-		Result      respjson.Field
-		Status      respjson.Field
-		Type        respjson.Field
-		ExtraFields map[string]respjson.Field
-		raw         string
+		Action        respjson.Field
+		Background    respjson.Field
+		ID            respjson.Field
+		OutputFormat  respjson.Field
+		Quality       respjson.Field
+		Result        respjson.Field
+		RevisedPrompt respjson.Field
+		Size          respjson.Field
+		Status        respjson.Field
+		Type          respjson.Field
+		ExtraFields   map[string]respjson.Field
+		raw           string
 	} `json:"-"`
 }
 
@@ -15166,10 +15202,22 @@ func (r *ResponseOutputItemUnionTools) UnmarshalJSON(data []byte) error {
 
 // An image generation request made by the model.
 type ResponseOutputItemImageGenerationCall struct {
+	// The action that produced the generated image.
+	Action string `json:"action"`
+	// The background setting for the generated image.
+	Background string `json:"background"`
 	// The unique ID of the image generation call.
 	ID string `json:"id" api:"required"`
+	// The output format of the generated image.
+	OutputFormat string `json:"output_format"`
+	// The quality setting for the generated image.
+	Quality string `json:"quality"`
 	// The generated image encoded in base64.
 	Result string `json:"result" api:"required"`
+	// The revised prompt used to generate the image.
+	RevisedPrompt string `json:"revised_prompt"`
+	// The size of the generated image.
+	Size string `json:"size"`
 	// The status of the image generation call.
 	//
 	// Any of "in_progress", "completed", "generating", "failed".
@@ -15178,12 +15226,18 @@ type ResponseOutputItemImageGenerationCall struct {
 	Type constant.ImageGenerationCall `json:"type" default:"image_generation_call"`
 	// JSON contains metadata for fields, check presence with [respjson.Field.Valid].
 	JSON struct {
-		ID          respjson.Field
-		Result      respjson.Field
-		Status      respjson.Field
-		Type        respjson.Field
-		ExtraFields map[string]respjson.Field
-		raw         string
+		Action        respjson.Field
+		Background    respjson.Field
+		ID            respjson.Field
+		OutputFormat  respjson.Field
+		Quality       respjson.Field
+		Result        respjson.Field
+		RevisedPrompt respjson.Field
+		Size          respjson.Field
+		Status        respjson.Field
+		Type          respjson.Field
+		ExtraFields   map[string]respjson.Field
+		raw           string
 	} `json:"-"`
 }
 


### PR DESCRIPTION
## Summary
- expose `action`, `background`, `output_format`, `quality`, `revised_prompt`, and `size` on image-generation response variants
- keep response input-item, item, output-item, and conversation-item representations consistent
- add a decode regression through `ResponseOutputItemUnion.AsImageGenerationCall()`

The Responses API image-generation guide documents these fields in emitted `image_generation_call` output items: https://developers.openai.com/api/docs/guides/tools-image-generation

Fixes #675.

## Validation
- `git diff --check`
- `go test ./responses -run '^TestResponseOutputItemImageGenerationCallFields$' -count=1`

## Remote Linux validation
- `git diff --check`
- `./scripts/lint`
- `./scripts/bootstrap`
- `./scripts/test`