### PR TITLE
ci: tighten release and Codex secret boundaries

### DIFF
--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -32,7 +32,6 @@ jobs:
     needs: release
     if: ${{ needs.release.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
-    environment: publish
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -19,8 +19,6 @@ jobs:
       releases_created: ${{ steps.release.outputs.releases_created }}
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
-
       - uses: stainless-api/trigger-release-please@bb6677c5a04578eec1ccfd9e1913b5b78ed64c61 # v1.4.0
         id: release
         with:
@@ -35,6 +33,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          persist-credentials: false
 
       - name: Generate godocs
         run: |

--- a/.github/workflows/go-version-review.yml
+++ b/.github/workflows/go-version-review.yml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   propose:
     name: Propose Go version update
+    if: github.ref == 'refs/heads/main' && github.repository == 'openai/openai-go'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     # OPENAI_API_KEY already lives in this environment. The environment is


### PR DESCRIPTION
## Summary

- keep the `publish` environment—and therefore access to `STAINLESS_API_KEY`—on only the Stainless release-trigger job
- remove the release trigger's unnecessary checkout and prevent credential persistence in the secretless godocs checkout
- require the monthly Codex proposal job to run only for `openai/openai-go` on `main`

## Why

The Codex runtime/profile handoff issue was fixed separately by #721 and is no longer part of this diff.

The remaining changes are still useful defense in depth. The godocs job does not use the Stainless credential and should not opt into the `publish` environment or any future approval policy attached to it. The Codex job's repository/ref restriction is now checked into the workflow instead of relying only on live environment configuration.

The live environments are already reconciled: `ci` contains only `OPENAI_API_KEY`, `publish` contains only `STAINLESS_API_KEY`, both permit only `main`, and neither has a reviewer gate.

## Validation

- rebased onto `main` at `1c660eb` (#721)
- `actionlint` and YAML parsing across the workflows
- `./scripts/check-go-mod`
- `./scripts/lint`
- `./scripts/test`
- examples and external-consumer tests
- `govulncheck` for the root and examples modules with Go 1.26.5
- all GitHub CI and CodeQL checks green
- OkTest: 237/237 SDK tests passed