### PR TITLE
Suppress automatic Authorization with Azure Api-Key auth

### DIFF
--- a/azure/azure.go
+++ b/azure/azure.go
@@ -151,9 +151,15 @@ func WithTokenCredential(tokenCredential azcore.TokenCredential, options ...Toke
 // WithAPIKey configures this client to authenticate using an API key.
 // This function should be paired with a call to [WithEndpoint] to point to your Azure OpenAI instance.
 func WithAPIKey(apiKey string) option.RequestOption {
-	// NOTE: there is an option.WithApiKey(), but that adds the value into
-	// the Authorization header instead so we're doing this instead.
-	return option.WithHeader("Api-Key", apiKey)
+	// NOTE: option.WithAPIKey() uses the Authorization header. Azure expects
+	// Api-Key instead, and we also need to suppress any automatically injected
+	// Authorization header from environment-derived client credentials.
+	return requestconfig.RequestOptionFunc(func(rc *requestconfig.RequestConfig) error {
+		if err := requestconfig.WithAutomaticAuthorizationDisabled().Apply(rc); err != nil {
+			return err
+		}
+		return option.WithHeader("Api-Key", apiKey).Apply(rc)
+	})
 }
 
 // jsonRoutes have JSON payloads - we'll deserialize looking for a .model field in there

--- a/azure/azure_test.go
+++ b/azure/azure_test.go
@@ -106,6 +106,44 @@ func TestAPIKeyAuthentication(t *testing.T) {
 	}
 }
 
+func TestAPIKeyAuthenticationSuppressesAutomaticAuthorization(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "normal-openai-key")
+	t.Setenv("OPENAI_ADMIN_KEY", "normal-admin-key")
+
+	var captured *http.Request
+	client := openai.NewClient(
+		WithEndpoint("https://my-resource.openai.azure.com", "2024-10-21"),
+		WithAPIKey("azure-api-key"),
+		option.WithHTTPClient(&http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				captured = req
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header: http.Header{
+						"Content-Type": []string{"application/json"},
+					},
+					Body:    io.NopCloser(strings.NewReader(`{"ok":true}`)),
+					Request: req,
+				}, nil
+			}),
+		}),
+	)
+
+	var res map[string]any
+	if err := client.Execute(context.Background(), http.MethodGet, "models", nil, &res); err != nil {
+		t.Fatalf("request failed: %s", err)
+	}
+	if captured == nil {
+		t.Fatal("request was not captured")
+	}
+	if got := captured.Header.Get("Api-Key"); got != "azure-api-key" {
+		t.Fatalf("Api-Key header = %q, want %q", got, "azure-api-key")
+	}
+	if got := captured.Header.Get("Authorization"); got != "" {
+		t.Fatalf("Authorization header = %q, want empty", got)
+	}
+}
+
 func TestJSONRoutePathConstruction(t *testing.T) {
 	cases := []struct {
 		path     string

--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -241,17 +241,18 @@ type RequestConfig struct {
 	BaseURL        *url.URL
 	// DefaultBaseURL will be used if BaseURL is not explicitly overridden using
 	// WithBaseURL.
-	DefaultBaseURL     *url.URL
-	CustomHTTPDoer     HTTPDoer
-	HTTPClient         *http.Client
-	Middlewares        []middleware
-	APIKey             string
-	AdminAPIKey        string
-	Organization       string
-	Project            string
-	WebhookSecret      string
-	authHeaderOverride bool
-	authPreference     authCredentialPreference
+	DefaultBaseURL           *url.URL
+	CustomHTTPDoer           HTTPDoer
+	HTTPClient               *http.Client
+	Middlewares              []middleware
+	APIKey                   string
+	AdminAPIKey              string
+	Organization             string
+	Project                  string
+	WebhookSecret            string
+	authHeaderOverride       bool
+	disableAutoAuthorization bool
+	authPreference           authCredentialPreference
 	// Configure which security scheme(s) should be enabled for this request
 	Security Security
 	// If ResponseBodyInto not nil, then we will attempt to deserialize into
@@ -621,20 +622,21 @@ func (cfg *RequestConfig) Clone(ctx context.Context) *RequestConfig {
 		return nil
 	}
 	new := &RequestConfig{
-		MaxRetries:         cfg.MaxRetries,
-		RequestTimeout:     cfg.RequestTimeout,
-		Context:            ctx,
-		Request:            req,
-		BaseURL:            cfg.BaseURL,
-		HTTPClient:         cfg.HTTPClient,
-		Middlewares:        cfg.Middlewares,
-		APIKey:             cfg.APIKey,
-		AdminAPIKey:        cfg.AdminAPIKey,
-		Organization:       cfg.Organization,
-		Project:            cfg.Project,
-		WebhookSecret:      cfg.WebhookSecret,
-		authHeaderOverride: cfg.authHeaderOverride,
-		authPreference:     cfg.authPreference,
+		MaxRetries:               cfg.MaxRetries,
+		RequestTimeout:           cfg.RequestTimeout,
+		Context:                  ctx,
+		Request:                  req,
+		BaseURL:                  cfg.BaseURL,
+		HTTPClient:               cfg.HTTPClient,
+		Middlewares:              cfg.Middlewares,
+		APIKey:                   cfg.APIKey,
+		AdminAPIKey:              cfg.AdminAPIKey,
+		Organization:             cfg.Organization,
+		Project:                  cfg.Project,
+		WebhookSecret:            cfg.WebhookSecret,
+		authHeaderOverride:       cfg.authHeaderOverride,
+		disableAutoAuthorization: cfg.disableAutoAuthorization,
+		authPreference:           cfg.authPreference,
 	}
 
 	return new
@@ -664,12 +666,14 @@ func (cfg *RequestConfig) DelHeader(key string) {
 func (cfg *RequestConfig) SetAPIKey(value string) {
 	cfg.APIKey = value
 	cfg.authHeaderOverride = false
+	cfg.disableAutoAuthorization = false
 	cfg.authPreference = authCredentialPreferenceBearer
 }
 
 func (cfg *RequestConfig) SetAdminAPIKey(value string) {
 	cfg.AdminAPIKey = value
 	cfg.authHeaderOverride = false
+	cfg.disableAutoAuthorization = false
 	cfg.authPreference = authCredentialPreferenceAdmin
 }
 
@@ -769,8 +773,18 @@ func WithBearerAuthPreference() RequestOption {
 	})
 }
 
+// WithAutomaticAuthorizationDisabled prevents request security from injecting an
+// Authorization header. This should only be used for endpoints that authenticate
+// with non-Authorization headers or middleware-managed credentials.
+func WithAutomaticAuthorizationDisabled() RequestOption {
+	return RequestOptionFunc(func(r *RequestConfig) error {
+		r.disableAutoAuthorization = true
+		return nil
+	})
+}
+
 func ApplySecurity(r RequestConfig) {
-	if r.authHeaderOverride {
+	if r.authHeaderOverride || r.disableAutoAuthorization {
 		return
 	}
 


### PR DESCRIPTION
## Summary
- suppress automatic `Authorization` header injection when `azure.WithAPIKey` is used
- keep Azure API-key auth on the `Api-Key` header
- add a regression test covering env-provided API keys with `Client.Execute`

## Why
- `OPENAI_API_KEY` and `OPENAI_ADMIN_KEY` can be loaded by default on the client
- Azure API-key auth only set `Api-Key`, so request security could still append `Authorization`
- that could send an OpenAI bearer token to an Azure endpoint

## Checks
- `go test ./azure -run 'TestAPIKeyAuthentication|TestAPIKeyAuthenticationSuppressesAutomaticAuthorization|TestWithEndpointPreservesEscapedPathParams'`
- `go test . -run 'TestRequestAPIKeyOverridesClientAuthorizationHeader|TestExecuteRequestAdminAPIKeyOverridesClientAPIKey|TestExecuteRequestAPIKeyOverridesClientAdminAPIKey'`
- `go test ./...` currently needs the repo test server on `localhost:4010`; unrelated admin API tests fail without it