### PR TITLE
fix(apijson): reject non-object root payloads

### DIFF
--- a/chatcompletion_unmarshal_test.go
+++ b/chatcompletion_unmarshal_test.go
@@ -1,0 +1,66 @@
+package openai_test
+
+import (
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/openai/openai-go/v3"
+)
+
+func TestChatCompletionChunkUnmarshalValidatesTopLevelShape(t *testing.T) {
+	t.Run("object", func(t *testing.T) {
+		var chunk openai.ChatCompletionChunk
+		if err := json.Unmarshal([]byte(`{"id":"chatcmpl_test","choices":[]}`), &chunk); err != nil {
+			t.Fatalf("unmarshal object: %v", err)
+		}
+		if chunk.ID != "chatcmpl_test" {
+			t.Fatalf("chunk ID = %q, want %q", chunk.ID, "chatcmpl_test")
+		}
+	})
+
+	t.Run("null", func(t *testing.T) {
+		chunk := openai.ChatCompletionChunk{ID: "unchanged"}
+		if err := json.Unmarshal([]byte(`null`), &chunk); err != nil {
+			t.Fatalf("unmarshal null: %v", err)
+		}
+		if chunk.ID != "unchanged" {
+			t.Fatalf("chunk ID = %q after null, want unchanged", chunk.ID)
+		}
+	})
+
+	for name, test := range map[string]struct {
+		input string
+		value string
+	}{
+		"array":   {input: `[]`, value: "array"},
+		"boolean": {input: `true`, value: "bool"},
+		"number":  {input: `42`, value: "number"},
+		"string":  {input: `"chunk"`, value: "string"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			chunk := openai.ChatCompletionChunk{ID: "unchanged"}
+			err := json.Unmarshal([]byte(test.input), &chunk)
+			if err == nil {
+				t.Fatalf("unmarshal %s succeeded, want a type error", name)
+			}
+			var typeErr *json.UnmarshalTypeError
+			if !errors.As(err, &typeErr) {
+				t.Fatalf("error type = %T, want *json.UnmarshalTypeError", err)
+			}
+			if typeErr.Value != test.value {
+				t.Fatalf("error value = %q, want %q", typeErr.Value, test.value)
+			}
+			if typeErr.Type != reflect.TypeOf(chunk) {
+				t.Fatalf("error target type = %v, want %v", typeErr.Type, reflect.TypeOf(chunk))
+			}
+			if chunk.ID != "unchanged" {
+				t.Fatalf("chunk ID = %q after failed unmarshal, want unchanged", chunk.ID)
+			}
+			if got := chunk.RawJSON(); got != "" {
+				t.Fatalf("raw JSON = %q after failed unmarshal, want empty", got)
+			}
+		})
+	}
+}

--- a/internal/apijson/decoder.go
+++ b/internal/apijson/decoder.go
@@ -180,6 +180,8 @@ func isRegisteredStructUnionSlice(t reflect.Type) bool {
 }
 
 func (d *decoderBuilder) newTypeDecoder(t reflect.Type) decoderFunc {
+	isRoot := d.root
+
 	if t.ConvertibleTo(reflect.TypeOf(time.Time{})) {
 		return d.newTimeTypeDecoder(t)
 	}
@@ -235,7 +237,7 @@ func (d *decoderBuilder) newTypeDecoder(t reflect.Type) decoderFunc {
 		if isStructUnion(t) {
 			return d.newStructUnionDecoder(t)
 		}
-		return d.newStructTypeDecoder(t)
+		return d.newStructTypeDecoder(t, isRoot)
 	case reflect.Array:
 		fallthrough
 	case reflect.Slice:
@@ -341,7 +343,7 @@ func (d *decoderBuilder) newArrayTypeDecoder(t reflect.Type) decoderFunc {
 	}
 }
 
-func (d *decoderBuilder) newStructTypeDecoder(t reflect.Type) decoderFunc {
+func (d *decoderBuilder) newStructTypeDecoder(t reflect.Type, isRoot bool) decoderFunc {
 	// map of json field name to struct field decoders
 	decoderFields := map[string]decoderField{}
 	anonymousDecoders := []decoderField{}
@@ -416,6 +418,18 @@ func (d *decoderBuilder) newStructTypeDecoder(t reflect.Type) decoderFunc {
 	}
 
 	return func(node gjson.Result, value reflect.Value, state *decoderState) (err error) {
+		// Plain structs represent JSON objects. Inline structs represent
+		// unions and may legitimately decode from scalar or array values.
+		if isRoot && len(inlineDecoders) == 0 && !node.IsObject() && node.Type != gjson.Null {
+			var object struct{}
+			if err := json.Unmarshal([]byte(node.Raw), &object); err != nil {
+				if typeErr, ok := err.(*json.UnmarshalTypeError); ok {
+					typeErr.Type = t
+					return typeErr
+				}
+			}
+		}
+
 		if field := value.FieldByName("JSON"); field.IsValid() {
 			if raw := field.FieldByName("raw"); raw.IsValid() {
 				setUnexportedField(raw, node.Raw)

--- a/internal/apijson/decoder.go
+++ b/internal/apijson/decoder.go
@@ -217,7 +217,8 @@ func (d *decoderBuilder) newTypeDecoder(t reflect.Type) decoderFunc {
 	switch t.Kind() {
 	case reflect.Pointer:
 		inner := t.Elem()
-		innerDecoder := d.typeDecoder(inner)
+		innerBuilder := decoderBuilder{root: isRoot, dateFormat: d.dateFormat}
+		innerDecoder := innerBuilder.typeDecoder(inner)
 
 		return func(n gjson.Result, v reflect.Value, state *decoderState) error {
 			if !v.IsValid() {

--- a/internal/apijson/decoder.go
+++ b/internal/apijson/decoder.go
@@ -6,6 +6,7 @@ package apijson
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/openai/openai-go/v3/packages/param"
 	"reflect"
@@ -423,8 +424,9 @@ func (d *decoderBuilder) newStructTypeDecoder(t reflect.Type, isRoot bool) decod
 		// unions and may legitimately decode from scalar or array values.
 		if isRoot && len(inlineDecoders) == 0 && !node.IsObject() && node.Type != gjson.Null {
 			var object struct{}
-			if err := json.Unmarshal([]byte(node.Raw), &object); err != nil {
-				if typeErr, ok := err.(*json.UnmarshalTypeError); ok {
+			if decodeErr := json.Unmarshal([]byte(node.Raw), &object); decodeErr != nil {
+				var typeErr *json.UnmarshalTypeError
+				if errors.As(decodeErr, &typeErr) {
 					typeErr.Type = t
 					return typeErr
 				}

--- a/internal/apijson/root_pointer_shape_test.go
+++ b/internal/apijson/root_pointer_shape_test.go
@@ -1,0 +1,31 @@
+package apijson
+
+import (
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+)
+
+type rootPointerShape struct {
+	Value string `json:"value"`
+}
+
+func TestRootPointerStructRejectsNonObjectJSON(t *testing.T) {
+	for _, input := range []string{`[]`, `true`, `42`, `"value"`} {
+		t.Run(input, func(t *testing.T) {
+			var got *rootPointerShape
+			err := UnmarshalRoot([]byte(input), &got)
+			if err == nil {
+				t.Fatalf("UnmarshalRoot(%s) succeeded with %#v", input, got)
+			}
+			var typeErr *json.UnmarshalTypeError
+			if !errors.As(err, &typeErr) {
+				t.Fatalf("error type = %T, want *json.UnmarshalTypeError", err)
+			}
+			if typeErr.Type != reflect.TypeOf(rootPointerShape{}) {
+				t.Fatalf("error target type = %v", typeErr.Type)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #379.

Require top-level JSON objects when decoding ordinary response structs, while preserving `null` behavior and inline union decoding.

Tests:
- `go test . -run TestChatCompletionChunkUnmarshalValidatesTopLevelShape -count=1`
- `go test ./internal/apijson -count=1`
- lint and full tests on Go 1.25 and 1.26