### PR TITLE
fix(polling): honor context cancellation during waits

### DIFF
--- a/polling.go
+++ b/polling.go
@@ -25,6 +25,22 @@ func getPollInterval(raw *http.Response) (ms int) {
 	return 1000
 }
 
+func waitForPoll(ctx context.Context, interval time.Duration) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
 // PollStatus waits until a VectorStoreFile is no longer in an incomplete state and returns it.
 // Pass 0 as pollIntervalMs to use the default polling interval of 1 second.
 func (r *VectorStoreFileService) PollStatus(ctx context.Context, vectorStoreID string, fileID string, pollIntervalMs int, opts ...option.RequestOption) (*VectorStoreFile, error) {
@@ -42,20 +58,15 @@ func (r *VectorStoreFileService) PollStatus(ctx context.Context, vectorStoreID s
 			if pollIntervalMs <= 0 {
 				pollIntervalMs = getPollInterval(raw)
 			}
-			time.Sleep(time.Duration(pollIntervalMs) * time.Millisecond)
+			if err := waitForPoll(ctx, time.Duration(pollIntervalMs)*time.Millisecond); err != nil {
+				return nil, err
+			}
 		case VectorStoreFileStatusCancelled,
 			VectorStoreFileStatusCompleted,
 			VectorStoreFileStatusFailed:
 			return file, nil
 		default:
 			return nil, fmt.Errorf("invalid vector store file status during polling: received %s", file.Status)
-		}
-
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		default:
-
 		}
 	}
 }
@@ -77,19 +88,15 @@ func (r *VectorStoreFileBatchService) PollStatus(ctx context.Context, vectorStor
 			if pollIntervalMs <= 0 {
 				pollIntervalMs = getPollInterval(raw)
 			}
-			time.Sleep(time.Duration(pollIntervalMs) * time.Millisecond)
+			if err := waitForPoll(ctx, time.Duration(pollIntervalMs)*time.Millisecond); err != nil {
+				return nil, err
+			}
 		case VectorStoreFileBatchStatusCancelled,
 			VectorStoreFileBatchStatusCompleted,
 			VectorStoreFileBatchStatusFailed:
 			return batch, nil
 		default:
 			return nil, fmt.Errorf("invalid vector store file batch status during polling: received %s", batch.Status)
-		}
-
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		default:
 		}
 	}
 }
@@ -111,19 +118,14 @@ func (r *VideoService) PollStatus(ctx context.Context, videoID string, pollInter
 			if pollIntervalMs <= 0 {
 				pollIntervalMs = getPollInterval(raw)
 			}
-			time.Sleep(time.Duration(pollIntervalMs) * time.Millisecond)
+			if err := waitForPoll(ctx, time.Duration(pollIntervalMs)*time.Millisecond); err != nil {
+				return nil, err
+			}
 		case VideoStatusCompleted,
 			VideoStatusFailed:
 			return video, nil
 		default:
 			return nil, fmt.Errorf("invalid video status during polling: received %s", video.Status)
-		}
-
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		default:
-
 		}
 	}
 }

--- a/polling_test.go
+++ b/polling_test.go
@@ -18,26 +18,39 @@ func (f pollingHTTPDoerFunc) Do(req *http.Request) (*http.Response, error) {
 	return f(req)
 }
 
+type cancelOnCloseBody struct {
+	io.Reader
+	cancel context.CancelFunc
+}
+
+func (b *cancelOnCloseBody) Close() error {
+	b.cancel()
+	return nil
+}
+
 func TestVideoPollStatusReturnsWhenContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
 	client := NewClient(
 		option.WithAPIKey("test-key"),
 		option.WithHTTPClient(pollingHTTPDoerFunc(func(req *http.Request) (*http.Response, error) {
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Header:     http.Header{"Content-Type": []string{"application/json"}},
-				Body:       io.NopCloser(strings.NewReader(`{"id":"video_123","status":"in_progress"}`)),
-				Request:    req,
+				Body: &cancelOnCloseBody{
+					Reader: strings.NewReader(`{"id":"video_123","status":"in_progress"}`),
+					cancel: cancel,
+				},
+				Request: req,
 			}, nil
 		})),
 	)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
-	t.Cleanup(cancel)
-
 	start := time.Now()
 	_, err := client.Videos.PollStatus(ctx, "video_123", 1000)
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("PollStatus() error = %v, want %v", err, context.DeadlineExceeded)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("PollStatus() error = %v, want %v", err, context.Canceled)
 	}
 	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
 		t.Fatalf("PollStatus() took %s after context cancellation", elapsed)

--- a/polling_test.go
+++ b/polling_test.go
@@ -1,0 +1,45 @@
+package openai
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openai/openai-go/v3/option"
+)
+
+type pollingHTTPDoerFunc func(*http.Request) (*http.Response, error)
+
+func (f pollingHTTPDoerFunc) Do(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestVideoPollStatusReturnsWhenContextCancelled(t *testing.T) {
+	client := NewClient(
+		option.WithAPIKey("test-key"),
+		option.WithHTTPClient(pollingHTTPDoerFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"id":"video_123","status":"in_progress"}`)),
+				Request:    req,
+			}, nil
+		})),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	t.Cleanup(cancel)
+
+	start := time.Now()
+	_, err := client.Videos.PollStatus(ctx, "video_123", 1000)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("PollStatus() error = %v, want %v", err, context.DeadlineExceeded)
+	}
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("PollStatus() took %s after context cancellation", elapsed)
+	}
+}


### PR DESCRIPTION
## Summary

- replace unconditional polling sleeps with context-aware waits
- apply the behavior to vector store file, file batch, and video polling
- cover cancellation through the public video polling helper

## Why

The polling helpers checked context cancellation only after time.Sleep returned. Cancellation could therefore be delayed by the full caller-provided or server-provided polling interval.

The regression test cancels after a successful response has been consumed but before the poll wait starts, so it deterministically exercises the affected path.

## Impact

Polling now returns promptly when its context is canceled, even during the wait between requests.

## Checks

- SKIP_MOCK_TESTS=true go test ./...
- go test -race . -run TestVideoPollStatusReturnsWhenContextCancelled -count=10
- ./scripts/lint
- git diff --check