### PR TITLE
fix(pagination): preserve custom HTTP clients across pages

### DIFF
--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -736,6 +736,7 @@ func (cfg *RequestConfig) Clone(ctx context.Context) *RequestConfig {
 		Context:            ctx,
 		Request:            req,
 		BaseURL:            cfg.BaseURL,
+		CustomHTTPDoer:     cfg.CustomHTTPDoer,
 		HTTPClient:         cfg.HTTPClient,
 		Middlewares:        cfg.Middlewares,
 		APIKey:             cfg.APIKey,

--- a/internal/requestconfig/requestconfig_test.go
+++ b/internal/requestconfig/requestconfig_test.go
@@ -56,6 +56,31 @@ func newBodyCloseRequestConfig(t *testing.T, body io.ReadCloser) *RequestConfig 
 	return cfg
 }
 
+func TestClonePreservesCustomHTTPDoer(t *testing.T) {
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.com", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	called := false
+	doer := httpDoerFunc(func(*http.Request) (*http.Response, error) {
+		called = true
+		return nil, nil
+	})
+	cfg := &RequestConfig{Request: req, CustomHTTPDoer: doer}
+
+	clone := cfg.Clone(context.Background())
+	if clone.CustomHTTPDoer == nil {
+		t.Fatal("CustomHTTPDoer is nil after cloning")
+	}
+	if _, err := clone.CustomHTTPDoer.Do(req); err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Fatal("cloned CustomHTTPDoer did not call the configured client")
+	}
+}
+
 func TestFormatPathEscapesPathParams(t *testing.T) {
 	tests := map[string]struct {
 		format string

--- a/internal/requestconfig/requestconfig_test.go
+++ b/internal/requestconfig/requestconfig_test.go
@@ -56,31 +56,6 @@ func newBodyCloseRequestConfig(t *testing.T, body io.ReadCloser) *RequestConfig 
 	return cfg
 }
 
-func TestClonePreservesCustomHTTPDoer(t *testing.T) {
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.com", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	called := false
-	doer := httpDoerFunc(func(*http.Request) (*http.Response, error) {
-		called = true
-		return nil, nil
-	})
-	cfg := &RequestConfig{Request: req, CustomHTTPDoer: doer}
-
-	clone := cfg.Clone(context.Background())
-	if clone.CustomHTTPDoer == nil {
-		t.Fatal("CustomHTTPDoer is nil after cloning")
-	}
-	if _, err := clone.CustomHTTPDoer.Do(req); err != nil {
-		t.Fatal(err)
-	}
-	if !called {
-		t.Fatal("cloned CustomHTTPDoer did not call the configured client")
-	}
-}
-
 func TestFormatPathEscapesPathParams(t *testing.T) {
 	tests := map[string]struct {
 		format string

--- a/pagination_custom_http_test.go
+++ b/pagination_custom_http_test.go
@@ -1,0 +1,85 @@
+package openai_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+)
+
+type paginationHTTPDoerFunc func(*http.Request) (*http.Response, error)
+
+func (f paginationHTTPDoerFunc) Do(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type paginationRoundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f paginationRoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestPaginationPreservesCustomHTTPClient(t *testing.T) {
+	calls := 0
+	customClient := paginationHTTPDoerFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+
+		var body string
+		switch calls {
+		case 1:
+			if after := req.URL.Query().Get("after"); after != "" {
+				t.Fatalf("first request after = %q, want empty", after)
+			}
+			body = `{"data":[{"id":"file_1"}],"has_more":true}`
+		case 2:
+			if after := req.URL.Query().Get("after"); after != "file_1" {
+				t.Fatalf("second request after = %q, want %q", after, "file_1")
+			}
+			body = `{"data":[{"id":"file_2"}],"has_more":false}`
+		default:
+			t.Fatalf("unexpected request %d", calls)
+		}
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    req,
+		}, nil
+	})
+	fallbackClient := &http.Client{
+		Transport: paginationRoundTripperFunc(func(*http.Request) (*http.Response, error) {
+			return nil, errors.New("fallback HTTP client used")
+		}),
+	}
+	client := openai.NewClient(
+		option.WithAPIKey("test-key"),
+		option.WithBaseURL("https://example.com/v1/"),
+		option.WithHTTPClient(fallbackClient),
+		option.WithHTTPClient(customClient),
+		option.WithMaxRetries(0),
+	)
+
+	page, err := client.Files.List(context.Background(), openai.FileListParams{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	nextPage, err := page.GetNextPage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if nextPage == nil {
+		t.Fatal("next page is nil")
+	}
+	if len(nextPage.Data) != 1 || nextPage.Data[0].ID != "file_2" {
+		t.Fatalf("next page data = %#v, want file_2", nextPage.Data)
+	}
+	if calls != 2 {
+		t.Fatalf("custom client calls = %d, want 2", calls)
+	}
+}


### PR DESCRIPTION
## Summary

- preserve the configured custom HTTP client when cloning request state
- cover the public Files.List to GetNextPage flow with two cursor pages
- fail the regression test immediately if page two falls back to the standard client

## Why

Pagination clones the initial request config before fetching the next page. The clone copied the standard HTTP client but omitted a custom non-standard client, so a client provided through option.WithHTTPClient could be replaced by the default client after page one.

## Impact

Every page now uses the HTTP client configured by the caller.

## Checks

- SKIP_MOCK_TESTS=true go test ./...
- go test -race . -run TestPaginationPreservesCustomHTTPClient -count=10
- ./scripts/lint
- git diff --check