### PR TITLE
fix: preserve azure endpoint path prefixes

### DIFF
--- a/azure/azure.go
+++ b/azure/azure.go
@@ -54,17 +54,34 @@ func WithEndpoint(endpoint string, apiVersion string) option.RequestOption {
 		endpoint += "/"
 	}
 
+	endpointURL, _ := url.Parse(endpoint)
+	endpointPathPrefix := strings.TrimRight(endpointURL.EscapedPath(), "/")
+
 	withQueryAdd := option.WithQueryAdd("api-version", apiVersion)
 	withEndpoint := option.WithBaseURL(endpoint)
 
 	withModelMiddleware := option.WithMiddleware(func(r *http.Request, mn option.MiddlewareNext) (*http.Response, error) {
+		pathWithoutEndpointPrefix := strings.TrimPrefix(r.URL.EscapedPath(), endpointPathPrefix)
+		if pathWithoutEndpointPrefix == "" {
+			pathWithoutEndpointPrefix = "/"
+		}
+
+		originalPath := r.URL.Path
+		originalRawPath := r.URL.RawPath
+		if err := setEscapedPath(r.URL, pathWithoutEndpointPrefix); err != nil {
+			return nil, err
+		}
+
 		replacementPath, err := getReplacementPathWithDeployment(r)
+
+		r.URL.Path = originalPath
+		r.URL.RawPath = originalRawPath
 
 		if err != nil {
 			return nil, err
 		}
 
-		if err := setEscapedPath(r.URL, replacementPath); err != nil {
+		if err := setEscapedPath(r.URL, endpointPathPrefix+replacementPath); err != nil {
 			return nil, err
 		}
 		return mn(r)

--- a/azure/azure_test.go
+++ b/azure/azure_test.go
@@ -242,6 +242,52 @@ func TestWithEndpointPreservesEscapedPathParams(t *testing.T) {
 	}
 }
 
+func TestWithEndpointPreservesBaseURLPathPrefix(t *testing.T) {
+	var captured *http.Request
+	client := openai.NewClient(
+		WithEndpoint("https://my-resource.openai.azure.com/apim-suffix", "2024-10-21"),
+		WithAPIKey("sk-test"),
+		option.WithHTTPClient(&http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				captured = req
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header: http.Header{
+						"Content-Type": []string{"application/json"},
+					},
+					Body: io.NopCloser(strings.NewReader(`{
+						"id": "chatcmpl_dummy",
+						"object": "chat.completion",
+						"created": 0,
+						"model": "deployment-name",
+						"choices": []
+					}`)),
+					Request: req,
+				}, nil
+			}),
+		}),
+	)
+
+	_, err := client.Chat.Completions.New(context.Background(), openai.ChatCompletionNewParams{
+		Model: openai.ChatModel("deployment-name"),
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			openai.UserMessage("Hello"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("request failed: %s", err)
+	}
+	if captured == nil {
+		t.Fatal("request was not captured")
+	}
+
+	got := captured.URL.String()
+	want := "https://my-resource.openai.azure.com/apim-suffix/openai/deployments/deployment-name/chat/completions?api-version=2024-10-21"
+	if got != want {
+		t.Fatalf("url = %q, want %q", got, want)
+	}
+}
+
 func TestWithEndpointBaseURL(t *testing.T) {
 	tests := map[string]struct {
 		endpoint        string


### PR DESCRIPTION
## Summary
- Preserve path prefixes from Azure endpoints such as `https://host/apim-suffix`.
- Run Azure deployment route rewriting against the request path without the endpoint prefix, then restore the prefix on the final URL.
- Add a regression test covering a prefixed Azure endpoint and the final chat completions URL.

Fixes #239

## Test plan
- `go test ./azure -count=1`
