### PR TITLE
Prevent OpenAI credentials from being sent to Azure endpoints

### DIFF
--- a/azure/azure.go
+++ b/azure/azure.go
@@ -151,9 +151,15 @@ func WithTokenCredential(tokenCredential azcore.TokenCredential, options ...Toke
 // WithAPIKey configures this client to authenticate using an API key.
 // This function should be paired with a call to [WithEndpoint] to point to your Azure OpenAI instance.
 func WithAPIKey(apiKey string) option.RequestOption {
-	// NOTE: there is an option.WithApiKey(), but that adds the value into
-	// the Authorization header instead so we're doing this instead.
-	return option.WithHeader("Api-Key", apiKey)
+	// NOTE: option.WithAPIKey() uses the Authorization header. Azure expects
+	// Api-Key instead, and we also need to suppress any automatically injected
+	// Authorization header from environment-derived client credentials.
+	return requestconfig.RequestOptionFunc(func(rc *requestconfig.RequestConfig) error {
+		if err := requestconfig.WithAutomaticAuthorizationDisabled().Apply(rc); err != nil {
+			return err
+		}
+		return option.WithHeader("Api-Key", apiKey).Apply(rc)
+	})
 }
 
 // jsonRoutes have JSON payloads - we'll deserialize looking for a .model field in there

--- a/azure/azure.go
+++ b/azure/azure.go
@@ -152,13 +152,13 @@ func WithTokenCredential(tokenCredential azcore.TokenCredential, options ...Toke
 // This function should be paired with a call to [WithEndpoint] to point to your Azure OpenAI instance.
 func WithAPIKey(apiKey string) option.RequestOption {
 	// NOTE: option.WithAPIKey() uses the Authorization header. Azure expects
-	// Api-Key instead, and we also need to suppress any automatically injected
-	// Authorization header from environment-derived client credentials.
+	// Api-Key instead. Deleting Authorization also prevents request security from
+	// automatically injecting environment-derived client credentials.
 	return requestconfig.RequestOptionFunc(func(rc *requestconfig.RequestConfig) error {
-		if err := requestconfig.WithAutomaticAuthorizationDisabled().Apply(rc); err != nil {
-			return err
-		}
-		return option.WithHeader("Api-Key", apiKey).Apply(rc)
+		return rc.Apply(
+			option.WithHeaderDel("Authorization"),
+			option.WithHeader("Api-Key", apiKey),
+		)
 	})
 }
 

--- a/azure/azure_test.go
+++ b/azure/azure_test.go
@@ -107,40 +107,54 @@ func TestAPIKeyAuthentication(t *testing.T) {
 }
 
 func TestAPIKeyAuthenticationSuppressesAutomaticAuthorization(t *testing.T) {
-	t.Setenv("OPENAI_API_KEY", "normal-openai-key")
-	t.Setenv("OPENAI_ADMIN_KEY", "normal-admin-key")
+	tests := []struct {
+		name        string
+		apiKey      string
+		adminAPIKey string
+	}{
+		{name: "OpenAI API key", apiKey: "normal-openai-key"},
+		{name: "OpenAI admin API key", adminAPIKey: "normal-admin-key"},
+		{name: "both OpenAI keys", apiKey: "normal-openai-key", adminAPIKey: "normal-admin-key"},
+	}
 
-	var captured *http.Request
-	client := openai.NewClient(
-		WithEndpoint("https://my-resource.openai.azure.com", "2024-10-21"),
-		WithAPIKey("azure-api-key"),
-		option.WithHTTPClient(&http.Client{
-			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-				captured = req
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Header: http.Header{
-						"Content-Type": []string{"application/json"},
-					},
-					Body:    io.NopCloser(strings.NewReader(`{"ok":true}`)),
-					Request: req,
-				}, nil
-			}),
-		}),
-	)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("OPENAI_API_KEY", tt.apiKey)
+			t.Setenv("OPENAI_ADMIN_KEY", tt.adminAPIKey)
 
-	var res map[string]any
-	if err := client.Execute(context.Background(), http.MethodGet, "models", nil, &res); err != nil {
-		t.Fatalf("request failed: %s", err)
-	}
-	if captured == nil {
-		t.Fatal("request was not captured")
-	}
-	if got := captured.Header.Get("Api-Key"); got != "azure-api-key" {
-		t.Fatalf("Api-Key header = %q, want %q", got, "azure-api-key")
-	}
-	if got := captured.Header.Get("Authorization"); got != "" {
-		t.Fatalf("Authorization header = %q, want empty", got)
+			var captured *http.Request
+			client := openai.NewClient(
+				WithEndpoint("https://my-resource.openai.azure.com", "2024-10-21"),
+				WithAPIKey("azure-api-key"),
+				option.WithHTTPClient(&http.Client{
+					Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+						captured = req
+						return &http.Response{
+							StatusCode: http.StatusOK,
+							Header: http.Header{
+								"Content-Type": []string{"application/json"},
+							},
+							Body:    io.NopCloser(strings.NewReader(`{"ok":true}`)),
+							Request: req,
+						}, nil
+					}),
+				}),
+			)
+
+			var res map[string]any
+			if err := client.Execute(context.Background(), http.MethodGet, "models", nil, &res); err != nil {
+				t.Fatalf("request failed: %s", err)
+			}
+			if captured == nil {
+				t.Fatal("request was not captured")
+			}
+			if got := captured.Header.Get("Api-Key"); got != "azure-api-key" {
+				t.Fatalf("Api-Key header = %q, want %q", got, "azure-api-key")
+			}
+			if got := captured.Header.Get("Authorization"); got != "" {
+				t.Fatalf("Authorization header = %q, want empty", got)
+			}
+		})
 	}
 }
 

--- a/azure/azure_test.go
+++ b/azure/azure_test.go
@@ -106,6 +106,44 @@ func TestAPIKeyAuthentication(t *testing.T) {
 	}
 }
 
+func TestAPIKeyAuthenticationSuppressesAutomaticAuthorization(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "normal-openai-key")
+	t.Setenv("OPENAI_ADMIN_KEY", "normal-admin-key")
+
+	var captured *http.Request
+	client := openai.NewClient(
+		WithEndpoint("https://my-resource.openai.azure.com", "2024-10-21"),
+		WithAPIKey("azure-api-key"),
+		option.WithHTTPClient(&http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				captured = req
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header: http.Header{
+						"Content-Type": []string{"application/json"},
+					},
+					Body:    io.NopCloser(strings.NewReader(`{"ok":true}`)),
+					Request: req,
+				}, nil
+			}),
+		}),
+	)
+
+	var res map[string]any
+	if err := client.Execute(context.Background(), http.MethodGet, "models", nil, &res); err != nil {
+		t.Fatalf("request failed: %s", err)
+	}
+	if captured == nil {
+		t.Fatal("request was not captured")
+	}
+	if got := captured.Header.Get("Api-Key"); got != "azure-api-key" {
+		t.Fatalf("Api-Key header = %q, want %q", got, "azure-api-key")
+	}
+	if got := captured.Header.Get("Authorization"); got != "" {
+		t.Fatalf("Authorization header = %q, want empty", got)
+	}
+}
+
 func TestJSONRoutePathConstruction(t *testing.T) {
 	cases := []struct {
 		path     string

--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -241,18 +241,17 @@ type RequestConfig struct {
 	BaseURL        *url.URL
 	// DefaultBaseURL will be used if BaseURL is not explicitly overridden using
 	// WithBaseURL.
-	DefaultBaseURL           *url.URL
-	CustomHTTPDoer           HTTPDoer
-	HTTPClient               *http.Client
-	Middlewares              []middleware
-	APIKey                   string
-	AdminAPIKey              string
-	Organization             string
-	Project                  string
-	WebhookSecret            string
-	authHeaderOverride       bool
-	disableAutoAuthorization bool
-	authPreference           authCredentialPreference
+	DefaultBaseURL     *url.URL
+	CustomHTTPDoer     HTTPDoer
+	HTTPClient         *http.Client
+	Middlewares        []middleware
+	APIKey             string
+	AdminAPIKey        string
+	Organization       string
+	Project            string
+	WebhookSecret      string
+	authHeaderOverride bool
+	authPreference     authCredentialPreference
 	// Configure which security scheme(s) should be enabled for this request
 	Security Security
 	// If ResponseBodyInto not nil, then we will attempt to deserialize into
@@ -622,21 +621,20 @@ func (cfg *RequestConfig) Clone(ctx context.Context) *RequestConfig {
 		return nil
 	}
 	new := &RequestConfig{
-		MaxRetries:               cfg.MaxRetries,
-		RequestTimeout:           cfg.RequestTimeout,
-		Context:                  ctx,
-		Request:                  req,
-		BaseURL:                  cfg.BaseURL,
-		HTTPClient:               cfg.HTTPClient,
-		Middlewares:              cfg.Middlewares,
-		APIKey:                   cfg.APIKey,
-		AdminAPIKey:              cfg.AdminAPIKey,
-		Organization:             cfg.Organization,
-		Project:                  cfg.Project,
-		WebhookSecret:            cfg.WebhookSecret,
-		authHeaderOverride:       cfg.authHeaderOverride,
-		disableAutoAuthorization: cfg.disableAutoAuthorization,
-		authPreference:           cfg.authPreference,
+		MaxRetries:         cfg.MaxRetries,
+		RequestTimeout:     cfg.RequestTimeout,
+		Context:            ctx,
+		Request:            req,
+		BaseURL:            cfg.BaseURL,
+		HTTPClient:         cfg.HTTPClient,
+		Middlewares:        cfg.Middlewares,
+		APIKey:             cfg.APIKey,
+		AdminAPIKey:        cfg.AdminAPIKey,
+		Organization:       cfg.Organization,
+		Project:            cfg.Project,
+		WebhookSecret:      cfg.WebhookSecret,
+		authHeaderOverride: cfg.authHeaderOverride,
+		authPreference:     cfg.authPreference,
 	}
 
 	return new
@@ -666,14 +664,12 @@ func (cfg *RequestConfig) DelHeader(key string) {
 func (cfg *RequestConfig) SetAPIKey(value string) {
 	cfg.APIKey = value
 	cfg.authHeaderOverride = false
-	cfg.disableAutoAuthorization = false
 	cfg.authPreference = authCredentialPreferenceBearer
 }
 
 func (cfg *RequestConfig) SetAdminAPIKey(value string) {
 	cfg.AdminAPIKey = value
 	cfg.authHeaderOverride = false
-	cfg.disableAutoAuthorization = false
 	cfg.authPreference = authCredentialPreferenceAdmin
 }
 
@@ -773,18 +769,8 @@ func WithBearerAuthPreference() RequestOption {
 	})
 }
 
-// WithAutomaticAuthorizationDisabled prevents request security from injecting an
-// Authorization header. This should only be used for endpoints that authenticate
-// with non-Authorization headers or middleware-managed credentials.
-func WithAutomaticAuthorizationDisabled() RequestOption {
-	return RequestOptionFunc(func(r *RequestConfig) error {
-		r.disableAutoAuthorization = true
-		return nil
-	})
-}
-
 func ApplySecurity(r RequestConfig) {
-	if r.authHeaderOverride || r.disableAutoAuthorization {
+	if r.authHeaderOverride {
 		return
 	}
 

--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -241,17 +241,18 @@ type RequestConfig struct {
 	BaseURL        *url.URL
 	// DefaultBaseURL will be used if BaseURL is not explicitly overridden using
 	// WithBaseURL.
-	DefaultBaseURL     *url.URL
-	CustomHTTPDoer     HTTPDoer
-	HTTPClient         *http.Client
-	Middlewares        []middleware
-	APIKey             string
-	AdminAPIKey        string
-	Organization       string
-	Project            string
-	WebhookSecret      string
-	authHeaderOverride bool
-	authPreference     authCredentialPreference
+	DefaultBaseURL           *url.URL
+	CustomHTTPDoer           HTTPDoer
+	HTTPClient               *http.Client
+	Middlewares              []middleware
+	APIKey                   string
+	AdminAPIKey              string
+	Organization             string
+	Project                  string
+	WebhookSecret            string
+	authHeaderOverride       bool
+	disableAutoAuthorization bool
+	authPreference           authCredentialPreference
 	// Configure which security scheme(s) should be enabled for this request
 	Security Security
 	// If ResponseBodyInto not nil, then we will attempt to deserialize into
@@ -621,20 +622,21 @@ func (cfg *RequestConfig) Clone(ctx context.Context) *RequestConfig {
 		return nil
 	}
 	new := &RequestConfig{
-		MaxRetries:         cfg.MaxRetries,
-		RequestTimeout:     cfg.RequestTimeout,
-		Context:            ctx,
-		Request:            req,
-		BaseURL:            cfg.BaseURL,
-		HTTPClient:         cfg.HTTPClient,
-		Middlewares:        cfg.Middlewares,
-		APIKey:             cfg.APIKey,
-		AdminAPIKey:        cfg.AdminAPIKey,
-		Organization:       cfg.Organization,
-		Project:            cfg.Project,
-		WebhookSecret:      cfg.WebhookSecret,
-		authHeaderOverride: cfg.authHeaderOverride,
-		authPreference:     cfg.authPreference,
+		MaxRetries:               cfg.MaxRetries,
+		RequestTimeout:           cfg.RequestTimeout,
+		Context:                  ctx,
+		Request:                  req,
+		BaseURL:                  cfg.BaseURL,
+		HTTPClient:               cfg.HTTPClient,
+		Middlewares:              cfg.Middlewares,
+		APIKey:                   cfg.APIKey,
+		AdminAPIKey:              cfg.AdminAPIKey,
+		Organization:             cfg.Organization,
+		Project:                  cfg.Project,
+		WebhookSecret:            cfg.WebhookSecret,
+		authHeaderOverride:       cfg.authHeaderOverride,
+		disableAutoAuthorization: cfg.disableAutoAuthorization,
+		authPreference:           cfg.authPreference,
 	}
 
 	return new
@@ -664,12 +666,14 @@ func (cfg *RequestConfig) DelHeader(key string) {
 func (cfg *RequestConfig) SetAPIKey(value string) {
 	cfg.APIKey = value
 	cfg.authHeaderOverride = false
+	cfg.disableAutoAuthorization = false
 	cfg.authPreference = authCredentialPreferenceBearer
 }
 
 func (cfg *RequestConfig) SetAdminAPIKey(value string) {
 	cfg.AdminAPIKey = value
 	cfg.authHeaderOverride = false
+	cfg.disableAutoAuthorization = false
 	cfg.authPreference = authCredentialPreferenceAdmin
 }
 
@@ -769,8 +773,18 @@ func WithBearerAuthPreference() RequestOption {
 	})
 }
 
+// WithAutomaticAuthorizationDisabled prevents request security from injecting an
+// Authorization header. This should only be used for endpoints that authenticate
+// with non-Authorization headers or middleware-managed credentials.
+func WithAutomaticAuthorizationDisabled() RequestOption {
+	return RequestOptionFunc(func(r *RequestConfig) error {
+		r.disableAutoAuthorization = true
+		return nil
+	})
+}
+
 func ApplySecurity(r RequestConfig) {
-	if r.authHeaderOverride {
+	if r.authHeaderOverride || r.disableAutoAuthorization {
 		return
 	}
 


### PR DESCRIPTION
## Summary

- preserve @fallintoplace's original contribution and commit authorship from #693
- prevent environment-derived OpenAI credentials from being sent to Azure endpoints
- reuse the existing explicit `Authorization` header deletion behavior instead of adding separate request state
- cover `OPENAI_API_KEY`, `OPENAI_ADMIN_KEY`, and both credentials together

This PR supersedes #693.

## Why

`azure.WithAPIKey` previously set the Azure `Api-Key` header without preventing request security from also injecting an `Authorization` header from `OPENAI_API_KEY` or `OPENAI_ADMIN_KEY`. Explicitly deleting `Authorization` uses the existing header-override path to suppress automatic injection without introducing additional request configuration state.

## Validation

- `gofmt -w azure/azure.go azure/azure_test.go internal/requestconfig/requestconfig.go`
- `git diff --check`
- `GOCACHE=/tmp/openai-go-cache ./scripts/test`