### PR TITLE
build: Remove scheduled release runs

### DIFF
--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -1,7 +1,5 @@
 name: Create releases
 on:
-  schedule:
-    - cron: '0 5 * * *' # every day at 5am UTC
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary
- remove the daily cron trigger from the Create releases workflow
- keep the push-to-main release path intact

## Why
Release PR merges already trigger this workflow via push to main. Recent scheduled runs did not create releases and mostly add noise / publish-environment queue entries.

## Validation
- inspected the workflow diff
- ran `git diff --check`