### PR TITLE
ci: fix Codex permission profile handoff

### DIFF
--- a/.github/codex/go-version-review-config.toml
+++ b/.github/codex/go-version-review-config.toml
@@ -1,6 +1,8 @@
 # Least-privilege profile for the scheduled Go version review. The workflow
-# copies this file into an ignored, disposable Codex home before the action
-# starts, so proxy configuration and session state never enter the patch.
+# installs this file in the unprivileged user's disposable home before the
+# action starts. Proxy configuration and session state stay outside the
+# checkout, while caches and generated output use its ignored automation
+# directory and never enter the patch.
 default_permissions = "go-version-review"
 
 [permissions."go-version-review"]

--- a/.github/codex/go-version-review-config.toml
+++ b/.github/codex/go-version-review-config.toml
@@ -1,32 +1,24 @@
-# Least-privilege profile for the scheduled Go version review. The workflow
-# installs this file in the unprivileged user's disposable home before the
-# action starts. Proxy configuration and session state stay outside the
-# checkout, while caches and generated output use its ignored automation
-# directory and never enter the patch.
+# Permission profile for the scheduled Go version review. The workflow installs
+# this file in the unprivileged user's disposable home before the action starts.
+# Codex may edit the disposable checkout, but it has no network or repository
+# credential. The publisher independently rejects patch paths and changes that
+# are outside the narrow Go-version policy allowlist.
 default_permissions = "go-version-review"
 
 [permissions."go-version-review"]
-description = "Review and update only Go-version policy artifacts"
+description = "Prepare a validated Go-version policy patch in a disposable checkout"
 extends = ":read-only"
 
 [permissions."go-version-review".filesystem]
 glob_scan_max_depth = 4
 
 [permissions."go-version-review".filesystem.":workspace_roots"]
-"." = "read"
-".codex-automation" = "write"
-"go.mod" = "write"
-"go.sum" = "write"
-"README.md" = "write"
-"CONTRIBUTING.md" = "write"
-"GO_VERSION_POLICY.md" = "write"
-"examples/go.mod" = "write"
-"examples/go.sum" = "write"
-"internal/testdata/consumer/go.mod" = "write"
-"internal/testdata/consumer/go.sum" = "write"
-"tools/go.mod" = "write"
-"tools/go.sum" = "write"
-".github/workflows/ci.yml" = "write"
+# Codex 0.144.6's Linux sandbox treats every write root as a directory, so
+# listing individual files here makes command startup fail while it tries to
+# protect children such as `go.mod/.codex`. Workspace write is the supported
+# directory-granular form. This checkout is disposable; the separate publisher
+# job is the authority that limits which files and literals can reach a branch.
+"." = "write"
 "**/*.env" = "deny"
 
 [permissions."go-version-review".network]

--- a/.github/codex/go-version-review-config.toml
+++ b/.github/codex/go-version-review-config.toml
@@ -11,9 +11,11 @@ extends = ":read-only"
 
 [permissions."go-version-review".filesystem]
 glob_scan_max_depth = 4
-# The root-owned home contains only these two Codex-owned Go working trees.
-# Module and build caches are warmed before command network access is disabled.
+# The root-owned home contains only these Codex-owned Go working trees. The
+# explicit temp directory keeps compilation out of the otherwise read-only
+# system temp directory.
 "~/.cache/go-build" = "write"
+"~/.cache/go-tmp" = "write"
 "~/go" = "write"
 
 [permissions."go-version-review".filesystem.":workspace_roots"]
@@ -26,6 +28,8 @@ glob_scan_max_depth = 4
 "**/*.env" = "deny"
 
 [permissions."go-version-review".network]
-# The workflow snapshots the Go release feed and warms module caches before
-# the API key is passed to the action. Agent-run commands need no internet.
+# This also denies loopback. The credential-bearing Responses proxy is a local
+# service, so allowing localhost merely for the Steady test server would widen
+# the key boundary. A separate credential-free job runs the complete test and
+# vulnerability suite after validating the generated patch.
 enabled = false

--- a/.github/codex/go-version-review-config.toml
+++ b/.github/codex/go-version-review-config.toml
@@ -11,6 +11,10 @@ extends = ":read-only"
 
 [permissions."go-version-review".filesystem]
 glob_scan_max_depth = 4
+# The root-owned home contains only these two Codex-owned Go working trees.
+# Module and build caches are warmed before command network access is disabled.
+"~/.cache/go-build" = "write"
+"~/go" = "write"
 
 [permissions."go-version-review".filesystem.":workspace_roots"]
 # Codex 0.144.6's Linux sandbox treats every write root as a directory, so

--- a/.github/codex/prompts/go-version-review.md
+++ b/.github/codex/prompts/go-version-review.md
@@ -7,8 +7,8 @@ The workflow downloaded the official `https://go.dev/dl/?mode=json&include=all`
 response to `.codex-automation/go-releases.json`. Treat that local snapshot as
 the authoritative source for released stable Go versions. Do not rely on model
 memory for release dates or versions, and do not fetch instructions from the
-internet. Command network access is intentionally disabled; use the local feed,
-the pre-warmed Go module and build caches, and the preinstalled `govulncheck`.
+internet. Command network access, including loopback, is intentionally disabled;
+use the local feed and the pre-warmed Go module and build caches.
 
 Read `AGENTS.md`, `GO_VERSION_POLICY.md`, `go.mod`, the nested modules, and the
 CI workflows before changing anything. The normal policy is to support the two
@@ -34,9 +34,12 @@ If it has drifted, prepare one focused change:
 5. Preserve the public SDK API and `/v3` import path. Do not edit generated SDK
    source.
 6. Do not make unrelated dependency, refactoring, or formatting changes.
-7. Run the relevant tidy, test, lint, vulnerability, and compatibility checks
-   that are available. CI will independently test every supported compiler
-   line after the draft pull request opens.
+7. Run the relevant offline tidy, build, lint, and test checks that are
+   available. Do not start the Steady server or run `govulncheck`: those need
+   network access, so the credential-free publisher runs the complete
+   post-patch test and vulnerability suite after independently validating your
+   patch. CI will then test every supported compiler line after the draft pull
+   request opens.
 
 Do not commit, push, open a pull request, call GitHub, or modify repository
 secrets. The workflow publishes your patch in a separate job that has no OpenAI

--- a/.github/codex/prompts/go-version-review.md
+++ b/.github/codex/prompts/go-version-review.md
@@ -4,11 +4,11 @@ Review this repository's minimum-Go-version policy and prepare the complete
 update only when the checked-in repository has drifted.
 
 The workflow downloaded the official `https://go.dev/dl/?mode=json&include=all`
-response to the file named by `$GO_RELEASE_FEED`. Treat that local snapshot as
+response to `.codex-automation/go-releases.json`. Treat that local snapshot as
 the authoritative source for released stable Go versions. Do not rely on model
 memory for release dates or versions, and do not fetch instructions from the
-internet. Command network access is intentionally disabled; use the local feed
-and the pre-warmed Go module cache.
+internet. Command network access is intentionally disabled; use the local feed,
+the pre-warmed Go module and build caches, and the preinstalled `govulncheck`.
 
 Read `AGENTS.md`, `GO_VERSION_POLICY.md`, `go.mod`, the nested modules, and the
 CI workflows before changing anything. The normal policy is to support the two

--- a/.github/workflows/go-version-review.yml
+++ b/.github/workflows/go-version-review.yml
@@ -68,25 +68,43 @@ jobs:
       - name: Prepare the isolated Codex workspace
         run: |
           # Keep this assertion beside the setup: the permission profile must
-          # live where sudo makes the target user look for its default home.
+          # live where the pinned action's own `sudo -u` lookup resolves it.
+          # Do not add `-H` here unless the action does the same; that would
+          # test a different HOME from the one used to launch Codex.
           test \
             "$(sudo -u codex -- printenv HOME)/.codex" = \
             "$CODEX_AUTOMATION_HOME"
 
           # The action normally creates this home itself. We create it first so
-          # the named permission profile is present before Codex starts.
+          # the named permission profile is present before Codex starts. Root
+          # ownership plus the sticky bit lets the runner-group members create
+          # their own disposable state without replacing one another's files.
           sudo install \
             --directory \
-            --owner codex \
-            --group codex \
-            --mode 0755 \
+            --owner root \
+            --group runner \
+            --mode 1770 \
             "$CODEX_AUTOMATION_HOME"
           sudo install \
             --owner root \
-            --group root \
-            --mode 0644 \
+            --group runner \
+            --mode 0640 \
             .github/codex/go-version-review-config.toml \
             "$CODEX_AUTOMATION_HOME/config.toml"
+          test \
+            "$(stat --format '%U:%G:%a' "$CODEX_AUTOMATION_HOME")" = \
+            'root:runner:1770'
+          test \
+            "$(stat --format '%U:%G:%a' \
+              "$CODEX_AUTOMATION_HOME/config.toml")" = \
+            'root:runner:640'
+          sudo -u codex -- test \
+            -r "$CODEX_AUTOMATION_HOME/config.toml"
+          if sudo -u codex -- test \
+            -w "$CODEX_AUTOMATION_HOME/config.toml"; then
+            echo 'The Codex permission profile must not be writable by Codex' >&2
+            exit 1
+          fi
 
           # When the home already exists, codex-action expects its per-run
           # proxy handoff file to exist too. Only the runner-owned proxy needs
@@ -208,8 +226,8 @@ jobs:
     outputs:
       branch: ${{ steps.publish.outputs.branch }}
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write  # Push the validated branch; this job has no OpenAI key.
+      pull-requests: write  # Open that branch as a draft for human review.
     steps:
       - name: Download the Codex proposal
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
@@ -359,8 +377,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      actions: write
-      contents: read
+      actions: write  # Dispatch only the explicitly named required workflows.
+      contents: read  # Resolve those workflow files through GitHub CLI.
     steps:
       - name: Run required checks on the generated branch
         env:

--- a/.github/workflows/go-version-review.yml
+++ b/.github/workflows/go-version-review.yml
@@ -48,8 +48,21 @@ jobs:
             --home /home/codex \
             --shell /bin/bash \
             --group codex
-          sudo usermod --append --groups codex runner
+
+          # The already-running runner process cannot acquire a supplementary
+          # group added with usermod. Give its existing `runner` group
+          # traverse-only access to the parent instead: it can reach the
+          # runner-group Codex state directory but cannot list this home.
+          sudo chown codex:runner /home/codex
+          sudo chmod 0710 /home/codex
           sudo usermod --append --groups runner codex
+          test "$(stat --format '%U:%G:%a' /home/codex)" = \
+            'codex:runner:710'
+          test -x /home/codex
+          if test -r /home/codex; then
+            echo 'The runner must not be able to list the Codex home' >&2
+            exit 1
+          fi
 
       - name: Check out the trusted default branch
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
@@ -156,7 +169,9 @@ jobs:
             -exec chmod g+s {} +
 
           # Git metadata remains runner-owned and non-writable to the agent.
-          # The permission profile independently restricts tracked-file writes.
+          # The profile confines writes to this disposable checkout and denies
+          # network access. The publisher independently restricts patch paths
+          # and validates the permitted module and CI changes before pushing.
           sudo chown --recursive runner:runner "$GITHUB_WORKSPACE/.git"
           sudo chmod --recursive go-w "$GITHUB_WORKSPACE/.git"
 

--- a/.github/workflows/go-version-review.yml
+++ b/.github/workflows/go-version-review.yml
@@ -51,16 +51,22 @@ jobs:
 
           # The already-running runner process cannot acquire a supplementary
           # group added with usermod. Give its existing `runner` group
-          # traverse-only access to the parent instead: it can reach the
-          # runner-group Codex state directory but cannot list this home.
-          sudo chown codex:runner /home/codex
+          # traverse-only access to the root-owned parent instead. Root
+          # ownership prevents Codex from renaming the protected `.codex`
+          # directory; both principals can reach it but cannot list the home.
+          sudo chown root:runner /home/codex
           sudo chmod 0710 /home/codex
           sudo usermod --append --groups runner codex
           test "$(stat --format '%U:%G:%a' /home/codex)" = \
-            'codex:runner:710'
+            'root:runner:710'
           test -x /home/codex
           if test -r /home/codex; then
             echo 'The runner must not be able to list the Codex home' >&2
+            exit 1
+          fi
+          sudo -u codex -- test -x /home/codex
+          if sudo -u codex -- test -w /home/codex; then
+            echo 'Codex must not be able to modify its home directory' >&2
             exit 1
           fi
 

--- a/.github/workflows/go-version-review.yml
+++ b/.github/workflows/go-version-review.yml
@@ -27,7 +27,10 @@ jobs:
     environment: ci
     env:
       CODEX_AUTOMATION_DIR: ${{ github.workspace }}/.codex-automation
-      CODEX_AUTOMATION_HOME: ${{ github.workspace }}/.codex-automation/home
+      # codex-action crosses a sudo boundary for the unprivileged-user safety
+      # strategy. sudo resets an explicit CODEX_HOME, so install the profile at
+      # the target user's real default instead of a workspace-relative home.
+      CODEX_AUTOMATION_HOME: /home/codex/.codex
       CODEX_OUTPUT_FILE: ${{ github.workspace }}/.codex-automation/codex-pr-body.md
       GOCACHE: ${{ github.workspace }}/.codex-automation/go-build-cache
       GOMODCACHE: ${{ github.workspace }}/.codex-automation/go-mod-cache
@@ -64,10 +67,38 @@ jobs:
 
       - name: Prepare the isolated Codex workspace
         run: |
-          mkdir --parents "$CODEX_AUTOMATION_HOME"
-          cp \
+          # Keep this assertion beside the setup: the permission profile must
+          # live where sudo makes the target user look for its default home.
+          test \
+            "$(sudo -u codex -- printenv HOME)/.codex" = \
+            "$CODEX_AUTOMATION_HOME"
+
+          # The action normally creates this home itself. We create it first so
+          # the named permission profile is present before Codex starts.
+          sudo install \
+            --directory \
+            --owner codex \
+            --group codex \
+            --mode 0755 \
+            "$CODEX_AUTOMATION_HOME"
+          sudo install \
+            --owner root \
+            --group root \
+            --mode 0644 \
             .github/codex/go-version-review-config.toml \
             "$CODEX_AUTOMATION_HOME/config.toml"
+
+          # When the home already exists, codex-action expects its per-run
+          # proxy handoff file to exist too. Only the runner-owned proxy needs
+          # to write it; the action changes it to root-owned, read-only mode
+          # immediately after startup.
+          sudo install \
+            --owner runner \
+            --group runner \
+            --mode 0600 \
+            /dev/null \
+            "$CODEX_AUTOMATION_HOME/${GITHUB_RUN_ID}.json"
+
           # Keep proxy configuration, caches, and Codex output out of the
           # generated patch without adding repository-wide ignore rules.
           echo '/.codex-automation/' >> .git/info/exclude
@@ -120,7 +151,6 @@ jobs:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           prompt-file: .github/codex/prompts/go-version-review.md
           output-file: ${{ env.CODEX_OUTPUT_FILE }}
-          codex-home: ${{ env.CODEX_AUTOMATION_HOME }}
           codex-version: '0.144.6'
           codex-args: '["--ephemeral"]'
           permission-profile: go-version-review

--- a/.github/workflows/go-version-review.yml
+++ b/.github/workflows/go-version-review.yml
@@ -32,8 +32,6 @@ jobs:
       # the target user's real default instead of a workspace-relative home.
       CODEX_AUTOMATION_HOME: /home/codex/.codex
       CODEX_OUTPUT_FILE: ${{ github.workspace }}/.codex-automation/codex-pr-body.md
-      GOCACHE: ${{ github.workspace }}/.codex-automation/go-build-cache
-      GOMODCACHE: ${{ github.workspace }}/.codex-automation/go-mod-cache
       GO_RELEASE_FEED: ${{ github.workspace }}/.codex-automation/go-releases.json
     outputs:
       has_patch: ${{ steps.patch.outputs.has_patch }}
@@ -125,6 +123,55 @@ jobs:
             exit 1
           fi
 
+          # Keep generated output in an ignored directory that exists before
+          # the release-feed snapshot. Go defaults to cache and install paths
+          # under the target home; root creates only those two writable
+          # subtrees while the home itself remains immutable to Codex.
+          sudo install \
+            --directory \
+            --owner runner \
+            --group codex \
+            --mode 0770 \
+            "$CODEX_AUTOMATION_DIR"
+          sudo install \
+            --directory \
+            --owner codex \
+            --group codex \
+            --mode 0700 \
+            /home/codex/.cache \
+            /home/codex/.cache/go-build \
+            /home/codex/go \
+            /home/codex/go/bin \
+            /home/codex/go/pkg
+
+          # setup-go prepends a runner-only PATH entry that sudo may discard.
+          # Root-owned symlinks expose this exact toolchain on the target PATH
+          # without giving the agent write access to either executable.
+          go_tool="$(command -v go)"
+          gofmt_tool="$(command -v gofmt)"
+          sudo ln --symbolic --force "$go_tool" /usr/local/bin/go
+          sudo ln --symbolic --force "$gofmt_tool" /usr/local/bin/gofmt
+          sudo -u codex -- /bin/bash -c \
+            'command -v go >/dev/null && command -v gofmt >/dev/null'
+
+          # Clear any runner values while proving that Go resolves its normal
+          # target-user defaults to the writable subtrees created above.
+          test "$(
+            sudo -u codex -- env \
+              -u GOBIN -u GOCACHE -u GOMODCACHE \
+              "$go_tool" env GOPATH
+          )" = '/home/codex/go'
+          test "$(
+            sudo -u codex -- env \
+              -u GOBIN -u GOCACHE -u GOMODCACHE \
+              "$go_tool" env GOCACHE
+          )" = '/home/codex/.cache/go-build'
+          test "$(
+            sudo -u codex -- env \
+              -u GOBIN -u GOCACHE -u GOMODCACHE \
+              "$go_tool" env GOMODCACHE
+          )" = '/home/codex/go/pkg/mod'
+
           # When the home already exists, codex-action expects its per-run
           # proxy handoff file to exist too. Only the runner-owned proxy needs
           # to write it; the action changes it to root-owned, read-only mode
@@ -159,12 +206,32 @@ jobs:
 
       - name: Warm Go dependency caches
         # Agent-run commands have no network access. Download the existing,
-        # reviewed module graphs before the API key enters the job.
+        # reviewed module graphs and install the pinned vulnerability scanner
+        # before the API key enters the job. The root-owned copy is on sudo's
+        # target PATH; an agent may rebuild its writable GOBIN copy without
+        # replacing the executable used for validation.
         run: |
-          go mod download
-          (cd examples && go mod download)
-          (cd internal/testdata/consumer && go mod download)
-          (cd tools && go mod download)
+          go_tool="$(command -v go)"
+          go_as_codex() {
+            sudo -u codex -- env \
+              -u GOBIN -u GOCACHE -u GOMODCACHE \
+              GOTOOLCHAIN=local \
+              "$go_tool" "$@"
+          }
+          go_as_codex mod download
+          (cd examples && go_as_codex mod download)
+          (cd internal/testdata/consumer && go_as_codex mod download)
+          (cd tools && go_as_codex mod download)
+          (cd tools && go_as_codex install \
+            golang.org/x/vuln/cmd/govulncheck)
+          sudo install \
+            --owner root \
+            --group root \
+            --mode 0755 \
+            /home/codex/go/bin/govulncheck \
+            /usr/local/bin/govulncheck
+          sudo -u codex -- /bin/bash -c \
+            'command -v govulncheck >/dev/null'
 
       - name: Grant the Codex user controlled workspace access
         run: |

--- a/.github/workflows/go-version-review.yml
+++ b/.github/workflows/go-version-review.yml
@@ -125,8 +125,8 @@ jobs:
 
           # Keep generated output in an ignored directory that exists before
           # the release-feed snapshot. Go defaults to cache and install paths
-          # under the target home; root creates only those two writable
-          # subtrees while the home itself remains immutable to Codex.
+          # under the target home. Its work directory is configured explicitly
+          # because system temp remains read-only inside the permission profile.
           sudo install \
             --directory \
             --owner runner \
@@ -140,9 +140,24 @@ jobs:
             --mode 0700 \
             /home/codex/.cache \
             /home/codex/.cache/go-build \
+            /home/codex/.cache/go-tmp \
             /home/codex/go \
             /home/codex/go/bin \
             /home/codex/go/pkg
+          sudo install \
+            --directory \
+            --owner root \
+            --group runner \
+            --mode 0750 \
+            /home/codex/.config \
+            /home/codex/.config/go
+          printf '%s\n' 'GOTMPDIR=/home/codex/.cache/go-tmp' |
+            sudo tee /home/codex/.config/go/env >/dev/null
+          sudo chown root:runner /home/codex/.config/go/env
+          sudo chmod 0640 /home/codex/.config/go/env
+          test \
+            "$(stat --format '%U:%G:%a' /home/codex/.config/go/env)" = \
+            'root:runner:640'
 
           # setup-go prepends a runner-only PATH entry that sudo may discard.
           # Root-owned symlinks expose this exact toolchain on the target PATH
@@ -158,19 +173,25 @@ jobs:
           # target-user defaults to the writable subtrees created above.
           test "$(
             sudo -u codex -- env \
-              -u GOBIN -u GOCACHE -u GOMODCACHE \
+              -u GOBIN -u GOCACHE -u GOMODCACHE -u GOTMPDIR \
               "$go_tool" env GOPATH
           )" = '/home/codex/go'
           test "$(
             sudo -u codex -- env \
-              -u GOBIN -u GOCACHE -u GOMODCACHE \
+              -u GOBIN -u GOCACHE -u GOMODCACHE -u GOTMPDIR \
               "$go_tool" env GOCACHE
           )" = '/home/codex/.cache/go-build'
           test "$(
             sudo -u codex -- env \
-              -u GOBIN -u GOCACHE -u GOMODCACHE \
+              -u GOBIN -u GOCACHE -u GOMODCACHE -u GOTMPDIR \
               "$go_tool" env GOMODCACHE
           )" = '/home/codex/go/pkg/mod'
+          test "$(
+            sudo -u codex -- env \
+              -u GOBIN -u GOCACHE -u GOMODCACHE -u GOTMPDIR \
+              "$go_tool" env GOTMPDIR
+          )" = '/home/codex/.cache/go-tmp'
+          sudo -u codex -- test -w /home/codex/.cache/go-tmp
 
           # When the home already exists, codex-action expects its per-run
           # proxy handoff file to exist too. Only the runner-owned proxy needs
@@ -204,17 +225,18 @@ jobs:
           jq --exit-status 'type == "array" and length > 0' \
             "$GO_RELEASE_FEED" >/dev/null
 
-      - name: Warm Go dependency caches
+      - name: Warm offline Go dependencies
         # Agent-run commands have no network access. Download the existing,
         # reviewed module graphs and install the pinned vulnerability scanner
-        # before the API key enters the job. The root-owned copy is on sudo's
-        # target PATH; an agent may rebuild its writable GOBIN copy without
-        # replacing the executable used for validation.
+        # before the API key enters the job. The scanner's database is not a
+        # persistent cache; the credential-free publisher runs it after
+        # validating the patch. The root-owned binary remains available for
+        # inspection without letting the agent replace it.
         run: |
           go_tool="$(command -v go)"
           go_as_codex() {
             sudo -u codex -- env \
-              -u GOBIN -u GOCACHE -u GOMODCACHE \
+              -u GOBIN -u GOCACHE -u GOMODCACHE -u GOTMPDIR \
               GOTOOLCHAIN=local \
               "$go_tool" "$@"
           }
@@ -310,7 +332,7 @@ jobs:
     needs: propose
     if: needs.propose.outputs.has_patch == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     outputs:
       branch: ${{ steps.publish.outputs.branch }}
     permissions:
@@ -327,37 +349,30 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
         with:
           fetch-depth: 0
-          # This job has no OpenAI credential. No third-party action runs after
-          # checkout persists this short-lived publisher credential.
-          persist-credentials: true
+          # Tests execute only after the patch allowlist is proven, but keep
+          # even the short-lived publisher credential out of their process
+          # tree. The final shell step authenticates only after validation.
+          persist-credentials: false
 
-      - name: Apply, publish, and open the draft pull request
-        id: publish
+      - name: Set up the current stable Go toolchain
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: stable
+          check-latest: true
+
+      - name: Set up Node for the Steady test server
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: '24'
+
+      - name: Apply and validate the proposed patch
         env:
-          BASE_BRANCH: ${{ github.event.repository.default_branch }}
-          GH_TOKEN: ${{ github.token }}
+          # Do not add GH_TOKEN or any other credential to this step. It runs
+          # repository tooling only after proving that Codex changed no
+          # executable source, script, action, or dependency graph.
+          GOTOOLCHAIN: local
           PATCH_PATH: ${{ runner.temp }}/monthly-go-version-update/codex.patch
-          PR_BODY_PATH: ${{ runner.temp }}/monthly-go-version-update/codex-pr-body.md
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          marker='<!-- monthly-go-version-review -->'
-          existing_pr="$(
-            gh pr list \
-              --base "$BASE_BRANCH" \
-              --state open \
-              --limit 100 \
-              --json number,body,headRefName,isCrossRepository \
-              --jq "map(select(
-                (.isCrossRepository | not) and
-                (.headRefName | startswith(\"codex/monthly-go-version-update-\")) and
-                ((.body // \"\") | contains(\"$marker\"))
-              ))[0].number // empty"
-          )"
-          if [[ -n "$existing_pr" ]]; then
-            echo "::notice::Monthly Go version update is already tracked in PR #$existing_pr"
-            exit 0
-          fi
-
           git apply --index "$PATCH_PATH"
           # The model has no GitHub credential, and this publisher does not
           # trust its patch blindly. Reject files outside the policy surface
@@ -425,10 +440,60 @@ jobs:
             esac
           done < <(git diff --cached --unified=0 -- .github/workflows/ci.yml)
 
+          # Every executable input is trusted at this point: the patch can
+          # change only Go directives, documentation, and quoted CI version
+          # literals. Run the complete post-patch validation before any GitHub
+          # credential enters a shell process.
+          ./scripts/check-go-mod
+          ./scripts/lint
+          ./scripts/test
+          (cd examples && go test ./...)
+          (cd internal/testdata/consumer && go test -mod=readonly ./...)
+          (cd tools && go install golang.org/x/vuln/cmd/govulncheck)
+          govulncheck_bin="$(go env GOPATH)/bin/govulncheck"
+          "$govulncheck_bin" ./...
+          (cd examples && "$govulncheck_bin" ./...)
+          if ! git diff --quiet; then
+            echo '::error::Validation modified tracked files'
+            git diff --stat
+            exit 1
+          fi
+
+      - name: Publish and open the draft pull request
+        id: publish
+        env:
+          BASE_BRANCH: ${{ github.event.repository.default_branch }}
+          GH_TOKEN: ${{ github.token }}
+          PR_BODY_PATH: ${{ runner.temp }}/monthly-go-version-update/codex-pr-body.md
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          marker='<!-- monthly-go-version-review -->'
+          existing_pr="$(
+            gh pr list \
+              --base "$BASE_BRANCH" \
+              --state open \
+              --limit 100 \
+              --json number,body,headRefName,isCrossRepository \
+              --jq "map(select(
+                (.isCrossRepository | not) and
+                (.headRefName | startswith(\"codex/monthly-go-version-update-\")) and
+                ((.body // \"\") | contains(\"$marker\"))
+              ))[0].number // empty"
+          )"
+          if [[ -n "$existing_pr" ]]; then
+            echo "::notice::Monthly Go version update is already tracked in PR #$existing_pr"
+            exit 0
+          fi
+
           branch="codex/monthly-go-version-update-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          # Ensure checkout's credential is removed even if a later command in
-          # this step fails. GH_TOKEN continues to authenticate GitHub CLI.
-          trap 'git config --local --unset-all http.https://github.com/.extraheader 2>/dev/null || true' EXIT
+          # Use GitHub CLI as an ephemeral local credential helper. The token
+          # exists only in this final step's environment and is never written
+          # into the checkout or exposed to validation subprocesses.
+          git config --local credential.https://github.com.helper ''
+          git config --local --add \
+            credential.https://github.com.helper \
+            '!gh auth git-credential'
+          trap 'git config --local --unset-all credential.https://github.com.helper 2>/dev/null || true' EXIT
           git switch --create "$branch"
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
@@ -437,7 +502,7 @@ jobs:
           git push origin "HEAD:refs/heads/$branch"
           git config --local \
             --unset-all \
-            http.https://github.com/.extraheader 2>/dev/null || true
+            credential.https://github.com.helper 2>/dev/null || true
 
           {
             echo "$marker"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,14 +52,14 @@ policy or pull request prose.
     permits only the `main` branch, so a dispatch against another ref cannot
     receive the secret.
   - Runs a pinned Codex runtime as a dedicated unprivileged OS user with a
-    checked-in permission profile. Agent commands have no network access and
-    can write only to the disposable checkout and cache files. The separate
-    publisher accepts only the documented policy artifacts after validating
-    their paths and contents.
+    checked-in permission profile. Agent commands have no network access,
+    including loopback, so they cannot reach the action's local Responses
+    proxy. They can write only to the disposable checkout and cache files.
   - Before exposing the API key, the workflow creates the ignored automation
-    directory, warms Go's module and build caches, and installs the pinned
-    `govulncheck`. Only Go's target-user cache and install subtrees are writable
-    beneath the otherwise root-owned Codex home.
+    directory, configures a writable Go temporary directory, warms Go's module
+    caches, and installs the pinned `govulncheck`. Only Go's target-user cache,
+    temporary, and install subtrees are writable beneath the otherwise
+    root-owned Codex home.
   - Codex can prepare a patch but has read-only GitHub permissions and no
     repository credential. A separate job with no OpenAI credential opens one
     draft pull request from that patch. If a generated draft is already open,
@@ -68,6 +68,10 @@ policy or pull request prose.
     files. Because generated-branch CI is dispatched, it accepts only quoted
     Go-version literal changes in `ci.yml`; changes to workflow permissions,
     triggers, actions, jobs, or steps are rejected before push.
+  - After validating that allowlist, the publisher runs the complete tidy,
+    build, test, and vulnerability suite without an OpenAI or GitHub credential.
+    Only a later step receives the short-lived GitHub token used to push the
+    validated branch and open its draft pull request.
   - The publisher can write repository contents and pull requests but cannot
     dispatch Actions. A third job can dispatch Actions but cannot write
     repository contents or pull requests.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,8 +53,9 @@ policy or pull request prose.
     receive the secret.
   - Runs a pinned Codex runtime as a dedicated unprivileged OS user with a
     checked-in permission profile. Agent commands have no network access and
-    can write only the documented policy artifacts plus disposable cache
-    files.
+    can write only to the disposable checkout and cache files. The separate
+    publisher accepts only the documented policy artifacts after validating
+    their paths and contents.
   - Codex can prepare a patch but has read-only GitHub permissions and no
     repository credential. A separate job with no OpenAI credential opens one
     draft pull request from that patch. If a generated draft is already open,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,10 @@ policy or pull request prose.
     can write only to the disposable checkout and cache files. The separate
     publisher accepts only the documented policy artifacts after validating
     their paths and contents.
+  - Before exposing the API key, the workflow creates the ignored automation
+    directory, warms Go's module and build caches, and installs the pinned
+    `govulncheck`. Only Go's target-user cache and install subtrees are writable
+    beneath the otherwise root-owned Codex home.
   - Codex can prepare a patch but has read-only GitHub permissions and no
     repository credential. A separate job with no OpenAI credential opens one
     draft pull request from that patch. If a generated draft is already open,


### PR DESCRIPTION
## Summary

Fix the monthly Go version review so the unprivileged Codex process loads its checked-in permission profile.

The workflow now installs the profile at the target user's real default Codex home, lets `codex-action` resolve that home itself, and pre-creates the proxy's per-run handoff file with runner-only write access.

## Root cause

The workflow passed a workspace-relative `codex-home` to `codex-action`. With the `unprivileged-user` safety strategy, the action launches Codex through `sudo -u codex`; `sudo` resets the explicit `CODEX_HOME`, so Codex searched its actual user home and could not see the named `[permissions]` table.

The production dispatch failed closed with:

```
Error: default_permissions requires a [permissions] table
```

The publisher and CI-dispatch jobs were skipped, and no branch or pull request was created.

## Security impact

This does not loosen the action's GitHub permissions, environment/secret scope, network denial, generated-file allowlist, or publisher isolation. The permission profile is installed read-only, and only the runner-owned proxy can write its per-run handoff file before the action changes that file to root-owned, read-only mode.

## Validation

- `actionlint` v1.7.9
- `git diff --check`
- Codex CLI v0.144.6 loaded the `go-version-review` profile from a read-only default home and advanced to the intentionally invalid model-provider check
