### PR TITLE
fix: don't drop tool_calls when content is empty but present

### DIFF
--- a/streamaccumulator.go
+++ b/streamaccumulator.go
@@ -173,15 +173,15 @@ func (prev *chatCompletionResponseState) update(chunk ChatCompletionChunk) (just
 	delta := chunk.Choices[0].Delta
 	new := chatCompletionResponseState{}
 	switch {
+	case len(delta.ToolCalls) > 0 && delta.Content == "":
+		new.state = toolResponseState
+		new.index = clampToZero(delta.ToolCalls[0].Index)
 	case delta.JSON.Content.Valid():
 		new.state = contentResponseState
 	case delta.JSON.Refusal.Valid():
 		new.state = refusalResponseState
 	case delta.JSON.ToolCalls.Valid():
 		new.state = toolResponseState
-		if len(delta.ToolCalls) > 0 {
-			new.index = clampToZero(delta.ToolCalls[0].Index)
-		}
 	default:
 		new.state = finishedResponseState
 	}

--- a/streamaccumulator.go
+++ b/streamaccumulator.go
@@ -17,8 +17,9 @@ type FinishedChatCompletionToolCall struct {
 }
 
 type chatCompletionResponseState struct {
-	state chatCompletionResponseStateEnum
-	index int
+	state         chatCompletionResponseStateEnum
+	choiceIndex   int
+	toolCallIndex int
 }
 
 type chatCompletionResponseStateEnum int
@@ -48,7 +49,7 @@ func (acc *ChatCompletionAccumulator) AddChunk(chunk ChatCompletionChunk) bool {
 
 	chunkIndex := int(chunk.Choices[0].Index)
 	acc.choiceChatCompletionStates = expandToFit(acc.choiceChatCompletionStates, chunkIndex)
-	acc.justFinished = acc.choiceChatCompletionStates[chunkIndex].update(chunk)
+	acc.justFinished = acc.choiceChatCompletionStates[chunkIndex].update(chunk, chunkIndex)
 	return true
 }
 
@@ -58,7 +59,7 @@ func (acc *ChatCompletionAccumulator) AddChunk(chunk ChatCompletionChunk) bool {
 // an empty string is returned and the boolean will be false.
 func (acc *ChatCompletionAccumulator) JustFinishedContent() (content string, ok bool) {
 	if acc.justFinished.state == contentResponseState {
-		return acc.Choices[0].Message.Content, true
+		return acc.Choices[acc.justFinished.choiceIndex].Message.Content, true
 	}
 	return "", false
 }
@@ -69,7 +70,7 @@ func (acc *ChatCompletionAccumulator) JustFinishedContent() (content string, ok 
 // an empty string is returned and the boolean will be false.
 func (acc *ChatCompletionAccumulator) JustFinishedRefusal() (refusal string, ok bool) {
 	if acc.justFinished.state == refusalResponseState {
-		return acc.Choices[0].Message.Refusal, true
+		return acc.Choices[acc.justFinished.choiceIndex].Message.Refusal, true
 	}
 	return "", false
 }
@@ -83,11 +84,12 @@ func (acc *ChatCompletionAccumulator) JustFinishedRefusal() (refusal string, ok 
 // You cannot rely on this with a stream that has ParallelToolCalls enabled.
 func (acc *ChatCompletionAccumulator) JustFinishedToolCall() (toolcall FinishedChatCompletionToolCall, ok bool) {
 	if acc.justFinished.state == toolResponseState {
-		f := acc.Choices[0].Message.ToolCalls[acc.justFinished.index].Function
-		id := acc.Choices[0].Message.ToolCalls[acc.justFinished.index].ID
+		choice := acc.Choices[acc.justFinished.choiceIndex]
+		f := choice.Message.ToolCalls[acc.justFinished.toolCallIndex].Function
+		id := choice.Message.ToolCalls[acc.justFinished.toolCallIndex].ID
 		return FinishedChatCompletionToolCall{
 			ID:    id,
-			Index: acc.justFinished.index,
+			Index: acc.justFinished.toolCallIndex,
 			ChatCompletionMessageFunctionToolCallFunction: ChatCompletionMessageFunctionToolCallFunction{
 				Name:      f.Name,
 				Arguments: f.Arguments,
@@ -169,17 +171,20 @@ func (cc *ChatCompletion) accumulateDelta(chunk ChatCompletionChunk) bool {
 
 // Updates the internal response state and returns the previous state if
 // the state changed. This ensures that JustFinished events only fire once.
-func (prev *chatCompletionResponseState) update(chunk ChatCompletionChunk) (justFinished chatCompletionResponseState) {
+func (prev *chatCompletionResponseState) update(chunk ChatCompletionChunk, choiceIndex int) (justFinished chatCompletionResponseState) {
 	delta := chunk.Choices[0].Delta
-	new := chatCompletionResponseState{}
+	new := chatCompletionResponseState{choiceIndex: choiceIndex}
 	switch {
+	case len(delta.ToolCalls) > 0 && delta.Content == "":
+		new.state = toolResponseState
+		new.toolCallIndex = clampToZero(delta.ToolCalls[0].Index)
 	case delta.JSON.Content.Valid():
 		new.state = contentResponseState
 	case delta.JSON.Refusal.Valid():
 		new.state = refusalResponseState
-	case delta.JSON.ToolCalls.Valid() && len(delta.ToolCalls) > 0:
+	case len(delta.ToolCalls) > 0:
 		new.state = toolResponseState
-		new.index = clampToZero(delta.ToolCalls[0].Index)
+		new.toolCallIndex = clampToZero(delta.ToolCalls[0].Index)
 	default:
 		new.state = finishedResponseState
 	}

--- a/streamaccumulator_test.go
+++ b/streamaccumulator_test.go
@@ -259,6 +259,33 @@ func TestAccumulatorEmptyToolCallsArray(t *testing.T) {
 	acc.AddChunk(chunk)
 }
 
+func TestAccumulatorToolCallWithEmptyContent(t *testing.T) {
+	acc := openai.ChatCompletionAccumulator{}
+
+	toolCallChunk := openai.ChatCompletionChunk{}
+	// content must be explicitly present (not omitted) to reproduce the bug.
+	toolCallJSON := `{"id":"test","choices":[{"index":0,"delta":{"content":"","tool_calls":[{"id":"call_1","index":0,"type":"function","function":{"name":"search","arguments":"{}"}}]}}]}`
+	if err := toolCallChunk.UnmarshalJSON([]byte(toolCallJSON)); err != nil {
+		t.Fatalf("Failed to unmarshal chunk: %v", err)
+	}
+	if !acc.AddChunk(toolCallChunk) {
+		t.Fatal("AddChunk returned false")
+	}
+
+	finishChunk := openai.ChatCompletionChunk{}
+	finishJSON := `{"id":"test","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`
+	if err := finishChunk.UnmarshalJSON([]byte(finishJSON)); err != nil {
+		t.Fatalf("Failed to unmarshal chunk: %v", err)
+	}
+	if !acc.AddChunk(finishChunk) {
+		t.Fatal("AddChunk returned false")
+	}
+
+	if _, ok := acc.JustFinishedToolCall(); !ok {
+		t.Fatal("JustFinishedToolCall did not fire after the finishing chunk")
+	}
+}
+
 // manually created on 11/3/2024
 var mockResponseBody = `data: {"id":"chatcmpl-A3Tguz3LSXTHBTY2NAPBCSyfBltxF","object":"chat.completion.chunk","created":1725392480,"model":"gpt-4o-2024-05-13","system_fingerprint":"fp_157b3831f5","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":{"content":[],"refusal":null},"finish_reason":null}],"usage":null}
 

--- a/streamaccumulator_test.go
+++ b/streamaccumulator_test.go
@@ -292,6 +292,72 @@ func TestAccumulatorNullToolCalls(t *testing.T) {
 	}
 }
 
+func TestAccumulatorToolCallWithEmptyContent(t *testing.T) {
+	acc := openai.ChatCompletionAccumulator{}
+
+	toolCallChunk := openai.ChatCompletionChunk{}
+	// Some OpenAI-compatible providers send an explicit empty content field
+	// alongside a real tool call.
+	toolCallJSON := `{"id":"test","choices":[{"index":0,"delta":{"content":"","tool_calls":[{"id":"call_1","index":0,"type":"function","function":{"name":"search","arguments":"{}"}}]}}]}`
+	if err := toolCallChunk.UnmarshalJSON([]byte(toolCallJSON)); err != nil {
+		t.Fatalf("Failed to unmarshal tool call chunk: %v", err)
+	}
+	if !acc.AddChunk(toolCallChunk) {
+		t.Fatal("AddChunk returned false")
+	}
+
+	finishChunk := openai.ChatCompletionChunk{}
+	finishJSON := `{"id":"test","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`
+	if err := finishChunk.UnmarshalJSON([]byte(finishJSON)); err != nil {
+		t.Fatalf("Failed to unmarshal finish chunk: %v", err)
+	}
+	if !acc.AddChunk(finishChunk) {
+		t.Fatal("AddChunk returned false")
+	}
+
+	if _, ok := acc.JustFinishedContent(); ok {
+		t.Fatal("JustFinishedContent fired for an empty content field with a tool call")
+	}
+
+	toolCall, ok := acc.JustFinishedToolCall()
+	if !ok {
+		t.Fatal("JustFinishedToolCall did not fire after the finishing chunk")
+	}
+	if toolCall.ID != "call_1" || toolCall.Name != "search" || toolCall.Arguments != "{}" {
+		t.Fatalf("Found unexpected tool call: %#v", toolCall)
+	}
+}
+
+func TestAccumulatorToolCallWithEmptyContentAtNonzeroChoice(t *testing.T) {
+	acc := openai.ChatCompletionAccumulator{}
+
+	toolCallChunk := openai.ChatCompletionChunk{}
+	toolCallJSON := `{"id":"test","choices":[{"index":1,"delta":{"content":"","tool_calls":[{"id":"call_1","index":0,"type":"function","function":{"name":"search","arguments":"{}"}}]}}]}`
+	if err := toolCallChunk.UnmarshalJSON([]byte(toolCallJSON)); err != nil {
+		t.Fatalf("Failed to unmarshal tool call chunk: %v", err)
+	}
+	if !acc.AddChunk(toolCallChunk) {
+		t.Fatal("AddChunk returned false")
+	}
+
+	finishChunk := openai.ChatCompletionChunk{}
+	finishJSON := `{"id":"test","choices":[{"index":1,"delta":{},"finish_reason":"tool_calls"}]}`
+	if err := finishChunk.UnmarshalJSON([]byte(finishJSON)); err != nil {
+		t.Fatalf("Failed to unmarshal finish chunk: %v", err)
+	}
+	if !acc.AddChunk(finishChunk) {
+		t.Fatal("AddChunk returned false")
+	}
+
+	toolCall, ok := acc.JustFinishedToolCall()
+	if !ok {
+		t.Fatal("JustFinishedToolCall did not fire after the finishing chunk")
+	}
+	if toolCall.ID != "call_1" || toolCall.Name != "search" || toolCall.Arguments != "{}" {
+		t.Fatalf("Found unexpected tool call: %#v", toolCall)
+	}
+}
+
 // manually created on 11/3/2024
 var mockResponseBody = `data: {"id":"chatcmpl-A3Tguz3LSXTHBTY2NAPBCSyfBltxF","object":"chat.completion.chunk","created":1725392480,"model":"gpt-4o-2024-05-13","system_fingerprint":"fp_157b3831f5","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":{"content":[],"refusal":null},"finish_reason":null}],"usage":null}
 


### PR DESCRIPTION
Ollama sends tool_calls alongside an explicit empty content field in
the same chunk. Content was checked first in the state switch, so the
tool call never got its own state and JustFinishedToolCall never fired.

Fixes #756