### PR TITLE
[codex] Use CI environment for workflow jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
   build:
     timeout-minutes: 10
     name: build
+    environment: CI
     permissions:
       contents: read
       id-token: write
@@ -49,6 +50,7 @@ jobs:
   lint:
     timeout-minutes: 10
     name: lint
+    environment: CI
     runs-on: ${{ github.repository == 'stainless-sdks/openai-go' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
     if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
 
@@ -68,6 +70,7 @@ jobs:
   test:
     timeout-minutes: 10
     name: test
+    environment: CI
     runs-on: ${{ github.repository == 'stainless-sdks/openai-go' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
     if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
     steps:

--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -9,6 +9,7 @@ jobs:
   detect_breaking_changes:
     runs-on: 'ubuntu-latest'
     name: detect-breaking-changes
+    environment: CI
     if: github.repository == 'openai/openai-go'
     steps:
       - name: Calculate fetch-depth


### PR DESCRIPTION
## Summary
- Add `environment: CI` to CI workflow jobs so environment-scoped secrets and variables, including `OPENAI_API_KEY`, are available to those jobs.
- Add the same environment declaration to the breaking-change detection job that runs as part of PR CI.

## Validation
- `git diff --check`
- Parsed all workflow YAML files with Ruby's YAML loader

## Notes
- The release publish job keeps its existing `publish` environment because it does not consume `OPENAI_API_KEY` and a GitHub Actions job can declare only one environment.