### PR TITLE
ci: prepare required checks for merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - '**'
+      - '!gh-readonly-queue/**'
       - '!integrated/**'
       - '!stl-preview-head/**'
       - '!stl-preview-base/**'
@@ -13,6 +14,9 @@ on:
     branches-ignore:
       - 'stl-preview-head/**'
       - 'stl-preview-base/**'
+  merge_group:
+    types:
+      - checks_requested
   # GitHub does not emit pull_request workflows for pull requests created with
   # GITHUB_TOKEN, so repository automation explicitly dispatches this
   # validation on generated branches.
@@ -73,6 +77,7 @@ jobs:
     if: >-
       github.event_name == 'push' ||
       github.event_name == 'pull_request' ||
+      github.event_name == 'merge_group' ||
       github.event_name == 'workflow_dispatch'
     # Prevent Go's automatic toolchain selection from hiding an accidental
     # increase above the minimum declared in go.mod.
@@ -102,6 +107,7 @@ jobs:
     if: >-
       github.event_name == 'push' ||
       github.event_name == 'pull_request' ||
+      github.event_name == 'merge_group' ||
       github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
@@ -157,6 +163,7 @@ jobs:
     # newly published advisories against an otherwise unchanged commit.
     if: >-
       github.event_name == 'pull_request' ||
+      github.event_name == 'merge_group' ||
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch'
     env:
@@ -194,6 +201,7 @@ jobs:
     if: >-
       always() &&
       (github.event_name == 'pull_request' ||
+      github.event_name == 'merge_group' ||
       github.event_name == 'workflow_dispatch')
     needs:
       - test

--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - main
       - next
+  merge_group:
+    types:
+      - checks_requested
   # See ci.yml: GITHUB_TOKEN-created pull requests dispatch this workflow
   # explicitly because GitHub suppresses their pull_request event.
   workflow_dispatch:
@@ -35,7 +38,7 @@ jobs:
 
       - name: Detect breaking changes
         env:
-          BASE_SHA: ${{ inputs.base_sha || github.event.pull_request.base.sha }}
+          BASE_SHA: ${{ inputs.base_sha || github.event.merge_group.base_sha || github.event.pull_request.base.sha }}
         run: |
           # Try to check out previous versions of the breaking change detection script. This ensures that
           # we still detect breaking changes when entire files and their tests are removed.


### PR DESCRIPTION
## Summary

- run every required Go CI check for GitHub merge-group commits
- compare breaking changes against the merge group base SHA
- exclude `gh-readonly-queue/**` from ordinary push CI so queue-branch pushes cannot duplicate the merge-group run

## Why

GitHub Actions required checks must subscribe to the separate `merge_group: checks_requested` event before merge queue can be enabled. Without this prerequisite, queued pull requests can wait indefinitely for checks that never report.

## Impact

Once the merge queue is enabled, `lint`, `govulncheck`, `test (all supported Go versions)`, and `detect-breaking-changes` will run against each prospective queued merge commit. Existing pull-request, branch-push, nightly vulnerability, manual-dispatch, Stainless staging, and release automation behavior remains unchanged.

The breaking-change workflow uses `merge_group.base_sha` for queued commits while retaining the existing pull-request and manual-dispatch base-SHA paths.

## Validation

- workflow YAML parsed successfully
- focused merge-group trigger, job-gate, queue-branch exclusion, and base-SHA assertions
- `./scripts/lint`
- `git diff --check`
- thermo-nuclear code-quality review (no findings)

## Follow-up

After this PR lands, update the existing `main` ruleset to enable squash-based merge queueing while preserving every current protection and bypass actor, then independently read back the stored ruleset, effective branch rules, and live queue configuration.