### PR TITLE
fix(webhooks): apply method-level options

### DIFF
--- a/webhooks/webhook.go
+++ b/webhooks/webhook.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -109,7 +110,7 @@ func (r *WebhookService) VerifySignatureWithTolerance(body []byte, headers http.
 // tolerance specifies the maximum age of the webhook.
 // now allows specifying the current time for testing purposes.
 func (r *WebhookService) VerifySignatureWithToleranceAndTime(body []byte, headers http.Header, tolerance time.Duration, now time.Time, opts ...option.RequestOption) error {
-	cfg, err := requestconfig.PreRequestOptions(r.Options...)
+	cfg, err := requestconfig.PreRequestOptions(slices.Concat(r.Options, opts)...)
 	if err != nil {
 		return err
 	}

--- a/webhooks/webhook_test.go
+++ b/webhooks/webhook_test.go
@@ -42,6 +42,41 @@ func TestWebhookService_VerifySignature_ValidSignature(t *testing.T) {
 	}
 }
 
+func TestWebhookService_VerifySignature_MethodLevelSecret(t *testing.T) {
+	client := openai.NewClient(option.WithAPIKey("test-key"))
+
+	fixedTime := time.Unix(testTimestamp, 0)
+	err := client.Webhooks.VerifySignatureWithToleranceAndTime(
+		[]byte(testPayload),
+		createTestHeaders(),
+		5*time.Minute,
+		fixedTime,
+		option.WithWebhookSecret(testSecret),
+	)
+	if err != nil {
+		t.Errorf("VerifySignatureWithToleranceAndTime should have succeeded with a method-level secret: %v", err)
+	}
+}
+
+func TestWebhookService_VerifySignature_MethodLevelSecretOverridesClientSecret(t *testing.T) {
+	client := openai.NewClient(
+		option.WithAPIKey("test-key"),
+		option.WithWebhookSecret("wrong-secret"),
+	)
+
+	fixedTime := time.Unix(testTimestamp, 0)
+	err := client.Webhooks.VerifySignatureWithToleranceAndTime(
+		[]byte(testPayload),
+		createTestHeaders(),
+		5*time.Minute,
+		fixedTime,
+		option.WithWebhookSecret(testSecret),
+	)
+	if err != nil {
+		t.Errorf("VerifySignatureWithToleranceAndTime should have preferred the method-level secret: %v", err)
+	}
+}
+
 func TestWebhookService_VerifySignature_InvalidSignature(t *testing.T) {
 	client := openai.NewClient(
 		option.WithAPIKey("test-key"),


### PR DESCRIPTION
## Summary

- apply method-level request options when resolving the webhook secret
- preserve method-level precedence over client configuration
- cover method-level secrets and override behavior with regression tests

## Why

The webhook verification methods accept request options, but signature verification only applied the service's stored options. As a result, passing `option.WithWebhookSecret` directly to `VerifySignature` or `Unwrap` was ignored and could return the missing-secret error.

## Tests

- `go test ./...`
- `./scripts/lint`