### PR TITLE
ci: migrate to upstream release-please

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ on:
     branches-ignore:
       - 'stl-preview-head/**'
       - 'stl-preview-base/**'
-  # The monthly Codex workflow opens its draft with GITHUB_TOKEN. GitHub does
-  # not emit pull_request workflows for token-created pull requests, so that
-  # workflow explicitly dispatches this validation on the generated branch.
+  # GitHub does not emit pull_request workflows for pull requests created with
+  # GITHUB_TOKEN, so repository automation explicitly dispatches this
+  # validation on generated branches.
   workflow_dispatch:
   # The vulnerability database changes even when this repository does not.
   # This schedule runs only the govulncheck job below; lint and tests remain

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,8 +7,8 @@ on:
   pull_request:
     branches:
       - main
-  # The monthly maintenance workflow explicitly dispatches CodeQL because its
-  # GITHUB_TOKEN-created pull request does not emit a pull_request event.
+  # Repository automation explicitly dispatches CodeQL because pull requests
+  # created with GITHUB_TOKEN do not emit a pull_request event.
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -4,32 +4,36 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   release:
     name: release
     if: github.ref == 'refs/heads/main' && github.repository == 'openai/openai-go'
     runs-on: ubuntu-latest
-    # STAINLESS_API_KEY is scoped to this environment, so the job that invokes
-    # trigger-release-please must explicitly opt in to receive it.
-    environment: publish
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
 
     steps:
-      - uses: stainless-api/trigger-release-please@bb6677c5a04578eec1ccfd9e1913b5b78ed64c61 # v1.4.0
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
-          repo: ${{ github.event.repository.full_name }}
-          stainless-api-key: ${{ secrets.STAINLESS_API_KEY }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          target-branch: main
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
 
   publish:
     name: publish
     needs: release
     if: ${{ needs.release.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
@@ -38,6 +42,6 @@ jobs:
 
       - name: Generate godocs
         run: |
-          # x-release-please-start-version
           version="$(jq -r '. | to_entries[0] | .value' .release-please-manifest.json)"
-          curl --fail --show-error --silent -X POST "https://pkg.go.dev/fetch/github.com/openai/openai-go/v2@v${version}"
+          module="$(awk '$1 == "module" { print $2; exit }' go.mod)"
+          curl --fail --show-error --silent -X POST "https://pkg.go.dev/fetch/${module}@v${version}"

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -16,6 +16,8 @@ jobs:
       issues: write
       pull-requests: write
     outputs:
+      prs_created: ${{ steps.release.outputs.prs_created }}
+      release_pr_branch: ${{ steps.release.outputs.pr && fromJSON(steps.release.outputs.pr).headBranchName || '' }}
       releases_created: ${{ steps.release.outputs.releases_created }}
 
     steps:
@@ -26,6 +28,36 @@ jobs:
           target-branch: main
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  dispatch_checks:
+    name: Dispatch release pull request checks
+    needs: release
+    if: needs.release.outputs.prs_created == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write  # Dispatch only the explicitly named required workflows.
+
+    steps:
+      - name: Run required checks on the release pull request
+        env:
+          BASE_SHA: ${{ github.sha }}
+          BRANCH: ${{ needs.release.outputs.release_pr_branch }}
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # GITHUB_TOKEN deliberately does not trigger pull_request workflows.
+          # workflow_dispatch is the documented exception.
+          if [[ "$BRANCH" != 'release-please--branches--main' ]]; then
+            echo "Unexpected release-please branch: $BRANCH" >&2
+            exit 1
+          fi
+
+          gh workflow run ci.yml --ref "$BRANCH"
+          gh workflow run detect-breaking-changes.yml \
+            --ref "$BRANCH" \
+            --field base_sha="$BASE_SHA"
+          gh workflow run codeql.yml --ref "$BRANCH"
 
   publish:
     name: publish

--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -4,8 +4,8 @@ on:
     branches:
       - main
       - next
-  # See ci.yml: GITHUB_TOKEN-created maintenance pull requests dispatch this
-  # workflow explicitly because GitHub suppresses their pull_request event.
+  # See ci.yml: GITHUB_TOKEN-created pull requests dispatch this workflow
+  # explicitly because GitHub suppresses their pull_request event.
   workflow_dispatch:
     inputs:
       base_sha:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,11 +2,9 @@
   "packages": {
     ".": {}
   },
-  "$schema": "https://raw.githubusercontent.com/stainless-api/release-please/main/schemas/config.json",
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "include-v-in-tag": true,
   "include-component-in-tag": false,
-  "versioning": "prerelease",
-  "prerelease": true,
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": false,
   "pull-request-header": "Automated Release PR",
@@ -62,7 +60,6 @@
   "release-type": "go",
   "extra-files": [
     "internal/version.go",
-    "README.md",
-    ".github/workflows/create-releases.yml"
+    "README.md"
   ]
 }


### PR DESCRIPTION
## Summary

- replace the Stainless release wrapper with the upstream `googleapis/release-please-action`
- run release-please from `main` with stable, non-prerelease versioning
- use the repository `GITHUB_TOKEN` temporarily, scoped to only the permissions release-please requires
- explicitly dispatch required checks for release PRs because `GITHUB_TOKEN` suppresses normal workflow events
- stop treating the workflow file as a release-managed version file
- derive the pkg.go.dev module path from `go.mod` instead of the stale hard-coded `/v2` path

## Security and permissions

- workflow-level `GITHUB_TOKEN` permissions default to none
- the release job receives only `contents: write`, `issues: write`, and `pull-requests: write`
- a separate dispatch job receives only `actions: write`, validates the exact generated branch, and starts only CI, breaking-change detection, and CodeQL
- the godocs job receives only `contents: read` and does not persist checkout credentials
- neither `STAINLESS_API_KEY` nor an SDK App private key is exposed to the workflow
- the repository Actions allowlist includes only the pinned `googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7`; verified-creator actions remain disabled
- default repository workflow-token permissions remain read-only

## Operational note

This temporarily uses `GITHUB_TOKEN` while the `openai-sdks` private-key handling is resolved. Since GitHub suppresses normal events for resources created with this token, the workflow explicitly dispatches the required checks on `release-please--branches--main`.

Two narrowly scoped repository settings make the temporary token path work:

- the ruleset exempts only the exact generated branch, `release-please--branches--main`
- `can_approve_pull_request_reviews` is temporarily enabled so `GITHUB_TOKEN` can create the release PR

When the App token is enabled, remove the branch exemption and restore `can_approve_pull_request_reviews` to `false`. The exact upstream-action allowlist entry remains necessary for the migrated workflow.

`STAINLESS_API_KEY` is no longer consumed and can be removed from the `publish` environment after this PR lands.

## Validation

- `actionlint` across all workflows
- upstream release-please v17.6.0 schemas for the config and manifest
- release-please v17.6.0 dry run against `main`, producing stable version `3.49.1`, branch `release-please--branches--main`, and the expected four file updates
- explicit workflow permission and dispatch-target assertions
- live repository Actions allowlist and workflow-token policy verification
- `git diff --check`
