### PR TITLE
build: Gate publish after release creation

### DIFF
--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -9,7 +9,8 @@ jobs:
     name: release
     if: github.ref == 'refs/heads/main' && github.repository == 'openai/openai-go'
     runs-on: ubuntu-latest
-    environment: publish
+    outputs:
+      releases_created: ${{ steps.release.outputs.releases_created }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -20,8 +21,17 @@ jobs:
           repo: ${{ github.event.repository.full_name }}
           stainless-api-key: ${{ secrets.STAINLESS_API_KEY }}
 
+  publish:
+    name: publish
+    needs: release
+    if: ${{ needs.release.outputs.releases_created == 'true' }}
+    runs-on: ubuntu-latest
+    environment: publish
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
       - name: Generate godocs
-        if: ${{ steps.release.outputs.releases_created }}
         run: |
           # x-release-please-start-version
           version=$(jq -r '. | to_entries[0] | .value' .release-please-manifest.json)


### PR DESCRIPTION
## Summary
- let the release-please job run on pushes to `main` without entering the protected `publish` environment
- expose `steps.release.outputs.releases_created` as a job output
- move the protected publish environment to a downstream `publish` job that only runs when `releases_created == true`

## Why
The release-please job should be able to check whether a release PR needs to be created or updated on every push to `main`. Only the actual post-release publish work should request the `publish` environment.

This follows the same model as openai/openai-python#3369.

## Validation
- inspected the workflow diff against `origin/main`
- ran `git diff --check`
- parsed `.github/workflows/create-releases.yml` as YAML successfully
- cancelled the waiting non-release run 27024852103