### PR TITLE
fix: prevent retry delay overflow

### DIFF
--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"math"
 	"math/rand"
 	"mime"
 	"net/http"
@@ -402,7 +401,10 @@ func retryDelay(res *http.Response, retryCount int) time.Duration {
 	}
 
 	maxDelay := 8 * time.Second
-	delay := time.Duration(0.5 * float64(time.Second) * math.Pow(2, float64(retryCount)))
+	delay := 500 * time.Millisecond
+	for i := 0; i < retryCount && delay < maxDelay; i++ {
+		delay *= 2
+	}
 	if delay > maxDelay {
 		delay = maxDelay
 	}

--- a/internal/requestconfig/requestconfig_test.go
+++ b/internal/requestconfig/requestconfig_test.go
@@ -1,6 +1,20 @@
 package requestconfig
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
+
+func TestRetryDelayDoesNotOverflowForLargeRetryCount(t *testing.T) {
+	delay := retryDelay(nil, 100)
+
+	if delay <= 0 {
+		t.Fatalf("retryDelay() = %s, want positive duration", delay)
+	}
+	if delay > 8*time.Second {
+		t.Fatalf("retryDelay() = %s, want no more than 8s", delay)
+	}
+}
 
 func TestFormatPathEscapesPathParams(t *testing.T) {
 	tests := map[string]struct {


### PR DESCRIPTION
## Summary
- Prevent retry backoff from overflowing `time.Duration` for large retry counts.
- Replace the floating-point exponential calculation with bounded duration doubling.
- Add a regression test covering large retry counts so jitter never receives an invalid bound.

Fixes #489

## Test plan
- `go test ./internal/requestconfig -run 'TestRetryDelay' -count=1`
- `go test ./internal/requestconfig -count=1`
