### PR TITLE
ci: create Go workspace before setup-go

### DIFF
--- a/.github/workflows/go-version-review.yml
+++ b/.github/workflows/go-version-review.yml
@@ -51,17 +51,9 @@ jobs:
           # a repository credential.
           persist-credentials: false
 
-      - name: Set up the current stable Go toolchain
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version: stable
-          check-latest: true
-          # setup-go's post action runs after Codex. Never save caches that the
-          # model can write, or a later publisher could restore poisoned module
-          # sources across the otherwise clean job boundary.
-          cache: false
-
-      - name: Prepare the disposable automation workspace
+      - name: Create the disposable automation workspace
+        # These job-wide Go paths must exist before setup-go invokes `go env`.
+        # Creating them does not require Go or expose the API key.
         run: |
           mkdir -p \
             "$CODEX_AUTOMATION_DIR" \
@@ -79,6 +71,18 @@ jobs:
           echo '/.codex-automation/' >> \
             "$(git rev-parse --git-path info/exclude)"
 
+      - name: Set up the current stable Go toolchain
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: stable
+          check-latest: true
+          # setup-go's post action runs after Codex. Never save caches that the
+          # model can write, or a later publisher could restore poisoned module
+          # sources across the otherwise clean job boundary.
+          cache: false
+
+      - name: Verify the Go automation environment
+        run: |
           # GOENV=off prevents Go from reading or writing the runner account's
           # persistent per-user configuration. Current supported toolchains
           # report an empty path; accept `off` too for forward compatibility.

--- a/.github/workflows/go-version-review.yml
+++ b/.github/workflows/go-version-review.yml
@@ -180,7 +180,7 @@ jobs:
 
       - name: Upload the proposed patch
         if: steps.patch.outputs.has_patch == 'true'
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: monthly-go-version-update
           # Both files are staged under one non-hidden directory so the

--- a/.github/workflows/go-version-review.yml
+++ b/.github/workflows/go-version-review.yml
@@ -202,7 +202,7 @@ jobs:
       pull-requests: write  # Open that branch as a draft for human review.
     steps:
       - name: Download the Codex proposal
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: monthly-go-version-update
           path: ${{ runner.temp }}/monthly-go-version-update

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,11 +57,12 @@ policy or pull request prose.
     and system temporary directories and denies command network access.
   - Before exposing the API key, the workflow disables Go's per-user config and
     automatic toolchain selection, creates ignored workspace-local Go cache and
-    temporary directories, and warms every module's dependencies. `setup-go`
-    caching is disabled in this job so those model-writable directories are
-    never persisted or restored across the publisher boundary. This avoids
-    cross-user HOME, XDG, and cache ownership setup while keeping model-run Go
-    commands inside the sandbox's writable workspace.
+    temporary directories before `setup-go` probes the Go environment, and
+    warms every module's dependencies. `setup-go` caching is disabled in this
+    job so those model-writable directories are never persisted or restored
+    across the publisher boundary. This avoids cross-user HOME, XDG, and cache
+    ownership setup while keeping model-run Go commands inside the sandbox's
+    writable workspace.
   - Codex can prepare a patch but has read-only GitHub permissions and no
     repository credential. A separate job with no OpenAI credential opens one
     draft pull request from that patch. If a generated draft is already open,


### PR DESCRIPTION
## Summary

- create the workspace-local Go cache and temporary directories before `setup-go`
- keep the environment assertions after the toolchain is available
- update `actions/upload-artifact` from pinned v5.0.0 to v6.0.0 and `actions/download-artifact` from pinned v6.0.0 to v7.0.0 so both natively use Node 24 instead of relying on GitHub's forced compatibility mode
- document why the setup ordering is required

## Root cause

Production run [#29961933853](https://github.com/openai/openai-go/actions/runs/29961933853) showed that `actions/setup-go` invokes `go env`. The job-wide `GOTMPDIR` pointed at `.codex-automation/go-tmp`, but that directory was created by the following step, so setup failed before the Go release feed, API key, or Codex action was reached.

## Security

This does not change workflow permissions, secrets, the Codex sandbox, the publisher allowlist, or the job boundaries. `setup-go` caching remains disabled. The directories are created before any step receives `OPENAI_API_KEY`.

The pre-merge integration runs used a disposable branch without the `ci` environment. The Codex/API-key step and credentialed publication step were branch-gated off, preserving the main-only secret boundary.

## Validation

- [GitHub-hosted preflight](https://github.com/openai/openai-go/actions/runs/29962381265): checkout, directory creation, real `setup-go@v6.4.0`, Go environment assertions, official release feed, all module downloads, tidy checks, builds, and tests
- [Synthetic full Go-floor raise](https://github.com/openai/openai-go/actions/runs/29963025931): proposal packaging, `upload-artifact@v6.0.0`, artifact handoff, all approved policy surfaces, publisher allowlist, module-graph and CI-workflow validation, full tests with Steady, `govulncheck`, and clean-tree verification
- [Synthetic no-op](https://github.com/openai/openai-go/actions/runs/29963249177): a successful proposal with no repository diff set `has_patch=false` and cleanly skipped artifact upload, publication, and dispatch
- [Final artifact and dispatcher integration](https://github.com/openai/openai-go/actions/runs/29963581129): native Node 24 upload/download, publisher validation, and the restricted dispatcher all succeeded without deprecation annotations; dispatched [CI](https://github.com/openai/openai-go/actions/runs/29963718073), [breaking-change detection](https://github.com/openai/openai-go/actions/runs/29963719057), and [CodeQL](https://github.com/openai/openai-go/actions/runs/29963720110) all passed
- [Expected malicious-patch rejection](https://github.com/openai/openai-go/actions/runs/29962684511): publisher rejected a model-written executable file before publication
- [Expected impossible-floor rejection](https://github.com/openai/openai-go/actions/runs/29962906018): `go mod tidy -diff` rejected a synthetic downgrade below the dependency graph's minimum
- exact publisher block locally rejected dependency-graph tampering, CI permission changes, file-mode changes, and duplicate Go directives
- `actionlint` with ShellCheck, `zizmor --pedantic`, parsed-workflow ordering assertions, normal PR CI, CodeQL, and OkTest (237/237)
