### PR TITLE
ci: Harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ on:
       - 'stl-preview-head/**'
       - 'stl-preview-base/**'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     timeout-minutes: 10
@@ -24,13 +27,17 @@ jobs:
     runs-on: ${{ github.repository == 'stainless-sdks/openai-go' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
     if: |-
       github.repository == 'stainless-sdks/openai-go' &&
-      (github.event_name == 'push' || github.event.pull_request.head.repo.fork) && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
+      github.event_name == 'push' &&
+      github.event.head_commit.message != 'codegen metadata'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Get GitHub OIDC Token
         if: |-
           github.repository == 'stainless-sdks/openai-go' &&
+          github.event_name == 'push' &&
           !startsWith(github.ref, 'refs/heads/stl/')
         id: github-oidc
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -40,6 +47,7 @@ jobs:
       - name: Upload tarball
         if: |-
           github.repository == 'stainless-sdks/openai-go' &&
+          github.event_name == 'push' &&
           !startsWith(github.ref, 'refs/heads/stl/')
         env:
           URL: https://pkg.stainless.com/s
@@ -54,6 +62,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Setup go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
@@ -72,6 +82,8 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Setup go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -11,14 +11,12 @@ jobs:
   release:
     name: release
     if: github.ref == 'refs/heads/main' && github.repository == 'openai/openai-go'
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
 
       - uses: stainless-api/trigger-release-please@bb6677c5a04578eec1ccfd9e1913b5b78ed64c61 # v1.4.0
         id: release
@@ -30,13 +28,11 @@ jobs:
     name: publish
     needs: release
     if: ${{ needs.release.outputs.releases_created == 'true' }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     environment: publish
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
 
       - name: Generate godocs
         run: |

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -11,12 +11,14 @@ jobs:
   release:
     name: release
     if: github.ref == 'refs/heads/main' && github.repository == 'openai/openai-go'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: stainless-api/trigger-release-please@bb6677c5a04578eec1ccfd9e1913b5b78ed64c61 # v1.4.0
         id: release
@@ -28,14 +30,16 @@ jobs:
     name: publish
     needs: release
     if: ${{ needs.release.outputs.releases_created == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: publish
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Generate godocs
         run: |
           # x-release-please-start-version
-          version=$(jq -r '. | to_entries[0] | .value' .release-please-manifest.json)
-          curl -X POST https://pkg.go.dev/fetch/github.com/openai/openai-go/v2@v${version}
+          version="$(jq -r '. | to_entries[0] | .value' .release-please-manifest.json)"
+          curl --fail --show-error --silent -X POST "https://pkg.go.dev/fetch/github.com/openai/openai-go/v2@v${version}"

--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -10,18 +10,21 @@ permissions:
 
 jobs:
   detect_breaking_changes:
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-24.04'
     name: detect-breaking-changes
     if: github.repository == 'openai/openai-go'
     steps:
       - name: Calculate fetch-depth
+        env:
+          PR_COMMITS: ${{ github.event.pull_request.commits }}
         run: |
-          echo "FETCH_DEPTH=$(expr ${{ github.event.pull_request.commits }} + 1)" >> $GITHUB_ENV
+          echo "FETCH_DEPTH=$(expr "$PR_COMMITS" + 1)" >> "$GITHUB_ENV"
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           # Ensure we can check out the pull request base in the script below.
           fetch-depth: ${{ env.FETCH_DEPTH }}
+          persist-credentials: false
 
       - name: Setup go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
@@ -29,8 +32,10 @@ jobs:
           go-version-file: ./go.mod
 
       - name: Detect breaking changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           # Try to check out previous versions of the breaking change detection script. This ensures that
           # we still detect breaking changes when entire files and their tests are removed.
-          git checkout "${{ github.event.pull_request.base.sha }}" -- ./scripts/detect-breaking-changes 2>/dev/null || true
-          ./scripts/detect-breaking-changes ${{ github.event.pull_request.base.sha }}
+          git checkout "$BASE_SHA" -- ./scripts/detect-breaking-changes 2>/dev/null || true
+          ./scripts/detect-breaking-changes "$BASE_SHA"

--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   detect_breaking_changes:
-    runs-on: 'ubuntu-24.04'
+    runs-on: 'ubuntu-latest'
     name: detect-breaking-changes
     if: github.repository == 'openai/openai-go'
     steps:
@@ -24,7 +24,6 @@ jobs:
         with:
           # Ensure we can check out the pull request base in the script below.
           fetch-depth: ${{ env.FETCH_DEPTH }}
-          persist-credentials: false
 
       - name: Setup go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5


### PR DESCRIPTION
## Summary
- lock workflow `GITHUB_TOKEN` defaults down to `contents: read`
- restrict OIDC tarball upload to trusted push events
- disable persisted checkout credentials and pin Ubuntu runner labels
- quote workflow shell variables and make the pkg.go.dev curl fail loudly

## Validation
- `git diff --check`
- parsed all workflow YAML files
- verified every action reference remains pinned to a full commit SHA
- inspected the pinned Stainless action for `GITHUB_TOKEN` usage