### PR TITLE
fix(httpdump): redact sensitive headers in request and response dumps

### DIFF
--- a/internal/apierror/apierror.go
+++ b/internal/apierror/apierror.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httputil"
 
 	"github.com/openai/openai-go/v3/internal/apijson"
+	"github.com/openai/openai-go/v3/internal/httpdump"
 	"github.com/openai/openai-go/v3/packages/respjson"
 )
 
@@ -48,11 +49,17 @@ func (r *Error) DumpRequest(body bool) []byte {
 	if r.Request.GetBody != nil {
 		r.Request.Body, _ = r.Request.GetBody()
 	}
+	origHeaders := r.Request.Header
+	r.Request.Header = httpdump.RedactSensitiveHeaders(origHeaders)
+	defer func() { r.Request.Header = origHeaders }()
 	out, _ := httputil.DumpRequestOut(r.Request, body)
 	return out
 }
 
 func (r *Error) DumpResponse(body bool) []byte {
+	origHeaders := r.Response.Header
+	r.Response.Header = httpdump.RedactSensitiveHeaders(origHeaders)
+	defer func() { r.Response.Header = origHeaders }()
 	out, _ := httputil.DumpResponse(r.Response, body)
 	return out
 }

--- a/internal/apierror/apierror_test.go
+++ b/internal/apierror/apierror_test.go
@@ -1,0 +1,103 @@
+package apierror
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestDumpRequestRedactsSensitiveHeaders(t *testing.T) {
+	body := []byte(`{"message":"hello"}`)
+	req, err := http.NewRequest(http.MethodPost, "https://api.openai.com/v1/responses", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(body)), nil
+	}
+	req.Header.Set("Authorization", "Bearer sk-test")
+	req.Header.Set("Api-Key", "azure-key")
+	req.Header.Set("OpenAI-Organization", "org_123")
+	req.Header.Set("OpenAI-Project", "proj_123")
+	req.Header.Set("Webhook-Signature", "v1,signature")
+	req.Header.Set("Webhook-Id", "wh_123")
+	req.Header.Set("Webhook-Timestamp", "123")
+	req.Header.Set("X-Custom", "keep-me")
+
+	apierr := &Error{Request: req}
+	dump := strings.ToLower(string(apierr.DumpRequest(true)))
+
+	for _, want := range []string{
+		"authorization: ***",
+		"api-key: ***",
+		"openai-organization: ***",
+		"openai-project: ***",
+		"webhook-signature: ***",
+		"webhook-id: ***",
+		"webhook-timestamp: ***",
+	} {
+		if !strings.Contains(dump, want) {
+			t.Fatalf("request dump missing redacted header %q:\n%s", want, dump)
+		}
+	}
+	if strings.Contains(dump, "sk-test") || strings.Contains(dump, "azure-key") || strings.Contains(dump, "org_123") {
+		t.Fatalf("request dump leaked a sensitive header:\n%s", dump)
+	}
+	if !strings.Contains(dump, "x-custom: keep-me") {
+		t.Fatalf("request dump dropped non-sensitive header:\n%s", dump)
+	}
+	if !strings.Contains(dump, `{"message":"hello"}`) {
+		t.Fatalf("request dump missing body:\n%s", dump)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer sk-test" {
+		t.Fatalf("request header mutated, got %q", got)
+	}
+}
+
+func TestDumpResponseRedactsSensitiveHeaders(t *testing.T) {
+	resp := &http.Response{
+		Status:     "401 Unauthorized",
+		StatusCode: http.StatusUnauthorized,
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header: http.Header{
+			"Authorization":       []string{"Bearer sk-test"},
+			"Set-Cookie":          []string{"session=secret"},
+			"OpenAI-Organization": []string{"org_123"},
+			"OpenAI-Project":      []string{"proj_123"},
+			"Webhook-Signature":   []string{"v1,signature"},
+			"X-Custom":            []string{"keep-me"},
+		},
+		Body: io.NopCloser(strings.NewReader(`{"error":"denied"}`)),
+	}
+
+	apierr := &Error{Response: resp}
+	dump := strings.ToLower(string(apierr.DumpResponse(true)))
+
+	for _, want := range []string{
+		"authorization: ***",
+		"set-cookie: ***",
+		"openai-organization: ***",
+		"openai-project: ***",
+		"webhook-signature: ***",
+	} {
+		if !strings.Contains(dump, want) {
+			t.Fatalf("response dump missing redacted header %q:\n%s", want, dump)
+		}
+	}
+	if strings.Contains(dump, "sk-test") || strings.Contains(dump, "session=secret") || strings.Contains(dump, "org_123") {
+		t.Fatalf("response dump leaked a sensitive header:\n%s", dump)
+	}
+	if !strings.Contains(dump, "x-custom: keep-me") {
+		t.Fatalf("response dump dropped non-sensitive header:\n%s", dump)
+	}
+	if !strings.Contains(dump, `{"error":"denied"}`) {
+		t.Fatalf("response dump missing body:\n%s", dump)
+	}
+	if got := resp.Header.Get("Authorization"); got != "Bearer sk-test" {
+		t.Fatalf("response header mutated, got %q", got)
+	}
+}

--- a/internal/httpdump/httpdump.go
+++ b/internal/httpdump/httpdump.go
@@ -1,0 +1,45 @@
+package httpdump
+
+import (
+	"net/http"
+	"strings"
+)
+
+var sensitiveHeaders = map[string]struct{}{
+	"authorization":       {},
+	"proxy-authorization": {},
+	"api-key":             {},
+	"x-api-key":           {},
+	"cookie":              {},
+	"set-cookie":          {},
+	"openai-organization": {},
+	"openai-project":      {},
+	"webhook-id":          {},
+	"webhook-signature":   {},
+	"webhook-timestamp":   {},
+}
+
+// RedactSensitiveHeaders returns a header map with known sensitive values
+// replaced. If no sensitive headers are present, the original map is returned.
+func RedactSensitiveHeaders(headers http.Header) http.Header {
+	var redacted http.Header
+	for name, values := range headers {
+		if len(values) == 0 {
+			continue
+		}
+		if _, ok := sensitiveHeaders[strings.ToLower(name)]; !ok {
+			continue
+		}
+		if redacted == nil {
+			redacted = headers.Clone()
+		}
+		redacted[name] = make([]string, len(values))
+		for i := range values {
+			redacted[name][i] = "***"
+		}
+	}
+	if redacted == nil {
+		return headers
+	}
+	return redacted
+}

--- a/option/middleware.go
+++ b/option/middleware.go
@@ -6,11 +6,9 @@ import (
 	"log"
 	"net/http"
 	"net/http/httputil"
-)
 
-// sensitiveLogHeaders are redacted before request and response content is
-// written to the debug logger.
-var sensitiveLogHeaders = []string{"authorization", "api-key", "x-api-key", "cookie", "set-cookie"}
+	"github.com/openai/openai-go/v3/internal/httpdump"
+)
 
 // WithDebugLog logs the HTTP request and response content.
 // If the logger parameter is nil, it uses the default logger.
@@ -46,35 +44,14 @@ func WithDebugLog(logger *log.Logger) RequestOption {
 // leak the placeholder map into the live request sent downstream.
 func dumpRedactedRequest(req *http.Request) ([]byte, error) {
 	origHeaders := req.Header
-	req.Header = redactDebugHeaders(origHeaders)
+	req.Header = httpdump.RedactSensitiveHeaders(origHeaders)
 	defer func() { req.Header = origHeaders }()
 	return httputil.DumpRequest(req, true)
 }
 
 func dumpRedactedResponse(resp *http.Response) ([]byte, error) {
 	origHeaders := resp.Header
-	resp.Header = redactDebugHeaders(origHeaders)
+	resp.Header = httpdump.RedactSensitiveHeaders(origHeaders)
 	defer func() { resp.Header = origHeaders }()
 	return httputil.DumpResponse(resp, true)
-}
-
-func redactDebugHeaders(headers http.Header) http.Header {
-	var redacted http.Header
-	for _, name := range sensitiveLogHeaders {
-		values := headers.Values(name)
-		if len(values) == 0 {
-			continue
-		}
-		if redacted == nil {
-			redacted = headers.Clone()
-		}
-		redacted.Del(name)
-		for range values {
-			redacted.Add(name, "***")
-		}
-	}
-	if redacted == nil {
-		return headers
-	}
-	return redacted
 }


### PR DESCRIPTION
## Why

HTTP dumps produced for API errors and debug logging could include sensitive header values. That could expose bearer tokens, API keys, organization and project identifiers, webhook signatures, or cookie values in logs.

## What changed

- Add one case-insensitive redaction helper for sensitive headers.
- Apply it to API error request/response dumps and option debug logging.
- Restore the original header maps after dumping so live requests and responses are not mutated.
- Add coverage for sensitive and non-sensitive headers, including manually constructed non-canonical header names.

## Validation

- `go test ./internal/apierror ./internal/httpdump ./option`