### PR TITLE
ci: use GitHub App for Release Please

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ on:
   merge_group:
     types:
       - checks_requested
-  # GitHub does not emit pull_request workflows for pull requests created with
-  # GITHUB_TOKEN, so repository automation explicitly dispatches this
-  # validation on generated branches.
+  # The monthly Go version review opens its draft with GITHUB_TOKEN. GitHub
+  # requires approval before running pull_request workflows for that draft, so
+  # that workflow explicitly dispatches this validation on its generated branch.
   workflow_dispatch:
   # The vulnerability database changes even when this repository does not.
   # This schedule runs only the govulncheck job below; lint and tests remain

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,8 +7,9 @@ on:
   pull_request:
     branches:
       - main
-  # Repository automation explicitly dispatches CodeQL because pull requests
-  # created with GITHUB_TOKEN do not emit a pull_request event.
+  # The monthly Go version review explicitly dispatches CodeQL because its
+  # GITHUB_TOKEN-created pull request requires approval before pull_request
+  # workflows run.
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -11,53 +11,29 @@ jobs:
     name: release
     if: github.ref == 'refs/heads/main' && github.repository == 'openai/openai-go'
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      issues: write
-      pull-requests: write
+    environment: release
+    permissions: {}
     outputs:
-      prs_created: ${{ steps.release.outputs.prs_created }}
-      release_pr_branch: ${{ steps.release.outputs.pr && fromJSON(steps.release.outputs.pr).headBranchName || '' }}
       releases_created: ${{ steps.release.outputs.releases_created }}
 
     steps:
+      - name: Create release app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.OPENAI_SDKS_APP_CLIENT_ID }}
+          private-key: ${{ secrets.OPENAI_SDKS_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           target-branch: main
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-
-  dispatch_checks:
-    name: Dispatch release pull request checks
-    needs: release
-    if: needs.release.outputs.prs_created == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      actions: write  # Dispatch only the explicitly named required workflows.
-
-    steps:
-      - name: Run required checks on the release pull request
-        env:
-          BASE_SHA: ${{ github.sha }}
-          BRANCH: ${{ needs.release.outputs.release_pr_branch }}
-          GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          # GITHUB_TOKEN deliberately does not trigger pull_request workflows.
-          # workflow_dispatch is the documented exception.
-          if [[ "$BRANCH" != 'release-please--branches--main' ]]; then
-            echo "Unexpected release-please branch: $BRANCH" >&2
-            exit 1
-          fi
-
-          gh workflow run ci.yml --ref "$BRANCH"
-          gh workflow run detect-breaking-changes.yml \
-            --ref "$BRANCH" \
-            --field base_sha="$BASE_SHA"
-          gh workflow run codeql.yml --ref "$BRANCH"
 
   publish:
     name: publish

--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -7,8 +7,9 @@ on:
   merge_group:
     types:
       - checks_requested
-  # See ci.yml: GITHUB_TOKEN-created pull requests dispatch this workflow
-  # explicitly because GitHub suppresses their pull_request event.
+  # See ci.yml: the GITHUB_TOKEN-created monthly maintenance pull request
+  # explicitly dispatches this workflow because its pull_request workflows
+  # require approval before running.
   workflow_dispatch:
     inputs:
       base_sha:

--- a/.github/workflows/go-version-review.yml
+++ b/.github/workflows/go-version-review.yml
@@ -402,8 +402,8 @@ jobs:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
         run: |
-          # GITHUB_TOKEN deliberately does not trigger pull_request workflows.
-          # workflow_dispatch is the documented exception.
+          # GITHUB_TOKEN-created pull requests require approval before their
+          # pull_request workflows run, so dispatch the required checks directly.
           gh workflow run ci.yml --ref "$BRANCH"
           gh workflow run detect-breaking-changes.yml \
             --ref "$BRANCH" \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,9 +79,9 @@ interpret release policy or pull request prose.
   - The publisher can write repository contents and pull requests but cannot
     dispatch Actions. A third job can dispatch Actions but cannot write
     repository contents or pull requests.
-  - Because GitHub suppresses normal workflow events for pull requests created
-    with `GITHUB_TOKEN`, the publishing job explicitly dispatches CI,
-    compatibility detection, and CodeQL on the generated branch.
+  - Because GitHub requires approval before running pull request workflows for
+    pull requests created with `GITHUB_TOKEN`, the publishing job explicitly
+    dispatches CI, compatibility detection, and CodeQL on the generated branch.
   - The draft never merges automatically. Normal CI and CODEOWNER review remain
     authoritative.
 - `.github/dependabot.yml`


### PR DESCRIPTION
## Summary

- mint a repository-scoped installation token for the `openai-sdks` GitHub App from the `release` environment
- pass that token to Release Please and disable the release job's built-in `GITHUB_TOKEN` permissions
- remove the Release Please workflow-dispatch workaround now that App-created release branch pushes and pull-request events trigger Actions normally
- retain manual dispatch support for the separate monthly Go version review, which still creates drafts with `GITHUB_TOKEN`

## Why

Release Please currently authenticates with `GITHUB_TOKEN`. Pull requests created with that token need manual workflow approval, so the release workflow carries a separate dispatch job. A GitHub App installation token triggers the normal push and pull-request workflows, so the release-specific workaround can be deleted.

## Repository configuration

Verified App: `openai-sdks` (App ID `3705508`, client ID `Iv23li2AtcmhLHO07J87`).

Configured:

- `release` environment exists
- `release` is restricted to the `main` branch
- `release` has no required-reviewer gate
- `release` variable `OPENAI_SDKS_APP_CLIENT_ID=Iv23li2AtcmhLHO07J87` exists

Still required before merge:

- add `OPENAI_SDKS_APP_PRIVATE_KEY` to the `release` environment

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7`
- `env GOCACHE=/private/tmp/openai-go-gocache ./scripts/lint`
- `env GOCACHE=/private/tmp/openai-go-gocache ./scripts/test`
- `(cd examples && env GOCACHE=/private/tmp/openai-go-gocache go test ./...)`
- `(cd internal/testdata/consumer && env GOCACHE=/private/tmp/openai-go-gocache go test -mod=readonly ./...)`
- `git diff --check`
- thermo-nuclear code quality review
