### PR TITLE
ci: split supported Go version gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,28 @@ jobs:
         working-directory: examples
         run: govulncheck ./...
 
+  go_version_tests:
+    timeout-minutes: 5
+    name: test (all supported Go versions)
+    runs-on: ubuntu-latest
+    if: >-
+      always() &&
+      (github.event_name == 'pull_request' ||
+      github.event_name == 'workflow_dispatch')
+    needs:
+      - test
+    steps:
+      - name: Require every supported Go version
+        env:
+          TEST_RESULT: ${{ needs.test.result }}
+        run: |
+          if [[ "$TEST_RESULT" != "success" ]]; then
+            echo "Supported Go version tests ended with: $TEST_RESULT"
+            exit 1
+          fi
+
+  # Keep this compatibility aggregate until the main ruleset requires
+  # "test (all supported Go versions)", "lint", and "govulncheck" directly.
   required:
     timeout-minutes: 5
     name: Go support policy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,37 +206,3 @@ jobs:
             echo "Supported Go version tests ended with: $TEST_RESULT"
             exit 1
           fi
-
-  # Keep this compatibility aggregate until the main ruleset requires
-  # "test (all supported Go versions)", "lint", and "govulncheck" directly.
-  required:
-    timeout-minutes: 5
-    name: Go support policy
-    runs-on: ubuntu-latest
-    if: >-
-      always() &&
-      (github.event_name == 'pull_request' ||
-      github.event_name == 'workflow_dispatch')
-    needs:
-      - lint
-      - test
-      - vulnerability
-    steps:
-      - name: Require every Go safety job
-        env:
-          LINT_RESULT: ${{ needs.lint.result }}
-          TEST_RESULT: ${{ needs.test.result }}
-          VULNERABILITY_RESULT: ${{ needs.vulnerability.result }}
-        run: |
-          failed=0
-          for result in \
-            "$LINT_RESULT" \
-            "$TEST_RESULT" \
-            "$VULNERABILITY_RESULT"
-          do
-            if [[ "$result" != "success" ]]; then
-              echo "Required Go safety job ended with: $result"
-              failed=1
-            fi
-          done
-          exit "$failed"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,10 +38,6 @@ checks on `main`. Together they prove the proposed repository state builds,
 tests, and passes reachable-vulnerability analysis; they do not attempt to
 interpret release policy or pull request prose.
 
-During the required-check migration, the legacy `Go support policy` aggregate
-remains as a compatibility check. Remove it after the `main` ruleset directly
-requires `test (all supported Go versions)`, `lint`, and `govulncheck`.
-
 ## Automation map
 
 - `.github/workflows/ci.yml`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,10 +32,15 @@ When changing a `go` directive:
    versions. Do not promise security backports for an old SDK release.
 5. Obtain SDK CODEOWNER approval.
 
-The stable `Go support policy` check aggregates the deterministic Go safety
-jobs and is a required status check on `main`. It proves the proposed repository
-state builds and tests correctly; it does not attempt to interpret release
-policy or pull request prose.
+The stable `test (all supported Go versions)` check aggregates the floating Go
+test matrix. The `lint` and `govulncheck` jobs are independently required status
+checks on `main`. Together they prove the proposed repository state builds,
+tests, and passes reachable-vulnerability analysis; they do not attempt to
+interpret release policy or pull request prose.
+
+During the required-check migration, the legacy `Go support policy` aggregate
+remains as a compatibility check. Remove it after the `main` ruleset directly
+requires `test (all supported Go versions)`, `lint`, and `govulncheck`.
 
 ## Automation map
 


### PR DESCRIPTION
## Summary

- add a stable `test (all supported Go versions)` check that aggregates only the floating Go test matrix
- require `lint` and `govulncheck` explicitly
- remove the broad legacy `Go support policy` aggregate
- document the new required-check structure in `AGENTS.md`

## Why

`Go support policy` combined lint, vulnerability scanning, and all supported Go test versions behind a name that did not make that scope obvious. The new split makes the required checks explicit while preserving a stable test-aggregate name as supported Go versions rotate.

## Ruleset

The active `main` ruleset now requires:

- `lint`
- `govulncheck`
- `test (all supported Go versions)`
- `detect-breaking-changes`
- `CodeQL`

## Validation

- `git diff --check`
- YAML parsed successfully with Ruby/Psych
- `actionlint` v1.7.7