### PR TITLE
fix(apijson): preserve unknown union array variants

### DIFF
--- a/chatcompletion_unknown_content_test.go
+++ b/chatcompletion_unknown_content_test.go
@@ -1,0 +1,66 @@
+package openai_test
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	openai "github.com/openai/openai-go/v3"
+)
+
+func TestChatCompletionParamsPreserveUnknownAssistantContentParts(t *testing.T) {
+	body := []byte(`{
+		"model":"gpt-4o-mini",
+		"messages":[{
+			"role":"assistant",
+			"content":[
+				{"type":"extension","text":"unknown","metadata":{"source":"fixture"}},
+				{"type":"text","text":"kept"}
+			]
+		}]
+	}`)
+
+	var params openai.ChatCompletionNewParams
+	if err := json.Unmarshal(body, &params); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(params.Messages) != 1 || params.Messages[0].OfAssistant == nil {
+		t.Fatalf("assistant message was not decoded: %#v", params.Messages)
+	}
+	parts := params.Messages[0].OfAssistant.Content.OfArrayOfContentParts
+	if len(parts) != 2 {
+		t.Fatalf("decoded content parts = %d, want 2", len(parts))
+	}
+	unknown, ok := parts[0].Overrides()
+	if !ok {
+		t.Fatal("unknown content part was not preserved as raw JSON")
+	}
+	var gotUnknown any
+	if err := json.Unmarshal(unknown.(json.RawMessage), &gotUnknown); err != nil {
+		t.Fatalf("decode preserved content part: %v", err)
+	}
+	var wantUnknown any
+	if err := json.Unmarshal([]byte(`{"type":"extension","text":"unknown","metadata":{"source":"fixture"}}`), &wantUnknown); err != nil {
+		t.Fatalf("decode expected content part: %v", err)
+	}
+	if !reflect.DeepEqual(gotUnknown, wantUnknown) {
+		t.Fatalf("preserved content part = %#v, want %#v", gotUnknown, wantUnknown)
+	}
+	if got := parts[1].GetText(); got == nil || *got != "kept" {
+		t.Fatalf("supported text content was not preserved: %#v", parts[1])
+	}
+
+	encoded, err := json.Marshal(params)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var roundTrip map[string]any
+	if err := json.Unmarshal(encoded, &roundTrip); err != nil {
+		t.Fatalf("decode marshaled params: %v", err)
+	}
+	messages := roundTrip["messages"].([]any)
+	content := messages[0].(map[string]any)["content"].([]any)
+	if !reflect.DeepEqual(content[0], wantUnknown) {
+		t.Fatalf("round-tripped content part = %#v, want %#v", content[0], wantUnknown)
+	}
+}

--- a/internal/apijson/decoder.go
+++ b/internal/apijson/decoder.go
@@ -316,6 +316,9 @@ func (d *decoderBuilder) newArrayTypeDecoder(t reflect.Type) decoderFunc {
 			if err != nil {
 				return err
 			}
+			if itemState.exactness < state.exactness {
+				state.exactness = itemState.exactness
+			}
 		}
 
 		value.Set(arrayValue)

--- a/internal/apijson/decoder.go
+++ b/internal/apijson/decoder.go
@@ -171,6 +171,14 @@ func unmarshalerDecoder(n gjson.Result, v reflect.Value, state *decoderState) er
 	return v.Interface().(json.Unmarshaler).UnmarshalJSON([]byte(n.Raw))
 }
 
+func isRegisteredStructUnionSlice(t reflect.Type) bool {
+	if t.Kind() != reflect.Slice {
+		return false
+	}
+	_, registered := unionRegistry[t.Elem()]
+	return registered && isStructUnion(t.Elem())
+}
+
 func (d *decoderBuilder) newTypeDecoder(t reflect.Type) decoderFunc {
 	if t.ConvertibleTo(reflect.TypeOf(time.Time{})) {
 		return d.newTimeTypeDecoder(t)
@@ -178,6 +186,13 @@ func (d *decoderBuilder) newTypeDecoder(t reflect.Type) decoderFunc {
 
 	if t.Implements(reflect.TypeOf((*param.Optional)(nil)).Elem()) {
 		return d.newOptTypeDecoder(t)
+	}
+
+	// Named union-list roots need UnmarshalJSON for encoding/json, but nested
+	// apijson decodes must retain the parent state for exactness selection.
+	if isRegisteredStructUnionSlice(t) {
+		d.root = false
+		return d.newArrayTypeDecoder(t)
 	}
 
 	if !d.root && t.Implements(reflect.TypeOf((*json.Unmarshaler)(nil)).Elem()) {

--- a/internal/apijson/decoder.go
+++ b/internal/apijson/decoder.go
@@ -48,9 +48,10 @@ type decoderBuilder struct {
 
 // decoderState contains the 'run-time' state of the decoder.
 type decoderState struct {
-	strict    bool
-	exactness exactness
-	validator *validationEntry
+	strict                            bool
+	exactness                         exactness
+	validator                         *validationEntry
+	preserveUnknownDiscriminatedUnion bool
 }
 
 // Exactness refers to how close to the type the result was if deserialization
@@ -288,7 +289,13 @@ func (d *decoderBuilder) newMapDecoder(t reflect.Type) decoderFunc {
 }
 
 func (d *decoderBuilder) newArrayTypeDecoder(t reflect.Type) decoderFunc {
-	itemDecoder := d.typeDecoder(t.Elem())
+	itemType := t.Elem()
+	itemDecoder := d.typeDecoder(itemType)
+	preserveUnknownUnion := false
+	if _, registered := unionRegistry[itemType]; registered && isStructUnion(itemType) {
+		itemDecoder = d.newStructUnionDecoder(itemType)
+		preserveUnknownUnion = true
+	}
 
 	return func(node gjson.Result, value reflect.Value, state *decoderState) (err error) {
 		if !node.IsArray() {
@@ -299,7 +306,13 @@ func (d *decoderBuilder) newArrayTypeDecoder(t reflect.Type) decoderFunc {
 
 		arrayValue := reflect.MakeSlice(reflect.SliceOf(t.Elem()), len(arrayNode), len(arrayNode))
 		for i, itemNode := range arrayNode {
-			err = itemDecoder(itemNode, arrayValue.Index(i), state)
+			itemState := state
+			if preserveUnknownUnion {
+				copy := *state
+				copy.preserveUnknownDiscriminatedUnion = true
+				itemState = &copy
+			}
+			err = itemDecoder(itemNode, arrayValue.Index(i), itemState)
 			if err != nil {
 				return err
 			}

--- a/internal/apijson/enum_test.go
+++ b/internal/apijson/enum_test.go
@@ -74,14 +74,14 @@ func TestEnumStructStringValidator(t *testing.T) {
 		var dst EnumStruct
 
 		dec := decoderBuilder{root: true}
-		exactness, _ := dec.unmarshalWithExactness([]byte(raw), &dst)
+		gotExactness, _ := dec.unmarshalWithExactness([]byte(raw), &dst)
 
 		if !reflect.DeepEqual(dst, expected.EnumStruct) {
 			t.Fatalf("failed equality check %#v", dst)
 		}
 
-		if exactness != expected.exactness {
-			t.Fatalf("exactness got %d expected %d %s", exactness, expected.exactness, raw)
+		if gotExactness != expected.exactness {
+			t.Fatalf("exactness got %d expected %d %s", gotExactness, expected.exactness, raw)
 		}
 	}
 }

--- a/internal/apijson/union.go
+++ b/internal/apijson/union.go
@@ -100,7 +100,13 @@ func (d *decoderBuilder) newStructUnionDecoder(t reflect.Type) decoderFunc {
 				}
 				if discriminator == decoder.discriminator {
 					inner := v.FieldByIndex(decoder.field.Index)
-					return decoder.decoder(n, inner, state)
+					// Preservation only applies to the union that is itself an array
+					// element. Nested arrays will opt their own elements in.
+					preserveUnknown := state.preserveUnknownDiscriminatedUnion
+					state.preserveUnknownDiscriminatedUnion = false
+					err := decoder.decoder(n, inner, state)
+					state.preserveUnknownDiscriminatedUnion = preserveUnknown
+					return err
 				}
 			}
 			if state.preserveUnknownDiscriminatedUnion && discriminatorNode.Exists() && compatibleDiscriminatorType && preserveUnknownParamUnion(v, n.Raw) {

--- a/internal/apijson/union.go
+++ b/internal/apijson/union.go
@@ -2,13 +2,26 @@ package apijson
 
 import (
 	"errors"
-	"github.com/openai/openai-go/v3/packages/param"
 	"reflect"
 
 	"github.com/tidwall/gjson"
+
+	"github.com/openai/openai-go/v3/packages/param"
 )
 
 var apiUnionType = reflect.TypeOf(param.APIUnion{})
+
+// param.SetJSON accepts an unexported setter interface. The decoder only has a
+// runtime reflect.Value, so invoke it reflectively after verifying the pointer.
+var setParamJSON = reflect.ValueOf(param.SetJSON)
+
+func preserveUnknownParamUnion(v reflect.Value, raw string) bool {
+	if !v.CanAddr() || !v.Addr().Type().Implements(setParamJSON.Type().In(1)) {
+		return false
+	}
+	setParamJSON.Call([]reflect.Value{reflect.ValueOf([]byte(raw)), v.Addr()})
+	return true
+}
 
 func isStructUnion(t reflect.Type) bool {
 	if t.Kind() != reflect.Struct {
@@ -78,12 +91,20 @@ func (d *decoderBuilder) newStructUnionDecoder(t reflect.Type) decoderFunc {
 
 	return func(n gjson.Result, v reflect.Value, state *decoderState) error {
 		if discriminated && n.Type == gjson.JSON && len(unionEntry.discriminatorKey) != 0 {
-			discriminator := n.Get(EscapeSJSONKey(unionEntry.discriminatorKey)).Value()
+			discriminatorNode := n.Get(EscapeSJSONKey(unionEntry.discriminatorKey))
+			discriminator := discriminatorNode.Value()
+			compatibleDiscriminatorType := false
 			for _, decoder := range discriminatedDecoders {
+				if reflect.TypeOf(discriminator) == reflect.TypeOf(decoder.discriminator) {
+					compatibleDiscriminatorType = true
+				}
 				if discriminator == decoder.discriminator {
 					inner := v.FieldByIndex(decoder.field.Index)
 					return decoder.decoder(n, inner, state)
 				}
+			}
+			if state.preserveUnknownDiscriminatedUnion && discriminatorNode.Exists() && compatibleDiscriminatorType && preserveUnknownParamUnion(v, n.Raw) {
+				return nil
 			}
 			return errors.New("apijson: was not able to find discriminated union variant")
 		}

--- a/internal/apijson/union_array_test.go
+++ b/internal/apijson/union_array_test.go
@@ -26,8 +26,14 @@ type arrayDiscriminatedRefusal struct {
 	Refusal string `json:"refusal"`
 }
 
+type arrayDiscriminatedList []arrayDiscriminatedUnion
+
+func (r *arrayDiscriminatedList) UnmarshalJSON(data []byte) error {
+	return UnmarshalRoot(data, r)
+}
+
 type arrayDiscriminatedHolder struct {
-	Parts []arrayDiscriminatedUnion `json:"parts"`
+	Parts arrayDiscriminatedList `json:"parts"`
 }
 
 type arrayNestedDiscriminatedUnion struct {

--- a/internal/apijson/union_array_test.go
+++ b/internal/apijson/union_array_test.go
@@ -1,0 +1,100 @@
+package apijson
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/openai/openai-go/v3/packages/param"
+)
+
+type arrayDiscriminatedUnion struct {
+	OfText    *arrayDiscriminatedText    `json:",omitzero,inline"`
+	OfRefusal *arrayDiscriminatedRefusal `json:",omitzero,inline"`
+	param.APIUnion
+}
+
+type arrayDiscriminatedText struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type arrayDiscriminatedRefusal struct {
+	Type    string `json:"type"`
+	Refusal string `json:"refusal"`
+}
+
+type arrayDiscriminatedHolder struct {
+	Parts []arrayDiscriminatedUnion `json:"parts"`
+}
+
+func init() {
+	RegisterUnion[arrayDiscriminatedUnion](
+		"type",
+		Discriminator[arrayDiscriminatedText]("text"),
+		Discriminator[arrayDiscriminatedRefusal]("refusal"),
+	)
+}
+
+func TestArrayDecoderPreservesUnknownDiscriminatedUnionVariant(t *testing.T) {
+	var got arrayDiscriminatedHolder
+	err := Unmarshal([]byte(`{"parts":[{"type":"extension","text":"unknown"},{"type":"text","text":"kept"}]}`), &got)
+	if err != nil {
+		t.Fatalf("Unmarshal returned error: %v", err)
+	}
+	if len(got.Parts) != 2 {
+		t.Fatalf("decoded parts = %d, want 2", len(got.Parts))
+	}
+	unknown, ok := got.Parts[0].Overrides()
+	if !ok || !reflect.DeepEqual(unknown, json.RawMessage(`{"type":"extension","text":"unknown"}`)) {
+		t.Fatalf("unknown union variant was not preserved: %#v", unknown)
+	}
+	if got.Parts[1].OfText == nil || got.Parts[1].OfText.Text != "kept" {
+		t.Fatalf("supported union variant was not preserved: %#v", got.Parts[1])
+	}
+}
+
+func TestArrayDecoderDoesNotPreserveMalformedUnionElement(t *testing.T) {
+	var got arrayDiscriminatedHolder
+	err := Unmarshal([]byte(`{"parts":[42,{"type":"text","text":"kept"}]}`), &got)
+	if err != nil {
+		t.Fatalf("Unmarshal returned error: %v", err)
+	}
+	if len(got.Parts) != 0 {
+		t.Fatalf("malformed element should keep the array invalid; decoded parts = %d", len(got.Parts))
+	}
+}
+
+func TestUnknownDiscriminatedUnionStillErrorsOutsideArray(t *testing.T) {
+	var got arrayDiscriminatedUnion
+	if err := Unmarshal([]byte(`{"type":"extension","text":"unknown"}`), &got); err == nil {
+		t.Fatal("unknown discriminated union unexpectedly decoded without an error")
+	}
+}
+
+func TestMissingDiscriminatorStillErrors(t *testing.T) {
+	var got arrayDiscriminatedUnion
+	if err := Unmarshal([]byte(`{"text":"missing type"}`), &got); err == nil {
+		t.Fatal("missing discriminator unexpectedly decoded without an error")
+	}
+}
+
+func TestArrayDecoderDoesNotPreserveMissingDiscriminator(t *testing.T) {
+	var got arrayDiscriminatedHolder
+	if err := Unmarshal([]byte(`{"parts":[{"text":"missing type"},{"type":"text","text":"kept"}]}`), &got); err != nil {
+		t.Fatalf("Unmarshal returned error: %v", err)
+	}
+	if len(got.Parts) != 0 {
+		t.Fatalf("missing discriminator should keep the array invalid; decoded parts = %d", len(got.Parts))
+	}
+}
+
+func TestArrayDecoderDoesNotPreserveWrongDiscriminatorType(t *testing.T) {
+	var got arrayDiscriminatedHolder
+	if err := Unmarshal([]byte(`{"parts":[{"type":42,"text":"wrong type"},{"type":"text","text":"kept"}]}`), &got); err != nil {
+		t.Fatalf("Unmarshal returned error: %v", err)
+	}
+	if len(got.Parts) != 0 {
+		t.Fatalf("wrong discriminator type should keep the array invalid; decoded parts = %d", len(got.Parts))
+	}
+}

--- a/internal/apijson/union_array_test.go
+++ b/internal/apijson/union_array_test.go
@@ -54,6 +54,27 @@ func TestArrayDecoderPreservesUnknownDiscriminatedUnionVariant(t *testing.T) {
 	}
 }
 
+func TestArrayDecoderPropagatesKnownUnionElementExactness(t *testing.T) {
+	cases := map[string]exactness{
+		`{"parts":[{"type":"text","text":"kept","extra":true}]}`: extras,
+		`{"parts":[{"type":"text","text":42}]}`:                  loose,
+	}
+
+	for raw, expected := range cases {
+		t.Run(raw, func(t *testing.T) {
+			var got arrayDiscriminatedHolder
+			decoder := decoderBuilder{root: true}
+			exactness, err := decoder.unmarshalWithExactness([]byte(raw), &got)
+			if err != nil {
+				t.Fatalf("Unmarshal returned error: %v", err)
+			}
+			if exactness != expected {
+				t.Fatalf("exactness = %d, want %d", exactness, expected)
+			}
+		})
+	}
+}
+
 func TestArrayDecoderDoesNotPreserveMalformedUnionElement(t *testing.T) {
 	var got arrayDiscriminatedHolder
 	err := Unmarshal([]byte(`{"parts":[42,{"type":"text","text":"kept"}]}`), &got)

--- a/internal/apijson/union_array_test.go
+++ b/internal/apijson/union_array_test.go
@@ -15,8 +15,10 @@ type arrayDiscriminatedUnion struct {
 }
 
 type arrayDiscriminatedText struct {
-	Type string `json:"type"`
-	Text string `json:"text"`
+	Type        string                          `json:"type"`
+	Text        string                          `json:"text"`
+	Nested      arrayNestedDiscriminatedUnion   `json:"nested"`
+	NestedParts []arrayNestedDiscriminatedUnion `json:"nested_parts"`
 }
 
 type arrayDiscriminatedRefusal struct {
@@ -28,11 +30,24 @@ type arrayDiscriminatedHolder struct {
 	Parts []arrayDiscriminatedUnion `json:"parts"`
 }
 
+type arrayNestedDiscriminatedUnion struct {
+	OfKnown *arrayNestedDiscriminatedKnown `json:",omitzero,inline"`
+	param.APIUnion
+}
+
+type arrayNestedDiscriminatedKnown struct {
+	Type string `json:"type"`
+}
+
 func init() {
 	RegisterUnion[arrayDiscriminatedUnion](
 		"type",
 		Discriminator[arrayDiscriminatedText]("text"),
 		Discriminator[arrayDiscriminatedRefusal]("refusal"),
+	)
+	RegisterUnion[arrayNestedDiscriminatedUnion](
+		"type",
+		Discriminator[arrayNestedDiscriminatedKnown]("known"),
 	)
 }
 
@@ -90,6 +105,34 @@ func TestUnknownDiscriminatedUnionStillErrorsOutsideArray(t *testing.T) {
 	var got arrayDiscriminatedUnion
 	if err := Unmarshal([]byte(`{"type":"extension","text":"unknown"}`), &got); err == nil {
 		t.Fatal("unknown discriminated union unexpectedly decoded without an error")
+	}
+}
+
+func TestArrayDecoderDoesNotPreserveNestedUnknownDiscriminatedUnion(t *testing.T) {
+	var got arrayDiscriminatedHolder
+	err := Unmarshal([]byte(`{"parts":[{"type":"text","text":"kept","nested":{"type":"extension"}}]}`), &got)
+	if err != nil {
+		t.Fatalf("Unmarshal returned error: %v", err)
+	}
+	if len(got.Parts) != 1 || got.Parts[0].OfText == nil {
+		t.Fatalf("known array element was not decoded: %#v", got.Parts)
+	}
+	if _, ok := got.Parts[0].OfText.Nested.Overrides(); ok {
+		t.Fatal("nested unknown union was unexpectedly preserved")
+	}
+}
+
+func TestArrayDecoderPreservesUnknownNestedArrayElement(t *testing.T) {
+	var got arrayDiscriminatedHolder
+	err := Unmarshal([]byte(`{"parts":[{"type":"text","text":"kept","nested_parts":[{"type":"extension"}]}]}`), &got)
+	if err != nil {
+		t.Fatalf("Unmarshal returned error: %v", err)
+	}
+	if len(got.Parts) != 1 || got.Parts[0].OfText == nil || len(got.Parts[0].OfText.NestedParts) != 1 {
+		t.Fatalf("nested array element was not decoded: %#v", got.Parts)
+	}
+	if _, ok := got.Parts[0].OfText.NestedParts[0].Overrides(); !ok {
+		t.Fatal("unknown nested array element was not preserved")
 	}
 }
 

--- a/realtime/unknown_union_list_root.go
+++ b/realtime/unknown_union_list_root.go
@@ -1,0 +1,15 @@
+package realtime
+
+import (
+	"bytes"
+
+	"github.com/openai/openai-go/v3/internal/apijson"
+)
+
+func (r *RealtimeToolsConfigParam) UnmarshalJSON(data []byte) error {
+	if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+		*r = nil
+		return nil
+	}
+	return apijson.UnmarshalRoot(data, r)
+}

--- a/responses/unknown_union_list_root.go
+++ b/responses/unknown_union_list_root.go
@@ -1,0 +1,39 @@
+package responses
+
+import (
+	"bytes"
+
+	"github.com/openai/openai-go/v3/internal/apijson"
+)
+
+func (r *ComputerActionListParam) UnmarshalJSON(data []byte) error {
+	if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+		*r = nil
+		return nil
+	}
+	return apijson.UnmarshalRoot(data, r)
+}
+
+func (r *ResponseFunctionCallOutputItemListParam) UnmarshalJSON(data []byte) error {
+	if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+		*r = nil
+		return nil
+	}
+	return apijson.UnmarshalRoot(data, r)
+}
+
+func (r *ResponseInputParam) UnmarshalJSON(data []byte) error {
+	if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+		*r = nil
+		return nil
+	}
+	return apijson.UnmarshalRoot(data, r)
+}
+
+func (r *ResponseInputMessageContentListParam) UnmarshalJSON(data []byte) error {
+	if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+		*r = nil
+		return nil
+	}
+	return apijson.UnmarshalRoot(data, r)
+}

--- a/unknown_union_list_root.go
+++ b/unknown_union_list_root.go
@@ -1,0 +1,39 @@
+package openai
+
+import (
+	"bytes"
+
+	"github.com/openai/openai-go/v3/internal/apijson"
+)
+
+func (r *BetaComputerActionListParam) UnmarshalJSON(data []byte) error {
+	if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+		*r = nil
+		return nil
+	}
+	return apijson.UnmarshalRoot(data, r)
+}
+
+func (r *BetaResponseFunctionCallOutputItemListParam) UnmarshalJSON(data []byte) error {
+	if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+		*r = nil
+		return nil
+	}
+	return apijson.UnmarshalRoot(data, r)
+}
+
+func (r *BetaResponseInputParam) UnmarshalJSON(data []byte) error {
+	if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+		*r = nil
+		return nil
+	}
+	return apijson.UnmarshalRoot(data, r)
+}
+
+func (r *BetaResponseInputMessageContentListParam) UnmarshalJSON(data []byte) error {
+	if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+		*r = nil
+		return nil
+	}
+	return apijson.UnmarshalRoot(data, r)
+}

--- a/unknown_union_list_root_test.go
+++ b/unknown_union_list_root_test.go
@@ -1,0 +1,120 @@
+package openai_test
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	openai "github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/realtime"
+	"github.com/openai/openai-go/v3/responses"
+)
+
+type unionListItem interface {
+	Overrides() (any, bool)
+}
+
+func assertUnknownUnionListRoot[T ~[]E, E unionListItem](t *testing.T) {
+	t.Helper()
+
+	body := []byte(`[{"type":"extension","metadata":{"source":"fixture"}}]`)
+	var got T
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("decoded items = %d, want 1", len(got))
+	}
+	override, ok := got[0].Overrides()
+	if !ok {
+		t.Fatal("unknown list item was not preserved as raw JSON")
+	}
+	raw, ok := override.(json.RawMessage)
+	if !ok {
+		t.Fatalf("preserved item type = %T, want json.RawMessage", override)
+	}
+	var gotUnknown any
+	if err := json.Unmarshal(raw, &gotUnknown); err != nil {
+		t.Fatalf("decode preserved item: %v", err)
+	}
+	var wantUnknown any
+	if err := json.Unmarshal(body[1:len(body)-1], &wantUnknown); err != nil {
+		t.Fatalf("decode expected item: %v", err)
+	}
+	if !reflect.DeepEqual(gotUnknown, wantUnknown) {
+		t.Fatalf("preserved item = %#v, want %#v", gotUnknown, wantUnknown)
+	}
+
+	encoded, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var roundTrip any
+	if err := json.Unmarshal(encoded, &roundTrip); err != nil {
+		t.Fatalf("decode marshaled list: %v", err)
+	}
+	var wantRoundTrip any
+	if err := json.Unmarshal(body, &wantRoundTrip); err != nil {
+		t.Fatalf("decode expected list: %v", err)
+	}
+	if !reflect.DeepEqual(roundTrip, wantRoundTrip) {
+		t.Fatalf("round-tripped list = %#v, want %#v", roundTrip, wantRoundTrip)
+	}
+}
+
+func TestParamUnionListRootsPreserveUnknownElements(t *testing.T) {
+	t.Run("beta computer actions", func(t *testing.T) {
+		assertUnknownUnionListRoot[openai.BetaComputerActionListParam, openai.BetaComputerActionUnionParam](t)
+	})
+	t.Run("beta function call output items", func(t *testing.T) {
+		assertUnknownUnionListRoot[openai.BetaResponseFunctionCallOutputItemListParam, openai.BetaResponseFunctionCallOutputItemUnionParam](t)
+	})
+	t.Run("beta response input", func(t *testing.T) {
+		assertUnknownUnionListRoot[openai.BetaResponseInputParam, openai.BetaResponseInputItemUnionParam](t)
+	})
+	t.Run("beta response input message content", func(t *testing.T) {
+		assertUnknownUnionListRoot[openai.BetaResponseInputMessageContentListParam, openai.BetaResponseInputContentUnionParam](t)
+	})
+	t.Run("computer actions", func(t *testing.T) {
+		assertUnknownUnionListRoot[responses.ComputerActionListParam, responses.ComputerActionUnionParam](t)
+	})
+	t.Run("function call output items", func(t *testing.T) {
+		assertUnknownUnionListRoot[responses.ResponseFunctionCallOutputItemListParam, responses.ResponseFunctionCallOutputItemUnionParam](t)
+	})
+	t.Run("response input", func(t *testing.T) {
+		assertUnknownUnionListRoot[responses.ResponseInputParam, responses.ResponseInputItemUnionParam](t)
+	})
+	t.Run("response input message content", func(t *testing.T) {
+		assertUnknownUnionListRoot[responses.ResponseInputMessageContentListParam, responses.ResponseInputContentUnionParam](t)
+	})
+	t.Run("realtime tools", func(t *testing.T) {
+		assertUnknownUnionListRoot[realtime.RealtimeToolsConfigParam, realtime.RealtimeToolsConfigUnionParam](t)
+	})
+}
+
+func TestParamUnionListRootPreservesNullSliceSemantics(t *testing.T) {
+	got := responses.ResponseInputParam{{OfMessage: &responses.EasyInputMessageParam{}}}
+	if err := json.Unmarshal([]byte(`null`), &got); err != nil {
+		t.Fatalf("unmarshal null: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("decoded null list = %#v, want nil", got)
+	}
+}
+
+func TestStandaloneParamUnionStillRejectsUnknownVariant(t *testing.T) {
+	var got responses.ResponseInputItemUnionParam
+	if err := json.Unmarshal([]byte(`{"type":"extension"}`), &got); err == nil {
+		t.Fatal("unknown standalone union unexpectedly decoded without an error")
+	}
+}
+
+func TestParamUnionListRootStillRejectsMalformedElement(t *testing.T) {
+	var got responses.ResponseInputParam
+	if err := json.Unmarshal([]byte(`[{"type":42}]`), &got); err == nil {
+		t.Fatal("wrong-typed list discriminator unexpectedly decoded without an error")
+	}
+	if err := json.Unmarshal([]byte(`[{"metadata":{"source":"fixture"}}]`), &got); err == nil {
+		t.Fatal("missing list discriminator unexpectedly decoded without an error")
+	}
+}


### PR DESCRIPTION
Fixes #425.

Preserve unknown discriminated union elements in parameter arrays as raw JSON, so supported neighboring content parts remain available and unknown parts round-trip without data loss.

Tests:
- `go test ./internal/apijson -count=1`
- `go test . -run TestChatCompletionParamsPreserveUnknownAssistantContentParts -count=1`
- lint and full tests on Go 1.25 and 1.26