### PR TITLE
docs: demonstrate mutual TLS with custom HTTP client

### DIFF
--- a/README.md
+++ b/README.md
@@ -983,6 +983,8 @@ if !ok {
 }
 transport := defaultTransport.Clone()
 transport.Proxy = nil
+transport.DialTLS = nil
+transport.DialTLSContext = nil
 transport.ResponseHeaderTimeout = 10 * time.Minute
 tlsConfig := &tls.Config{}
 if transport.TLSClientConfig != nil {
@@ -990,6 +992,7 @@ if transport.TLSClientConfig != nil {
 }
 tlsConfig.Certificates = []tls.Certificate{certificate}
 tlsConfig.GetClientCertificate = nil
+tlsConfig.ClientSessionCache = nil
 transport.TLSClientConfig = tlsConfig
 
 httpClient := &http.Client{
@@ -1003,13 +1006,18 @@ client := openai.NewClient(
 	option.WithBaseURL("https://mtls.api.openai.com/v1"),
 	option.WithHTTPClient(httpClient),
 )
+
+if _, err := client.Models.List(context.Background()); err != nil {
+	return err
+}
 ```
 
 The SDK does not select an mTLS endpoint automatically when a custom HTTP
-client is used. Set `option.WithBaseURL` explicitly, use
-`https://mtls-eu.api.openai.com/v1` for the EU endpoint, or set
-`OPENAI_BASE_URL`. Keep server trust separate by configuring `RootCAs` on the
-cloned `tls.Config` when custom roots are required.
+client is used. The explicit `option.WithBaseURL` above overrides
+`OPENAI_BASE_URL`; replace it with `https://mtls-eu.api.openai.com/v1` for the
+EU endpoint, or remove it to use `OPENAI_BASE_URL`. Keep server trust separate
+by configuring `RootCAs` on the cloned `tls.Config` when custom roots are
+required.
 
 `tls.LoadX509KeyPair` fails for unreadable files and for malformed or mismatched
 leaf/key material. It loads later `CERTIFICATE` blocks into the presented chain
@@ -1020,9 +1028,10 @@ because existing TLS connections cannot renegotiate client authentication.
 When overriding the HTTP client, the application also owns redirect, proxy, and
 timeout policy. This dedicated client bypasses proxies, retains the SDK's
 10-minute response-header timeout, clears inherited client-certificate
-callbacks, and disables redirects so the client certificate is only offered to
-the configured API endpoint. If a proxy is required, use a transport that keeps
-the proxy TLS configuration separate from the origin client certificate.
+callbacks, TLS dial hooks, and TLS session cache, and disables redirects so the
+client certificate is only offered to the configured API endpoint. If a proxy
+is required, use a transport that keeps the proxy TLS configuration separate
+from the origin client certificate.
 
 The complete tested recipe is in
 [`examples/mutual-tls`](./examples/mutual-tls/main.go).

--- a/README.md
+++ b/README.md
@@ -963,7 +963,10 @@ middleware has been applied.
 For API-key authenticated HTTP requests that require mutual TLS, configure a
 native Go `*http.Client` and pass it through `option.WithHTTPClient`. The
 certificate file must contain the client leaf followed by every required
-intermediate:
+intermediate. Presenting intermediates requires certificate-chain support to be
+enabled for your organization; otherwise, the client certificate must be
+signed directly by an active uploaded certificate. See the
+[OpenAI mTLS setup requirements](https://help.openai.com/en/articles/10876024):
 
 ```go
 certificate, err := tls.LoadX509KeyPair(
@@ -1005,13 +1008,15 @@ client is used. Set `option.WithBaseURL` explicitly, use
 `OPENAI_BASE_URL`. Keep server trust separate by configuring `RootCAs` on the
 cloned `tls.Config` when custom roots are required.
 
-`tls.LoadX509KeyPair` fails for unreadable, malformed, or mismatched local
-certificate and key files. Certificate validity, chain trust, and OpenAI
-product policy remain TLS-handshake/server checks. Rebuild the transport and
-OpenAI client after rotating a certificate because existing TLS connections
-cannot renegotiate client authentication. When overriding the HTTP client, the
-application also owns redirect, proxy, and timeout policy; the example disables
-redirects so the client certificate cannot be offered to another host.
+`tls.LoadX509KeyPair` fails for unreadable files and for malformed or mismatched
+leaf/key material. It loads later `CERTIFICATE` blocks into the presented chain
+without validating those intermediates. Certificate validity, intermediate
+parsing, chain trust, and OpenAI product policy remain TLS-handshake/server
+checks. Rebuild the transport and OpenAI client after rotating a certificate
+because existing TLS connections cannot renegotiate client authentication.
+When overriding the HTTP client, the application also owns redirect, proxy, and
+timeout policy; the example disables redirects so the client certificate cannot
+be offered to another host.
 
 The complete tested recipe is in
 [`examples/mutual-tls`](./examples/mutual-tls/main.go).

--- a/README.md
+++ b/README.md
@@ -982,11 +982,14 @@ if !ok {
 	return errors.New("http.DefaultTransport is not an *http.Transport")
 }
 transport := defaultTransport.Clone()
+transport.Proxy = nil
+transport.ResponseHeaderTimeout = 10 * time.Minute
 tlsConfig := &tls.Config{}
 if transport.TLSClientConfig != nil {
 	tlsConfig = transport.TLSClientConfig.Clone()
 }
 tlsConfig.Certificates = []tls.Certificate{certificate}
+tlsConfig.GetClientCertificate = nil
 transport.TLSClientConfig = tlsConfig
 
 httpClient := &http.Client{
@@ -1015,8 +1018,11 @@ parsing, chain trust, and OpenAI product policy remain TLS-handshake/server
 checks. Rebuild the transport and OpenAI client after rotating a certificate
 because existing TLS connections cannot renegotiate client authentication.
 When overriding the HTTP client, the application also owns redirect, proxy, and
-timeout policy; the example disables redirects so the client certificate cannot
-be offered to another host.
+timeout policy. This dedicated client bypasses proxies, retains the SDK's
+10-minute response-header timeout, clears inherited client-certificate
+callbacks, and disables redirects so the client certificate is only offered to
+the configured API endpoint. If a proxy is required, use a transport that keeps
+the proxy TLS configuration separate from the origin client certificate.
 
 The complete tested recipe is in
 [`examples/mutual-tls`](./examples/mutual-tls/main.go).

--- a/README.md
+++ b/README.md
@@ -986,16 +986,12 @@ transport.Proxy = nil
 transport.DialTLS = nil
 transport.DialTLSContext = nil
 transport.ResponseHeaderTimeout = 10 * time.Minute
-tlsConfig := &tls.Config{}
-if transport.TLSClientConfig != nil {
-	tlsConfig = transport.TLSClientConfig.Clone()
+transport.TLSClientConfig = &tls.Config{
+	Certificates: []tls.Certificate{certificate},
+	GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+		return &certificate, nil
+	},
 }
-tlsConfig.Certificates = []tls.Certificate{certificate}
-tlsConfig.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
-	return &certificate, nil
-}
-tlsConfig.ClientSessionCache = nil
-transport.TLSClientConfig = tlsConfig
 
 httpClient := &http.Client{
 	Transport: transport,
@@ -1018,7 +1014,7 @@ The SDK does not select an mTLS endpoint automatically when a custom HTTP
 client is used. The explicit `option.WithBaseURL` above overrides
 `OPENAI_BASE_URL`; replace it with `https://mtls-eu.api.openai.com/v1` for the
 EU endpoint, or remove it to use `OPENAI_BASE_URL`. Keep server trust separate
-by configuring `RootCAs` on the cloned `tls.Config` when custom roots are
+by configuring `RootCAs` on the fresh `tls.Config` when custom roots are
 required.
 
 `tls.LoadX509KeyPair` fails for unreadable files and for malformed or mismatched
@@ -1030,13 +1026,13 @@ because existing TLS connections cannot renegotiate client authentication.
 When overriding the HTTP client, the application also owns redirect, proxy, and
 timeout policy. This dedicated client bypasses proxies, retains the SDK's
 10-minute response-header timeout, replaces inherited client-certificate
-callbacks, clears TLS dial hooks and the TLS session cache, and disables
-redirects so the client certificate is only offered to the configured API
-endpoint. Its callback always returns the configured certificate because Go's
-automatic selection can otherwise suppress it when a server's acceptable-CA
-hint does not match the local chain. If a proxy is required, use a transport
-that keeps the proxy TLS configuration separate from the origin client
-certificate.
+callbacks, TLS dial hooks, and TLS session state with a fresh TLS config, and
+disables redirects so the client certificate is only offered to the configured
+API endpoint. Its callback always returns the configured certificate because
+Go's automatic selection can otherwise suppress it when a server's
+acceptable-CA hint does not match the local chain. If a proxy is required, use
+a transport that keeps the proxy TLS configuration separate from the origin
+client certificate.
 
 The complete tested recipe is in
 [`examples/mutual-tls`](./examples/mutual-tls/main.go).

--- a/README.md
+++ b/README.md
@@ -991,7 +991,9 @@ if transport.TLSClientConfig != nil {
 	tlsConfig = transport.TLSClientConfig.Clone()
 }
 tlsConfig.Certificates = []tls.Certificate{certificate}
-tlsConfig.GetClientCertificate = nil
+tlsConfig.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+	return &certificate, nil
+}
 tlsConfig.ClientSessionCache = nil
 transport.TLSClientConfig = tlsConfig
 
@@ -1027,11 +1029,14 @@ checks. Rebuild the transport and OpenAI client after rotating a certificate
 because existing TLS connections cannot renegotiate client authentication.
 When overriding the HTTP client, the application also owns redirect, proxy, and
 timeout policy. This dedicated client bypasses proxies, retains the SDK's
-10-minute response-header timeout, clears inherited client-certificate
-callbacks, TLS dial hooks, and TLS session cache, and disables redirects so the
-client certificate is only offered to the configured API endpoint. If a proxy
-is required, use a transport that keeps the proxy TLS configuration separate
-from the origin client certificate.
+10-minute response-header timeout, replaces inherited client-certificate
+callbacks, clears TLS dial hooks and the TLS session cache, and disables
+redirects so the client certificate is only offered to the configured API
+endpoint. Its callback always returns the configured certificate because Go's
+automatic selection can otherwise suppress it when a server's acceptable-CA
+hint does not match the local chain. If a proxy is required, use a transport
+that keeps the proxy TLS configuration separate from the origin client
+certificate.
 
 The complete tested recipe is in
 [`examples/mutual-tls`](./examples/mutual-tls/main.go).

--- a/README.md
+++ b/README.md
@@ -958,6 +958,64 @@ You may also replace the default `http.Client` with
 accepted (this overwrites any previous client) and receives requests after any
 middleware has been applied.
 
+### Mutual TLS with a custom HTTP client
+
+For API-key authenticated HTTP requests that require mutual TLS, configure a
+native Go `*http.Client` and pass it through `option.WithHTTPClient`. The
+certificate file must contain the client leaf followed by every required
+intermediate:
+
+```go
+certificate, err := tls.LoadX509KeyPair(
+	"/secrets/openai/client-chain.pem",
+	"/secrets/openai/client.key",
+)
+if err != nil {
+	return err
+}
+
+defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+if !ok {
+	return errors.New("http.DefaultTransport is not an *http.Transport")
+}
+transport := defaultTransport.Clone()
+tlsConfig := &tls.Config{}
+if transport.TLSClientConfig != nil {
+	tlsConfig = transport.TLSClientConfig.Clone()
+}
+tlsConfig.Certificates = []tls.Certificate{certificate}
+transport.TLSClientConfig = tlsConfig
+
+httpClient := &http.Client{
+	Transport: transport,
+	CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	},
+}
+
+client := openai.NewClient(
+	option.WithBaseURL("https://mtls.api.openai.com/v1"),
+	option.WithHTTPClient(httpClient),
+)
+```
+
+The SDK does not select an mTLS endpoint automatically when a custom HTTP
+client is used. Set `option.WithBaseURL` explicitly, use
+`https://mtls-eu.api.openai.com/v1` for the EU endpoint, or set
+`OPENAI_BASE_URL`. Keep server trust separate by configuring `RootCAs` on the
+cloned `tls.Config` when custom roots are required.
+
+`tls.LoadX509KeyPair` fails for unreadable, malformed, or mismatched local
+certificate and key files. Certificate validity, chain trust, and OpenAI
+product policy remain TLS-handshake/server checks. Rebuild the transport and
+OpenAI client after rotating a certificate because existing TLS connections
+cannot renegotiate client authentication. When overriding the HTTP client, the
+application also owns redirect, proxy, and timeout policy; the example disables
+redirects so the client certificate cannot be offered to another host.
+
+The complete tested recipe is in
+[`examples/mutual-tls`](./examples/mutual-tls/main.go).
+
 ## Workload Identity Authentication
 
 For cloud workloads (Kubernetes, Azure, Google Cloud Platform), you can use workload identity authentication instead of API keys. This provides short-lived tokens that are automatically refreshed.

--- a/examples/mutual-tls/main.go
+++ b/examples/mutual-tls/main.go
@@ -67,18 +67,14 @@ func newMutualTLSHTTPClient(certificate tls.Certificate) (*http.Client, error) {
 	transport.DialTLSContext = nil
 	transport.ResponseHeaderTimeout = responseHeaderTimeout
 
-	tlsConfig := &tls.Config{}
-	if transport.TLSClientConfig != nil {
-		tlsConfig = transport.TLSClientConfig.Clone()
+	transport.TLSClientConfig = &tls.Config{
+		Certificates: []tls.Certificate{certificate},
+		// Always return this certificate; automatic selection can reject it when
+		// the server's acceptable-CA hint does not match the local chain.
+		GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			return &certificate, nil
+		},
 	}
-	tlsConfig.Certificates = []tls.Certificate{certificate}
-	// Always return this certificate; automatic selection can reject it when
-	// the server's acceptable-CA hint does not match the local chain.
-	tlsConfig.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
-		return &certificate, nil
-	}
-	tlsConfig.ClientSessionCache = nil
-	transport.TLSClientConfig = tlsConfig
 
 	return &http.Client{
 		Transport: transport,

--- a/examples/mutual-tls/main.go
+++ b/examples/mutual-tls/main.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -18,13 +19,13 @@ import (
 const responseHeaderTimeout = 10 * time.Minute
 
 func main() {
-	if err := run(); err != nil {
+	if err := run(context.Background()); err != nil {
 		slog.Error("mutual TLS example failed", "err", err)
 		os.Exit(1)
 	}
 }
 
-func run() error {
+func run(ctx context.Context) error {
 	// When certificate-chain support is enabled for the organization,
 	// client-chain.pem must contain the leaf certificate first, followed by
 	// every required intermediate. Otherwise, the leaf must be signed directly
@@ -47,7 +48,11 @@ func run() error {
 		option.WithHTTPClient(httpClient),
 	)
 
-	_ = client
+	models, err := client.Models.List(ctx)
+	if err != nil {
+		return fmt.Errorf("list models: %w", err)
+	}
+	slog.Info("mutual TLS request succeeded", "models", len(models.Data))
 	return nil
 }
 
@@ -58,6 +63,8 @@ func newMutualTLSHTTPClient(certificate tls.Certificate) (*http.Client, error) {
 	}
 	transport := defaultTransport.Clone()
 	transport.Proxy = nil
+	transport.DialTLS = nil
+	transport.DialTLSContext = nil
 	transport.ResponseHeaderTimeout = responseHeaderTimeout
 
 	tlsConfig := &tls.Config{}
@@ -66,6 +73,7 @@ func newMutualTLSHTTPClient(certificate tls.Certificate) (*http.Client, error) {
 	}
 	tlsConfig.Certificates = []tls.Certificate{certificate}
 	tlsConfig.GetClientCertificate = nil
+	tlsConfig.ClientSessionCache = nil
 	transport.TLSClientConfig = tlsConfig
 
 	return &http.Client{

--- a/examples/mutual-tls/main.go
+++ b/examples/mutual-tls/main.go
@@ -9,10 +9,13 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/option"
 )
+
+const responseHeaderTimeout = 10 * time.Minute
 
 func main() {
 	if err := run(); err != nil {
@@ -54,12 +57,15 @@ func newMutualTLSHTTPClient(certificate tls.Certificate) (*http.Client, error) {
 		return nil, errors.New("http.DefaultTransport is not an *http.Transport")
 	}
 	transport := defaultTransport.Clone()
+	transport.Proxy = nil
+	transport.ResponseHeaderTimeout = responseHeaderTimeout
 
 	tlsConfig := &tls.Config{}
 	if transport.TLSClientConfig != nil {
 		tlsConfig = transport.TLSClientConfig.Clone()
 	}
 	tlsConfig.Certificates = []tls.Certificate{certificate}
+	tlsConfig.GetClientCertificate = nil
 	transport.TLSClientConfig = tlsConfig
 
 	return &http.Client{

--- a/examples/mutual-tls/main.go
+++ b/examples/mutual-tls/main.go
@@ -22,8 +22,10 @@ func main() {
 }
 
 func run() error {
+	// When certificate-chain support is enabled for the organization,
 	// client-chain.pem must contain the leaf certificate first, followed by
-	// every intermediate required by the OpenAI mTLS endpoint.
+	// every required intermediate. Otherwise, the leaf must be signed directly
+	// by an active uploaded certificate.
 	certificate, err := tls.LoadX509KeyPair(
 		"/secrets/openai/client-chain.pem",
 		"/secrets/openai/client.key",

--- a/examples/mutual-tls/main.go
+++ b/examples/mutual-tls/main.go
@@ -1,0 +1,69 @@
+// The mutual-tls command demonstrates native Go mutual TLS configuration with
+// option.WithHTTPClient.
+package main
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+)
+
+func main() {
+	if err := run(); err != nil {
+		slog.Error("mutual TLS example failed", "err", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	// client-chain.pem must contain the leaf certificate first, followed by
+	// every intermediate required by the OpenAI mTLS endpoint.
+	certificate, err := tls.LoadX509KeyPair(
+		"/secrets/openai/client-chain.pem",
+		"/secrets/openai/client.key",
+	)
+	if err != nil {
+		return fmt.Errorf("load client certificate: %w", err)
+	}
+
+	httpClient, err := newMutualTLSHTTPClient(certificate)
+	if err != nil {
+		return fmt.Errorf("configure mutual TLS HTTP client: %w", err)
+	}
+
+	client := openai.NewClient(
+		option.WithBaseURL("https://mtls.api.openai.com/v1"),
+		option.WithHTTPClient(httpClient),
+	)
+
+	_ = client
+	return nil
+}
+
+func newMutualTLSHTTPClient(certificate tls.Certificate) (*http.Client, error) {
+	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return nil, errors.New("http.DefaultTransport is not an *http.Transport")
+	}
+	transport := defaultTransport.Clone()
+
+	tlsConfig := &tls.Config{}
+	if transport.TLSClientConfig != nil {
+		tlsConfig = transport.TLSClientConfig.Clone()
+	}
+	tlsConfig.Certificates = []tls.Certificate{certificate}
+	transport.TLSClientConfig = tlsConfig
+
+	return &http.Client{
+		Transport: transport,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}, nil
+}

--- a/examples/mutual-tls/main.go
+++ b/examples/mutual-tls/main.go
@@ -72,7 +72,11 @@ func newMutualTLSHTTPClient(certificate tls.Certificate) (*http.Client, error) {
 		tlsConfig = transport.TLSClientConfig.Clone()
 	}
 	tlsConfig.Certificates = []tls.Certificate{certificate}
-	tlsConfig.GetClientCertificate = nil
+	// Always return this certificate; automatic selection can reject it when
+	// the server's acceptable-CA hint does not match the local chain.
+	tlsConfig.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+		return &certificate, nil
+	}
 	tlsConfig.ClientSessionCache = nil
 	transport.TLSClientConfig = tlsConfig
 

--- a/examples/mutual-tls/main_test.go
+++ b/examples/mutual-tls/main_test.go
@@ -56,6 +56,11 @@ func TestNativeMutualTLSHTTPClient(t *testing.T) {
 	defaultTLSConfig.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
 		return nil, nil
 	}
+	defaultTLSConfig.ServerName = "example.invalid"
+	defaultTLSConfig.InsecureSkipVerify = true //nolint:gosec // Verify the dedicated config restores server verification.
+	inheritedRootPool := x509.NewCertPool()
+	inheritedRootPool.AddCert(fixture.root)
+	defaultTLSConfig.RootCAs = inheritedRootPool
 	inheritedSessionCache := tls.NewLRUClientSessionCache(1)
 	defaultTLSConfig.ClientSessionCache = inheritedSessionCache
 	defaultTransport.TLSClientConfig = defaultTLSConfig
@@ -101,6 +106,18 @@ func TestNativeMutualTLSHTTPClient(t *testing.T) {
 	if transport.TLSClientConfig.GetClientCertificate == nil {
 		t.Error("newMutualTLSHTTPClient().Transport.TLSClientConfig.GetClientCertificate is nil")
 	}
+	if transport.TLSClientConfig.ServerName != "" {
+		t.Errorf(
+			"newMutualTLSHTTPClient().Transport.TLSClientConfig.ServerName = %q, want empty",
+			transport.TLSClientConfig.ServerName,
+		)
+	}
+	if transport.TLSClientConfig.InsecureSkipVerify {
+		t.Error("newMutualTLSHTTPClient().Transport.TLSClientConfig.InsecureSkipVerify = true")
+	}
+	if transport.TLSClientConfig.RootCAs != nil {
+		t.Error("newMutualTLSHTTPClient().Transport.TLSClientConfig.RootCAs is inherited")
+	}
 	if transport.TLSClientConfig.ClientSessionCache != nil {
 		t.Error("newMutualTLSHTTPClient().Transport.TLSClientConfig.ClientSessionCache is non-nil")
 	}
@@ -130,6 +147,19 @@ func TestNativeMutualTLSHTTPClient(t *testing.T) {
 	}
 	if defaultTransport.TLSClientConfig.GetClientCertificate == nil {
 		t.Error("newMutualTLSHTTPClient() cleared http.DefaultTransport.TLSClientConfig.GetClientCertificate")
+	}
+	if got, want := defaultTransport.TLSClientConfig.ServerName, "example.invalid"; got != want {
+		t.Errorf(
+			"newMutualTLSHTTPClient() default TLS server name = %q, want %q",
+			got,
+			want,
+		)
+	}
+	if !defaultTransport.TLSClientConfig.InsecureSkipVerify {
+		t.Error("newMutualTLSHTTPClient() reset http.DefaultTransport.TLSClientConfig.InsecureSkipVerify")
+	}
+	if defaultTransport.TLSClientConfig.RootCAs != inheritedRootPool {
+		t.Error("newMutualTLSHTTPClient() replaced http.DefaultTransport.TLSClientConfig.RootCAs")
 	}
 	if defaultTransport.TLSClientConfig.ClientSessionCache != inheritedSessionCache {
 		t.Error("newMutualTLSHTTPClient() replaced http.DefaultTransport.TLSClientConfig.ClientSessionCache")

--- a/examples/mutual-tls/main_test.go
+++ b/examples/mutual-tls/main_test.go
@@ -41,14 +41,28 @@ func TestNativeMutualTLSHTTPClient(t *testing.T) {
 		t.Fatalf("tls.LoadX509KeyPair() chain length = %d, want %d", got, want)
 	}
 
-	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+	originalDefaultTransport := http.DefaultTransport
+	baseTransport, ok := originalDefaultTransport.(*http.Transport)
 	if !ok {
 		t.Skip("http.DefaultTransport is not an *http.Transport")
 	}
-	originalCertificateCount := 0
+	defaultTransport := baseTransport.Clone()
+	defaultTLSConfig := &tls.Config{}
 	if defaultTransport.TLSClientConfig != nil {
-		originalCertificateCount = len(defaultTransport.TLSClientConfig.Certificates)
+		defaultTLSConfig = defaultTransport.TLSClientConfig.Clone()
 	}
+	defaultTLSConfig.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+		return nil, nil
+	}
+	defaultTransport.TLSClientConfig = defaultTLSConfig
+	defaultTransport.Proxy = http.ProxyFromEnvironment
+	http.DefaultTransport = defaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalDefaultTransport
+	})
+
+	originalCertificateCount := len(defaultTransport.TLSClientConfig.Certificates)
+	originalResponseHeaderTimeout := defaultTransport.ResponseHeaderTimeout
 	httpClient, err := newMutualTLSHTTPClient(certificate)
 	if err != nil {
 		t.Fatalf("newMutualTLSHTTPClient() error = %v", err)
@@ -62,16 +76,35 @@ func TestNativeMutualTLSHTTPClient(t *testing.T) {
 	if transport == defaultTransport {
 		t.Fatal("newMutualTLSHTTPClient() reused http.DefaultTransport")
 	}
-	defaultCertificateCount := 0
-	if defaultTransport.TLSClientConfig != nil {
-		defaultCertificateCount = len(defaultTransport.TLSClientConfig.Certificates)
+	if transport.Proxy != nil {
+		t.Error("newMutualTLSHTTPClient().Transport.Proxy is non-nil")
 	}
+	if got, want := transport.ResponseHeaderTimeout, responseHeaderTimeout; got != want {
+		t.Errorf("newMutualTLSHTTPClient().Transport.ResponseHeaderTimeout = %v, want %v", got, want)
+	}
+	if transport.TLSClientConfig.GetClientCertificate != nil {
+		t.Error("newMutualTLSHTTPClient().Transport.TLSClientConfig.GetClientCertificate is non-nil")
+	}
+	defaultCertificateCount := len(defaultTransport.TLSClientConfig.Certificates)
 	if defaultCertificateCount != originalCertificateCount {
 		t.Errorf(
 			"newMutualTLSHTTPClient() default certificate count = %d, want %d",
 			defaultCertificateCount,
 			originalCertificateCount,
 		)
+	}
+	if defaultTransport.Proxy == nil {
+		t.Error("newMutualTLSHTTPClient() cleared http.DefaultTransport.Proxy")
+	}
+	if defaultTransport.ResponseHeaderTimeout != originalResponseHeaderTimeout {
+		t.Errorf(
+			"newMutualTLSHTTPClient() default response header timeout = %v, want %v",
+			defaultTransport.ResponseHeaderTimeout,
+			originalResponseHeaderTimeout,
+		)
+	}
+	if defaultTransport.TLSClientConfig.GetClientCertificate == nil {
+		t.Error("newMutualTLSHTTPClient() cleared http.DefaultTransport.TLSClientConfig.GetClientCertificate")
 	}
 
 	rootPool := x509.NewCertPool()

--- a/examples/mutual-tls/main_test.go
+++ b/examples/mutual-tls/main_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
 	"math/big"
 	"net"
 	"net/http"
@@ -97,8 +98,8 @@ func TestNativeMutualTLSHTTPClient(t *testing.T) {
 	if got, want := transport.ResponseHeaderTimeout, responseHeaderTimeout; got != want {
 		t.Errorf("newMutualTLSHTTPClient().Transport.ResponseHeaderTimeout = %v, want %v", got, want)
 	}
-	if transport.TLSClientConfig.GetClientCertificate != nil {
-		t.Error("newMutualTLSHTTPClient().Transport.TLSClientConfig.GetClientCertificate is non-nil")
+	if transport.TLSClientConfig.GetClientCertificate == nil {
+		t.Error("newMutualTLSHTTPClient().Transport.TLSClientConfig.GetClientCertificate is nil")
 	}
 	if transport.TLSClientConfig.ClientSessionCache != nil {
 		t.Error("newMutualTLSHTTPClient().Transport.TLSClientConfig.ClientSessionCache is non-nil")
@@ -137,6 +138,11 @@ func TestNativeMutualTLSHTTPClient(t *testing.T) {
 	rootPool := x509.NewCertPool()
 	rootPool.AddCert(fixture.root)
 	transport.TLSClientConfig.RootCAs = rootPool
+	serverCertificate := parseCertificate(t, fixture.server.Certificate[0])
+	unrelatedClientCAPool := x509.NewCertPool()
+	// Advertise a CA name that cannot match the client chain, then verify the
+	// presented chain independently in VerifyConnection.
+	unrelatedClientCAPool.AddCert(serverCertificate)
 
 	peerCertificateCount := 0
 	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
@@ -157,9 +163,24 @@ func TestNativeMutualTLSHTTPClient(t *testing.T) {
 	}))
 	server.TLS = &tls.Config{
 		Certificates: []tls.Certificate{fixture.server},
-		ClientAuth:   tls.RequireAndVerifyClientCert,
-		ClientCAs:    rootPool,
+		ClientAuth:   tls.RequireAnyClientCert,
+		ClientCAs:    unrelatedClientCAPool,
 		MinVersion:   tls.VersionTLS12,
+		VerifyConnection: func(state tls.ConnectionState) error {
+			if len(state.PeerCertificates) == 0 {
+				return errors.New("client certificate missing")
+			}
+			intermediates := x509.NewCertPool()
+			for _, certificate := range state.PeerCertificates[1:] {
+				intermediates.AddCert(certificate)
+			}
+			_, err := state.PeerCertificates[0].Verify(x509.VerifyOptions{
+				Roots:         rootPool,
+				Intermediates: intermediates,
+				KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+			})
+			return err
+		},
 	}
 	server.StartTLS()
 	t.Cleanup(server.Close)

--- a/examples/mutual-tls/main_test.go
+++ b/examples/mutual-tls/main_test.go
@@ -1,0 +1,234 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+)
+
+func TestNativeMutualTLSHTTPClient(t *testing.T) {
+	fixture := newTLSFixture(t)
+	tempDir := t.TempDir()
+	certificatePath := filepath.Join(tempDir, "client-chain.pem")
+	privateKeyPath := filepath.Join(tempDir, "client.key")
+	if err := os.WriteFile(certificatePath, fixture.certificatePEM, 0o600); err != nil {
+		t.Fatalf("os.WriteFile(%q) error = %v", certificatePath, err)
+	}
+	if err := os.WriteFile(privateKeyPath, fixture.privateKeyPEM, 0o600); err != nil {
+		t.Fatalf("os.WriteFile(%q) error = %v", privateKeyPath, err)
+	}
+
+	certificate, err := tls.LoadX509KeyPair(certificatePath, privateKeyPath)
+	if err != nil {
+		t.Fatalf("tls.LoadX509KeyPair(%q, %q) error = %v", certificatePath, privateKeyPath, err)
+	}
+	if got, want := len(certificate.Certificate), 2; got != want {
+		t.Fatalf("tls.LoadX509KeyPair() chain length = %d, want %d", got, want)
+	}
+
+	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		t.Skip("http.DefaultTransport is not an *http.Transport")
+	}
+	originalCertificateCount := 0
+	if defaultTransport.TLSClientConfig != nil {
+		originalCertificateCount = len(defaultTransport.TLSClientConfig.Certificates)
+	}
+	httpClient, err := newMutualTLSHTTPClient(certificate)
+	if err != nil {
+		t.Fatalf("newMutualTLSHTTPClient() error = %v", err)
+	}
+	t.Cleanup(httpClient.CloseIdleConnections)
+
+	transport, ok := httpClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("newMutualTLSHTTPClient().Transport type = %T, want *http.Transport", httpClient.Transport)
+	}
+	if transport == defaultTransport {
+		t.Fatal("newMutualTLSHTTPClient() reused http.DefaultTransport")
+	}
+	defaultCertificateCount := 0
+	if defaultTransport.TLSClientConfig != nil {
+		defaultCertificateCount = len(defaultTransport.TLSClientConfig.Certificates)
+	}
+	if defaultCertificateCount != originalCertificateCount {
+		t.Errorf(
+			"newMutualTLSHTTPClient() default certificate count = %d, want %d",
+			defaultCertificateCount,
+			originalCertificateCount,
+		)
+	}
+
+	rootPool := x509.NewCertPool()
+	rootPool.AddCert(fixture.root)
+	transport.TLSClientConfig.RootCAs = rootPool
+
+	peerCertificateCount := 0
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		peerCertificateCount = len(request.TLS.PeerCertificates)
+		if got, want := request.Header.Get("Authorization"), "Bearer test-api-key"; got != want {
+			t.Errorf("Authorization header = %q, want %q", got, want)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(`{"ok":true}`)); err != nil {
+			t.Errorf("ResponseWriter.Write() error = %v", err)
+		}
+	}))
+	server.TLS = &tls.Config{
+		Certificates: []tls.Certificate{fixture.server},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    rootPool,
+		MinVersion:   tls.VersionTLS12,
+	}
+	server.StartTLS()
+	t.Cleanup(server.Close)
+
+	client := openai.NewClient(
+		option.WithAPIKey("test-api-key"),
+		option.WithBaseURL(server.URL+"/v1/"),
+		option.WithHTTPClient(httpClient),
+		option.WithMaxRetries(0),
+	)
+	var response struct {
+		OK bool `json:"ok"`
+	}
+	if err := client.Get(t.Context(), "test", nil, &response); err != nil {
+		t.Fatalf("Client.Get() error = %v", err)
+	}
+	if !response.OK {
+		t.Error("Client.Get().OK = false, want true")
+	}
+	if got, want := peerCertificateCount, 2; got != want {
+		t.Errorf("Client.Get() peer certificate count = %d, want %d", got, want)
+	}
+
+	redirectRequest := &http.Request{}
+	if err := httpClient.CheckRedirect(redirectRequest, nil); err != http.ErrUseLastResponse {
+		t.Errorf("CheckRedirect() error = %v, want %v", err, http.ErrUseLastResponse)
+	}
+}
+
+type tlsFixture struct {
+	root           *x509.Certificate
+	server         tls.Certificate
+	certificatePEM []byte
+	privateKeyPEM  []byte
+}
+
+func newTLSFixture(t *testing.T) tlsFixture {
+	t.Helper()
+	now := time.Now()
+
+	rootKey := newECDSAKey(t)
+	rootTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "mTLS test root"},
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.Add(24 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	rootDER := createCertificate(t, rootTemplate, rootTemplate, &rootKey.PublicKey, rootKey)
+	root := parseCertificate(t, rootDER)
+
+	intermediateKey := newECDSAKey(t)
+	intermediateTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(2),
+		Subject:               pkix.Name{CommonName: "mTLS test intermediate"},
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.Add(12 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	intermediateDER := createCertificate(t, intermediateTemplate, root, &intermediateKey.PublicKey, rootKey)
+	intermediate := parseCertificate(t, intermediateDER)
+
+	clientKey := newECDSAKey(t)
+	clientTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(3),
+		Subject:      pkix.Name{CommonName: "mTLS test client"},
+		NotBefore:    now.Add(-time.Hour),
+		NotAfter:     now.Add(12 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	clientDER := createCertificate(t, clientTemplate, intermediate, &clientKey.PublicKey, intermediateKey)
+	certificatePEM := append(
+		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientDER}),
+		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: intermediateDER})...,
+	)
+	privateKeyDER, err := x509.MarshalECPrivateKey(clientKey)
+	if err != nil {
+		t.Fatalf("x509.MarshalECPrivateKey() error = %v", err)
+	}
+
+	serverKey := newECDSAKey(t)
+	serverTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(4),
+		Subject:      pkix.Name{CommonName: "mTLS test server"},
+		NotBefore:    now.Add(-time.Hour),
+		NotAfter:     now.Add(12 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{"localhost"},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	serverDER := createCertificate(t, serverTemplate, root, &serverKey.PublicKey, rootKey)
+
+	return tlsFixture{
+		root: root,
+		server: tls.Certificate{
+			Certificate: [][]byte{serverDER},
+			PrivateKey:  serverKey,
+		},
+		certificatePEM: certificatePEM,
+		privateKeyPEM: pem.EncodeToMemory(&pem.Block{
+			Type:  "EC PRIVATE KEY",
+			Bytes: privateKeyDER,
+		}),
+	}
+}
+
+func newECDSAKey(t *testing.T) *ecdsa.PrivateKey {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ecdsa.GenerateKey() error = %v", err)
+	}
+	return key
+}
+
+func createCertificate(t *testing.T, template, parent *x509.Certificate, publicKey, signer any) []byte {
+	t.Helper()
+	der, err := x509.CreateCertificate(rand.Reader, template, parent, publicKey, signer)
+	if err != nil {
+		t.Fatalf("x509.CreateCertificate() error = %v", err)
+	}
+	return der
+}
+
+func parseCertificate(t *testing.T, der []byte) *x509.Certificate {
+	t.Helper()
+	certificate, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("x509.ParseCertificate() error = %v", err)
+	}
+	return certificate
+}

--- a/examples/mutual-tls/main_test.go
+++ b/examples/mutual-tls/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -54,8 +55,16 @@ func TestNativeMutualTLSHTTPClient(t *testing.T) {
 	defaultTLSConfig.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
 		return nil, nil
 	}
+	inheritedSessionCache := tls.NewLRUClientSessionCache(1)
+	defaultTLSConfig.ClientSessionCache = inheritedSessionCache
 	defaultTransport.TLSClientConfig = defaultTLSConfig
 	defaultTransport.Proxy = http.ProxyFromEnvironment
+	defaultTransport.DialTLS = func(string, string) (net.Conn, error) {
+		return nil, nil
+	}
+	defaultTransport.DialTLSContext = func(context.Context, string, string) (net.Conn, error) {
+		return nil, nil
+	}
 	http.DefaultTransport = defaultTransport
 	t.Cleanup(func() {
 		http.DefaultTransport = originalDefaultTransport
@@ -79,11 +88,20 @@ func TestNativeMutualTLSHTTPClient(t *testing.T) {
 	if transport.Proxy != nil {
 		t.Error("newMutualTLSHTTPClient().Transport.Proxy is non-nil")
 	}
+	if transport.DialTLS != nil {
+		t.Error("newMutualTLSHTTPClient().Transport.DialTLS is non-nil")
+	}
+	if transport.DialTLSContext != nil {
+		t.Error("newMutualTLSHTTPClient().Transport.DialTLSContext is non-nil")
+	}
 	if got, want := transport.ResponseHeaderTimeout, responseHeaderTimeout; got != want {
 		t.Errorf("newMutualTLSHTTPClient().Transport.ResponseHeaderTimeout = %v, want %v", got, want)
 	}
 	if transport.TLSClientConfig.GetClientCertificate != nil {
 		t.Error("newMutualTLSHTTPClient().Transport.TLSClientConfig.GetClientCertificate is non-nil")
+	}
+	if transport.TLSClientConfig.ClientSessionCache != nil {
+		t.Error("newMutualTLSHTTPClient().Transport.TLSClientConfig.ClientSessionCache is non-nil")
 	}
 	defaultCertificateCount := len(defaultTransport.TLSClientConfig.Certificates)
 	if defaultCertificateCount != originalCertificateCount {
@@ -96,6 +114,12 @@ func TestNativeMutualTLSHTTPClient(t *testing.T) {
 	if defaultTransport.Proxy == nil {
 		t.Error("newMutualTLSHTTPClient() cleared http.DefaultTransport.Proxy")
 	}
+	if defaultTransport.DialTLS == nil {
+		t.Error("newMutualTLSHTTPClient() cleared http.DefaultTransport.DialTLS")
+	}
+	if defaultTransport.DialTLSContext == nil {
+		t.Error("newMutualTLSHTTPClient() cleared http.DefaultTransport.DialTLSContext")
+	}
 	if defaultTransport.ResponseHeaderTimeout != originalResponseHeaderTimeout {
 		t.Errorf(
 			"newMutualTLSHTTPClient() default response header timeout = %v, want %v",
@@ -106,6 +130,9 @@ func TestNativeMutualTLSHTTPClient(t *testing.T) {
 	if defaultTransport.TLSClientConfig.GetClientCertificate == nil {
 		t.Error("newMutualTLSHTTPClient() cleared http.DefaultTransport.TLSClientConfig.GetClientCertificate")
 	}
+	if defaultTransport.TLSClientConfig.ClientSessionCache != inheritedSessionCache {
+		t.Error("newMutualTLSHTTPClient() replaced http.DefaultTransport.TLSClientConfig.ClientSessionCache")
+	}
 
 	rootPool := x509.NewCertPool()
 	rootPool.AddCert(fixture.root)
@@ -114,11 +141,17 @@ func TestNativeMutualTLSHTTPClient(t *testing.T) {
 	peerCertificateCount := 0
 	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
 		peerCertificateCount = len(request.TLS.PeerCertificates)
+		if got, want := request.Method, http.MethodGet; got != want {
+			t.Errorf("request.Method = %q, want %q", got, want)
+		}
+		if got, want := request.URL.Path, "/v1/models"; got != want {
+			t.Errorf("request.URL.Path = %q, want %q", got, want)
+		}
 		if got, want := request.Header.Get("Authorization"), "Bearer test-api-key"; got != want {
 			t.Errorf("Authorization header = %q, want %q", got, want)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		if _, err := w.Write([]byte(`{"ok":true}`)); err != nil {
+		if _, err := w.Write([]byte(`{"object":"list","data":[{"id":"test-model","object":"model","created":1,"owned_by":"openai"}]}`)); err != nil {
 			t.Errorf("ResponseWriter.Write() error = %v", err)
 		}
 	}))
@@ -137,17 +170,18 @@ func TestNativeMutualTLSHTTPClient(t *testing.T) {
 		option.WithHTTPClient(httpClient),
 		option.WithMaxRetries(0),
 	)
-	var response struct {
-		OK bool `json:"ok"`
+	models, err := client.Models.List(t.Context())
+	if err != nil {
+		t.Fatalf("Client.Models.List() error = %v", err)
 	}
-	if err := client.Get(t.Context(), "test", nil, &response); err != nil {
-		t.Fatalf("Client.Get() error = %v", err)
+	if got, want := len(models.Data), 1; got != want {
+		t.Fatalf("Client.Models.List() model count = %d, want %d", got, want)
 	}
-	if !response.OK {
-		t.Error("Client.Get().OK = false, want true")
+	if got, want := models.Data[0].ID, "test-model"; got != want {
+		t.Errorf("Client.Models.List().Data[0].ID = %q, want %q", got, want)
 	}
 	if got, want := peerCertificateCount, 2; got != want {
-		t.Errorf("Client.Get() peer certificate count = %d, want %d", got, want)
+		t.Errorf("Client.Models.List() peer certificate count = %d, want %d", got, want)
 	}
 
 	redirectRequest := &http.Request{}


### PR DESCRIPTION
## Summary

- document API-key mutual TLS using Go native TLS configuration with option.WithHTTPClient and an explicit mTLS base URL
- safely clone http.DefaultTransport and its TLS config, preserve server trust configuration, and disable redirects
- add a hermetic end-to-end example test covering API-key auth, a leaf-plus-intermediate client chain, separate server trust, and an unchanged default transport

This intentionally relies on the existing option.WithHTTPClient and option.WithBaseURL seams instead of adding a first-class SDK mTLS API.

## Validation

- go test -count=10 ./mutual-tls (examples module)
- go test -race ./mutual-tls (examples module)
- go test ./... (examples module)
- SKIP_MOCK_TESTS=true go test ./...
- ./scripts/lint
- go mod tidy -diff (root and examples modules)

No exported SDK API or production request path changes.