### PR TITLE
fix(api): clarify audio upload metadata requirements

### DIFF
--- a/.castiron.stats.yml
+++ b/.castiron.stats.yml
@@ -1,6 +1,6 @@
 schema_version: 1
-generation_id: 1a719ec8-b7c5-47b8-bc5e-d055df197ef8
-openapi_spec_hash: 8d5c14d02f8cc28de343933fae3a9c28
-openapi_transformed_spec_hash: cc042503b90491f4f162ce95fae87c36
+generation_id: c97eca58-998e-4074-835b-a9de56c49b7c
+openapi_spec_hash: 1faf0319c407c6534ef7c381614afbb6
+openapi_transformed_spec_hash: 53eff50caa9d18046e4ff0615bc7512d
 config_hash: 4617b0962f16d328804312ac81aac630
-codegen_sha: 4fb2ccd37c84e3dc3356cf4ddd3f57ed0f95106a
+codegen_sha: 39beae33b0abd184cc3b7415d82c9bfb2bff85eb

--- a/api_reference/openapi.transformed.yml
+++ b/api_reference/openapi.transformed.yml
@@ -34062,6 +34062,7 @@ components:
         file:
           description: |
             The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+            The request must include enough format metadata for the file to be identified. We recommend an extension-bearing filename and an appropriate content type.
           type: string
           x-oaiTypeLabel: file
           format: binary
@@ -34369,7 +34370,7 @@ components:
       properties:
         file:
           description: |
-            The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+            The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm. The request must include enough format metadata for the file to be identified. We recommend an extension-bearing filename and an appropriate content type.
           type: string
           x-oaiTypeLabel: file
           format: binary

--- a/audiotranscription.go
+++ b/audiotranscription.go
@@ -839,7 +839,9 @@ func (r *AudioTranscriptionNewResponseUnionUsage) UnmarshalJSON(data []byte) err
 
 type AudioTranscriptionNewParams struct {
 	// The audio file object (not file name) to transcribe, in one of these formats:
-	// flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+	// flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm. The request must include
+	// enough format metadata for the file to be identified. We recommend an
+	// extension-bearing filename and an appropriate content type.
 	File io.Reader `json:"file,omitzero" api:"required" format:"binary"`
 	// ID of the model to use. The options are `gpt-transcribe`, `gpt-4o-transcribe`,
 	// `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `whisper-1`

--- a/audiotranslation.go
+++ b/audiotranslation.go
@@ -66,7 +66,9 @@ func (r *Translation) UnmarshalJSON(data []byte) error {
 
 type AudioTranslationNewParams struct {
 	// The audio file object (not file name) translate, in one of these formats: flac,
-	// mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+	// mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm. The request must include enough
+	// format metadata for the file to be identified. We recommend an extension-bearing
+	// filename and an appropriate content type.
 	File io.Reader `json:"file,omitzero" api:"required" format:"binary"`
 	// ID of the model to use. Only `whisper-1` (which is powered by our open source
 	// Whisper V2 model) is currently available.


### PR DESCRIPTION
## Summary

Regenerates the Go SDK from the latest OpenAPI input for the audio upload documentation change.

- Clarifies that transcription and translation uploads must include enough metadata for the file format to be identified.
- Recommends an extension-bearing filename and an appropriate content type.
- Updates generated parameter comments, the transformed OpenAPI document, and Castiron provenance.

This is documentation-only; runtime behavior and exported API shapes are unchanged.

## Source

- Originating API change: [openai/openai#1270941](https://github.com/openai/openai/pull/1270941)
- OpenAPI input: [openai/openai-openapi@577fa922](https://github.com/openai/openai-openapi/commit/577fa92299e000af1616f3be1fec740e3383a86a)

## Validation

- Rebased directly onto the current public `main`
- Every changed file matches the Castiron-generated candidate
- `git diff --check`
- `./scripts/lint` with an isolated Go build cache
- Thermo-nuclear code-quality review