### PR TITLE
fix: disambiguate struct unions when multiple variants share a discriminator value

### DIFF
--- a/internal/apijson/decodeparam_test.go
+++ b/internal/apijson/decodeparam_test.go
@@ -496,3 +496,85 @@ func TestMultiDiscriminatorUnion(t *testing.T) {
 		})
 	}
 }
+
+// MessageVariantInput and MessageVariantOutput each implement their own
+// UnmarshalJSON, mirroring how generated SDK param types do it. That matters
+// here because it's what makes the variants bypass the regular struct decoder
+// when they're decoded as a nested union field.
+type MessageVariantInput struct {
+	Type    string `json:"type" api:"required"`
+	Role    string `json:"role" api:"required"`
+	Content string `json:"content" api:"required"`
+}
+
+func (m *MessageVariantInput) UnmarshalJSON(data []byte) error {
+	return apijson.UnmarshalRoot(data, m)
+}
+
+type MessageVariantOutput struct {
+	ID      string `json:"id" api:"required"`
+	Type    string `json:"type" api:"required"`
+	Role    string `json:"role" api:"required"`
+	Content string `json:"content" api:"required"`
+}
+
+func (m *MessageVariantOutput) UnmarshalJSON(data []byte) error {
+	return apijson.UnmarshalRoot(data, m)
+}
+
+type AmbiguousMessageUnion struct {
+	OfInput  *MessageVariantInput  `json:",inline"`
+	OfOutput *MessageVariantOutput `json:",inline"`
+
+	paramUnion
+}
+
+func (u *AmbiguousMessageUnion) UnmarshalJSON(data []byte) error {
+	return apijson.UnmarshalRoot(data, u)
+}
+
+func init() {
+	apijson.RegisterUnion[AmbiguousMessageUnion](
+		"type",
+		apijson.Discriminator[MessageVariantInput]("message"),
+		apijson.Discriminator[MessageVariantOutput]("message"),
+	)
+}
+
+func TestDiscriminatorTiebreakOnSharedValue(t *testing.T) {
+	tests := map[string]struct {
+		raw    string
+		target AmbiguousMessageUnion
+	}{
+		"matches_input_variant_fields": {
+			raw: `{"type":"message","role":"user","content":"hi"}`,
+			target: AmbiguousMessageUnion{OfInput: &MessageVariantInput{
+				Type:    "message",
+				Role:    "user",
+				Content: "hi",
+			}},
+		},
+		"matches_output_variant_fields": {
+			raw: `{"id":"msg_1","type":"message","role":"assistant","content":"hi"}`,
+			target: AmbiguousMessageUnion{OfOutput: &MessageVariantOutput{
+				ID:      "msg_1",
+				Type:    "message",
+				Role:    "assistant",
+				Content: "hi",
+			}},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var dst AmbiguousMessageUnion
+			err := json.Unmarshal([]byte(test.raw), &dst)
+			if err != nil {
+				t.Fatalf("failed unmarshal with err: %v", err)
+			}
+			if !reflect.DeepEqual(dst, test.target) {
+				t.Fatalf("failed equality, got %#v but expected %#v", dst, test.target)
+			}
+		})
+	}
+}

--- a/internal/apijson/union.go
+++ b/internal/apijson/union.go
@@ -37,6 +37,32 @@ func RegisterDiscriminatedUnion[T any](key string, mappings map[string]reflect.T
 	unionRegistry[reflect.TypeOf(t)] = entry
 }
 
+// knownJSONKeys returns the top-level JSON field names that t recognizes,
+// including those contributed by embedded anonymous structs.
+func knownJSONKeys(t reflect.Type) map[string]bool {
+	keys := map[string]bool{}
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		if !field.IsExported() {
+			continue
+		}
+		if field.Anonymous {
+			if field.Type.Kind() == reflect.Struct {
+				for key := range knownJSONKeys(field.Type) {
+					keys[key] = true
+				}
+			}
+			continue
+		}
+		ptag, ok := parseJSONStructTag(field)
+		if !ok || ptag.extras || ptag.inline || ptag.metadata {
+			continue
+		}
+		keys[ptag.name] = true
+	}
+	return keys
+}
+
 func (d *decoderBuilder) newStructUnionDecoder(t reflect.Type) decoderFunc {
 	type variantDecoder struct {
 		decoder decoderFunc
@@ -79,12 +105,56 @@ func (d *decoderBuilder) newStructUnionDecoder(t reflect.Type) decoderFunc {
 	return func(n gjson.Result, v reflect.Value, state *decoderState) error {
 		if discriminated && n.Type == gjson.JSON && len(unionEntry.discriminatorKey) != 0 {
 			discriminator := n.Get(EscapeSJSONKey(unionEntry.discriminatorKey)).Value()
+			matches := []discriminatedDecoder{}
 			for _, decoder := range discriminatedDecoders {
 				if discriminator == decoder.discriminator {
-					inner := v.FieldByIndex(decoder.field.Index)
-					return decoder.decoder(n, inner, state)
+					matches = append(matches, decoder)
 				}
 			}
+
+			if len(matches) == 1 {
+				decoder := matches[0]
+				inner := v.FieldByIndex(decoder.field.Index)
+				return decoder.decoder(n, inner, state)
+			}
+
+			if len(matches) > 1 {
+				// More than one variant shares this discriminator value (for example,
+				// several "message" shaped variants distinguished only by other
+				// fields), so prefer whichever one's own fields account for the most
+				// of the JSON object's keys, rather than blindly taking the first
+				// match.
+				nodeMap := n.Map()
+				bestUnknown := -1
+				var winner *discriminatedDecoder
+				for i := range matches {
+					decoder := matches[i]
+					known := knownJSONKeys(decoder.field.Type.Elem())
+					unknown := 0
+					for key := range nodeMap {
+						if !known[key] {
+							unknown++
+						}
+					}
+					if bestUnknown == -1 || unknown < bestUnknown {
+						bestUnknown = unknown
+						winner = &matches[i]
+					}
+				}
+
+				inner := v.FieldByIndex(winner.field.Index)
+				err := winner.decoder(n, inner, state)
+
+				for _, decoder := range decoders {
+					if decoder.field.Index[0] == winner.field.Index[0] {
+						continue
+					}
+					v.FieldByIndex(decoder.field.Index).SetZero()
+				}
+
+				return err
+			}
+
 			return errors.New("apijson: was not able to find discriminated union variant")
 		}
 

--- a/internal/apijson/union.go
+++ b/internal/apijson/union.go
@@ -50,6 +50,32 @@ func RegisterDiscriminatedUnion[T any](key string, mappings map[string]reflect.T
 	unionRegistry[reflect.TypeOf(t)] = entry
 }
 
+// knownJSONKeys returns the top-level JSON field names that t recognizes,
+// including those contributed by embedded anonymous structs.
+func knownJSONKeys(t reflect.Type) map[string]bool {
+	keys := map[string]bool{}
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		if !field.IsExported() {
+			continue
+		}
+		if field.Anonymous {
+			if field.Type.Kind() == reflect.Struct {
+				for key := range knownJSONKeys(field.Type) {
+					keys[key] = true
+				}
+			}
+			continue
+		}
+		ptag, ok := parseJSONStructTag(field)
+		if !ok || ptag.extras || ptag.inline || ptag.metadata {
+			continue
+		}
+		keys[ptag.name] = true
+	}
+	return keys
+}
+
 func (d *decoderBuilder) newStructUnionDecoder(t reflect.Type) decoderFunc {
 	type variantDecoder struct {
 		decoder decoderFunc
@@ -94,21 +120,68 @@ func (d *decoderBuilder) newStructUnionDecoder(t reflect.Type) decoderFunc {
 			discriminatorNode := n.Get(EscapeSJSONKey(unionEntry.discriminatorKey))
 			discriminator := discriminatorNode.Value()
 			compatibleDiscriminatorType := false
+			matches := []discriminatedDecoder{}
 			for _, decoder := range discriminatedDecoders {
 				if reflect.TypeOf(discriminator) == reflect.TypeOf(decoder.discriminator) {
 					compatibleDiscriminatorType = true
 				}
 				if discriminator == decoder.discriminator {
-					inner := v.FieldByIndex(decoder.field.Index)
-					// Preservation only applies to the union that is itself an array
-					// element. Nested arrays will opt their own elements in.
-					preserveUnknown := state.preserveUnknownDiscriminatedUnion
-					state.preserveUnknownDiscriminatedUnion = false
-					err := decoder.decoder(n, inner, state)
-					state.preserveUnknownDiscriminatedUnion = preserveUnknown
-					return err
+					matches = append(matches, decoder)
 				}
 			}
+
+			if len(matches) == 1 {
+				decoder := matches[0]
+				inner := v.FieldByIndex(decoder.field.Index)
+				// Preservation only applies to the union that is itself an array
+				// element. Nested arrays will opt their own elements in.
+				preserveUnknown := state.preserveUnknownDiscriminatedUnion
+				state.preserveUnknownDiscriminatedUnion = false
+				err := decoder.decoder(n, inner, state)
+				state.preserveUnknownDiscriminatedUnion = preserveUnknown
+				return err
+			}
+
+			if len(matches) > 1 {
+				// More than one variant shares this discriminator value (for example,
+				// several "message" shaped variants distinguished only by other
+				// fields), so prefer whichever one's own fields account for the most
+				// of the JSON object's keys, rather than blindly taking the first
+				// match.
+				nodeMap := n.Map()
+				bestUnknown := -1
+				var winner *discriminatedDecoder
+				for i := range matches {
+					decoder := matches[i]
+					known := knownJSONKeys(decoder.field.Type.Elem())
+					unknown := 0
+					for key := range nodeMap {
+						if !known[key] {
+							unknown++
+						}
+					}
+					if bestUnknown == -1 || unknown < bestUnknown {
+						bestUnknown = unknown
+						winner = &matches[i]
+					}
+				}
+
+				inner := v.FieldByIndex(winner.field.Index)
+				preserveUnknown := state.preserveUnknownDiscriminatedUnion
+				state.preserveUnknownDiscriminatedUnion = false
+				err := winner.decoder(n, inner, state)
+				state.preserveUnknownDiscriminatedUnion = preserveUnknown
+
+				for _, decoder := range decoders {
+					if decoder.field.Index[0] == winner.field.Index[0] {
+						continue
+					}
+					v.FieldByIndex(decoder.field.Index).SetZero()
+				}
+
+				return err
+			}
+
 			if state.preserveUnknownDiscriminatedUnion && discriminatorNode.Exists() && compatibleDiscriminatorType && preserveUnknownParamUnion(v, n.Raw) {
 				return nil
 			}


### PR DESCRIPTION
## Summary

When a struct union registers more than one variant under the same discriminator value (for example, several "message" shaped variants distinguished only by other fields like `role` or the presence of an `id`), `newStructUnionDecoder` always picked whichever matching variant was registered first, regardless of which one the data actually matched.

For `ResponseInputItemUnionParam`, three variants (`EasyInputMessageParam`, `ResponseInputItemMessageParam`, `ResponseOutputMessageParam`) are all registered under `"type":"message"`. As a result, decoding an output message echoed back into the input (e.g. `{"id":"msg_1","type":"message","role":"assistant","status":"completed","content":[...]}`) always landed on `EasyInputMessageParam`, dropping the `id`/`status` fields.

## Fix

When more than one registered variant matches the discriminator value, compare each candidate's own recognized JSON field names against the object's top-level keys and decode whichever one accounts for the most of them, instead of decoding the first match unconditionally. The existing single-match fast path is unchanged.

## Test plan

- [x] Added a test in `internal/apijson/decodeparam_test.go` that registers two variants under the same discriminator value and asserts both directions resolve to the correct variant.
- [x] Verified the new test fails against the pre-fix code and passes with the fix.
- [x] `go test ./...` passes with no regressions.