### PR TITLE
fix(requestconfig): normalize Windows OS header values

### DIFF
--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -50,15 +50,15 @@ func FormatPath(format string, params ...string) string {
 	return fmt.Sprintf(format, args...)
 }
 
-func getNormalizedOS() string {
-	switch runtime.GOOS {
+func normalizeOS(goos string) string {
+	switch goos {
 	case "ios":
 		return "iOS"
 	case "android":
 		return "Android"
 	case "darwin":
 		return "MacOS"
-	case "window":
+	case "windows":
 		return "Windows"
 	case "freebsd":
 		return "FreeBSD"
@@ -67,8 +67,12 @@ func getNormalizedOS() string {
 	case "linux":
 		return "Linux"
 	default:
-		return fmt.Sprintf("Other:%s", runtime.GOOS)
+		return fmt.Sprintf("Other:%s", goos)
 	}
+}
+
+func getNormalizedOS() string {
+	return normalizeOS(runtime.GOOS)
 }
 
 func getNormalizedArchitecture() string {

--- a/internal/requestconfig/requestconfig_test.go
+++ b/internal/requestconfig/requestconfig_test.go
@@ -48,3 +48,20 @@ func TestFormatPathEscapesPathParams(t *testing.T) {
 		})
 	}
 }
+
+func TestNormalizeOS(t *testing.T) {
+	tests := map[string]string{
+		"windows": "Windows",
+		"darwin":  "MacOS",
+		"linux":   "Linux",
+		"plan9":   "Other:plan9",
+	}
+
+	for input, want := range tests {
+		t.Run(input, func(t *testing.T) {
+			if got := normalizeOS(input); got != want {
+				t.Fatalf("normalizeOS(%q) = %q, want %q", input, got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why

runtime.GOOS returns windows, but the request configuration matched window. Windows requests were therefore reported as Other:windows instead of Windows in the X-Stainless-OS header.

## What changed

- Extract OS normalization into a small normalizeOS helper.
- Map windows to Windows while preserving the existing mappings for other platforms.
- Add focused coverage for Windows, macOS, Linux, and unknown OS values.

## Validation

- `go test ./internal/requestconfig`