### PR TITLE
ci: restore release environment

### DIFF
--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -12,6 +12,9 @@ jobs:
     name: release
     if: github.ref == 'refs/heads/main' && github.repository == 'openai/openai-go'
     runs-on: ubuntu-latest
+    # STAINLESS_API_KEY is scoped to this environment, so the job that invokes
+    # trigger-release-please must explicitly opt in to receive it.
+    environment: publish
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
 


### PR DESCRIPTION
## Summary

- Restore the `publish` environment on the `release` job that invokes `stainless-api/trigger-release-please`.
- Document why that job needs the environment.

## Root cause

When release creation and package publication were split into separate jobs, `environment: publish` moved to the downstream `publish` job. `STAINLESS_API_KEY` is an environment secret, but it is consumed by the upstream `release` job. Every main push since June 5 has therefore failed with `Missing stainless-api-key input`.

## Impact

Main pushes can invoke Release Please again. The secret remains scoped to the existing `publish` environment; it is not copied to repository scope or exposed to unrelated jobs.

## Validation

- `yq eval` parses the workflow successfully.
- `git diff --check` passes.