### PR TITLE
fix: ignore empty tool call deltas in accumulator

### DIFF
--- a/streamaccumulator.go
+++ b/streamaccumulator.go
@@ -177,11 +177,9 @@ func (prev *chatCompletionResponseState) update(chunk ChatCompletionChunk) (just
 		new.state = contentResponseState
 	case delta.JSON.Refusal.Valid():
 		new.state = refusalResponseState
-	case delta.JSON.ToolCalls.Valid():
+	case delta.JSON.ToolCalls.Valid() && len(delta.ToolCalls) > 0:
 		new.state = toolResponseState
-		if len(delta.ToolCalls) > 0 {
-			new.index = clampToZero(delta.ToolCalls[0].Index)
-		}
+		new.index = clampToZero(delta.ToolCalls[0].Index)
 	default:
 		new.state = finishedResponseState
 	}

--- a/streamaccumulator_test.go
+++ b/streamaccumulator_test.go
@@ -254,9 +254,48 @@ func TestAccumulatorNegativeToolCallIndex(t *testing.T) {
 
 func TestAccumulatorEmptyToolCallsArray(t *testing.T) {
 	acc := openai.ChatCompletionAccumulator{}
-	chunk := openai.ChatCompletionChunk{}
-	chunk.UnmarshalJSON([]byte(`{"id":"test","choices":[{"index":0,"delta":{"tool_calls":[]}}]}`))
-	acc.AddChunk(chunk)
+	chunkWithEmptyToolCalls := openai.ChatCompletionChunk{}
+	if err := chunkWithEmptyToolCalls.UnmarshalJSON([]byte(`{"id":"test","choices":[{"index":0,"delta":{"tool_calls":[]}}]}`)); err != nil {
+		t.Fatalf("Failed to unmarshal chunk: %v", err)
+	}
+	if !acc.AddChunk(chunkWithEmptyToolCalls) {
+		t.Fatal("AddChunk returned false")
+	}
+
+	finishedChunk := openai.ChatCompletionChunk{}
+	if err := finishedChunk.UnmarshalJSON([]byte(`{"id":"test","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`)); err != nil {
+		t.Fatalf("Failed to unmarshal chunk: %v", err)
+	}
+	if !acc.AddChunk(finishedChunk) {
+		t.Fatal("AddChunk returned false")
+	}
+
+	if toolCall, ok := acc.JustFinishedToolCall(); ok {
+		t.Fatalf("JustFinishedToolCall returned unexpected tool call: %+v", toolCall)
+	}
+}
+
+func TestAccumulatorNullToolCalls(t *testing.T) {
+	acc := openai.ChatCompletionAccumulator{}
+	chunkWithNullToolCalls := openai.ChatCompletionChunk{}
+	if err := chunkWithNullToolCalls.UnmarshalJSON([]byte(`{"id":"test","choices":[{"index":0,"delta":{"tool_calls":null}}]}`)); err != nil {
+		t.Fatalf("Failed to unmarshal chunk: %v", err)
+	}
+	if !acc.AddChunk(chunkWithNullToolCalls) {
+		t.Fatal("AddChunk returned false")
+	}
+
+	finishedChunk := openai.ChatCompletionChunk{}
+	if err := finishedChunk.UnmarshalJSON([]byte(`{"id":"test","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`)); err != nil {
+		t.Fatalf("Failed to unmarshal chunk: %v", err)
+	}
+	if !acc.AddChunk(finishedChunk) {
+		t.Fatal("AddChunk returned false")
+	}
+
+	if toolCall, ok := acc.JustFinishedToolCall(); ok {
+		t.Fatalf("JustFinishedToolCall returned unexpected tool call: %+v", toolCall)
+	}
 }
 
 // manually created on 11/3/2024


### PR DESCRIPTION
## Summary
- treat empty `tool_calls` deltas as a finished response state instead of an active tool-call state
- add regression coverage for empty and null `tool_calls` chunks before a finishing chunk

## Testing
- `go test . -run 'TestAccumulator(EmptyToolCallsArray|NullToolCalls|NegativeToolCallIndex)$'`\n\nFixes #437