### PR TITLE
chore: enable full go vet analysis

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,13 @@
 version: "2"
 
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
 linters:
   default: none
   enable:
+    - govet
     - ineffassign
     - nolintlint
   exclusions:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,12 @@ linters:
   exclusions:
     generated: disable
   settings:
+    govet:
+      enable-all: true
+      disable:
+        # Generated public API structs preserve schema field order; layout-only
+        # reordering would create compatibility risk without improving safety.
+        - fieldalignment
     nolintlint:
       # A disabled analyzer cannot reliably prove whether its directive is stale.
       allow-unused: true

--- a/auth/subjecttokenprovider_test.go
+++ b/auth/subjecttokenprovider_test.go
@@ -19,8 +19,8 @@ func TestK8sProviderFileReading(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 
 	tokenContent := "  test-jwt-token-123  \n"
-	if _, err := tmpFile.WriteString(tokenContent); err != nil {
-		t.Fatalf("Failed to write to temp file: %v", err)
+	if _, writeErr := tmpFile.WriteString(tokenContent); writeErr != nil {
+		t.Fatalf("Failed to write to temp file: %v", writeErr)
 	}
 	tmpFile.Close()
 
@@ -95,8 +95,8 @@ func TestK8sProviderEmptyToken(t *testing.T) {
 	}
 	defer os.Remove(tmpFile.Name())
 
-	if _, err := tmpFile.WriteString("   \n   "); err != nil {
-		t.Fatalf("Failed to write to temp file: %v", err)
+	if _, writeErr := tmpFile.WriteString("   \n   "); writeErr != nil {
+		t.Fatalf("Failed to write to temp file: %v", writeErr)
 	}
 	tmpFile.Close()
 

--- a/azure/azure_test.go
+++ b/azure/azure_test.go
@@ -64,12 +64,12 @@ func TestGetAudioMultipartRoute(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := mw.WriteField("model", "arbitraryDeployment"); err != nil {
-		t.Fatal(err)
+	if writeErr := mw.WriteField("model", "arbitraryDeployment"); writeErr != nil {
+		t.Fatal(writeErr)
 	}
 
-	if err := mw.Close(); err != nil {
-		t.Fatal(err)
+	if closeErr := mw.Close(); closeErr != nil {
+		t.Fatal(closeErr)
 	}
 
 	req, err := http.NewRequest("POST", "/audio/transcriptions", bytes.NewReader(buff.Bytes()))
@@ -378,11 +378,11 @@ func newMultipartRouteRequest(t *testing.T, route string, model string) *http.Re
 	if _, err = fw.Write([]byte("ignore me")); err != nil {
 		t.Fatal(err)
 	}
-	if err := mw.WriteField("model", model); err != nil {
-		t.Fatal(err)
+	if writeErr := mw.WriteField("model", model); writeErr != nil {
+		t.Fatal(writeErr)
 	}
-	if err := mw.Close(); err != nil {
-		t.Fatal(err)
+	if closeErr := mw.Close(); closeErr != nil {
+		t.Fatal(closeErr)
 	}
 
 	req, err := http.NewRequest("POST", route, bytes.NewReader(buff.Bytes()))

--- a/bedrock/auth.go
+++ b/bedrock/auth.go
@@ -120,8 +120,8 @@ func resolveConfig(ctx context.Context, cfg Config, now func() time.Time) (resol
 	if err != nil {
 		return resolvedConfig{}, err
 	}
-	if err := validateAWSRegion(region); err != nil {
-		return resolvedConfig{}, err
+	if regionErr := validateAWSRegion(region); regionErr != nil {
+		return resolvedConfig{}, regionErr
 	}
 	baseURLValue, err := resolveOptionalConfigValue("BaseURL", cfg.BaseURL, "AWS_BEDROCK_BASE_URL")
 	if err != nil {
@@ -137,8 +137,8 @@ func resolveConfig(ctx context.Context, cfg Config, now func() time.Time) (resol
 		if err != nil {
 			return resolvedConfig{}, err
 		}
-		if err := validateAWSRegion(region); err != nil {
-			return resolvedConfig{}, err
+		if regionErr := validateAWSRegion(region); regionErr != nil {
+			return resolvedConfig{}, regionErr
 		}
 	}
 
@@ -158,17 +158,17 @@ func resolveConfig(ctx context.Context, cfg Config, now func() time.Time) (resol
 		if region == "" {
 			return resolvedConfig{}, errors.New(missingRegionMessage)
 		}
-		if err := validateAWSRegion(region); err != nil {
-			return resolvedConfig{}, err
+		if regionErr := validateAWSRegion(region); regionErr != nil {
+			return resolvedConfig{}, regionErr
 		}
 		if baseURL != nil {
-			if _, err := reconcileEndpointRegion(baseURL, region); err != nil {
-				return resolvedConfig{}, err
+			if _, endpointErr := reconcileEndpointRegion(baseURL, region); endpointErr != nil {
+				return resolvedConfig{}, endpointErr
 			}
 		}
 		awsCfg.Region = region
-		if err := verifyAWSCredentials(ctx, awsCfg, explicitAWS); err != nil {
-			return resolvedConfig{}, err
+		if credentialErr := verifyAWSCredentials(ctx, awsCfg, explicitAWS); credentialErr != nil {
+			return resolvedConfig{}, credentialErr
 		}
 		resolved.region = region
 	default:

--- a/bedrock/auth_additional_test.go
+++ b/bedrock/auth_additional_test.go
@@ -165,21 +165,21 @@ func TestEnvironmentBearerRefreshesAndFailsSafelyWhenRemoved(t *testing.T) {
 	}
 
 	var response *http.Response
-	if err := client.Get(context.Background(), "/models", nil, &response); err != nil {
-		t.Fatal(err)
+	if requestErr := client.Get(context.Background(), "/models", nil, &response); requestErr != nil {
+		t.Fatal(requestErr)
 	}
-	if err := os.Setenv("AWS_BEARER_TOKEN_BEDROCK", "second-token"); err != nil {
-		t.Fatal(err)
+	if setEnvErr := os.Setenv("AWS_BEARER_TOKEN_BEDROCK", "second-token"); setEnvErr != nil {
+		t.Fatal(setEnvErr)
 	}
-	if err := client.Get(context.Background(), "/models", nil, &response); err != nil {
-		t.Fatal(err)
+	if requestErr := client.Get(context.Background(), "/models", nil, &response); requestErr != nil {
+		t.Fatal(requestErr)
 	}
 	if got := strings.Join(authorizations, ","); got != "Bearer first-token,Bearer second-token" {
 		t.Fatalf("authorizations = %q", got)
 	}
 
-	if err := os.Unsetenv("AWS_BEARER_TOKEN_BEDROCK"); err != nil {
-		t.Fatal(err)
+	if unsetEnvErr := os.Unsetenv("AWS_BEARER_TOKEN_BEDROCK"); unsetEnvErr != nil {
+		t.Fatal(unsetEnvErr)
 	}
 	err = client.Get(context.Background(), "/models", nil, &response)
 	if err == nil || !strings.Contains(err.Error(), "failed to resolve a bearer credential") {

--- a/bedrock/auth_test.go
+++ b/bedrock/auth_test.go
@@ -189,8 +189,8 @@ func TestSigV4Fixture(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := json.Unmarshal(contents, &fixture); err != nil {
-		t.Fatal(err)
+	if unmarshalErr := json.Unmarshal(contents, &fixture); unmarshalErr != nil {
+		t.Fatal(unmarshalErr)
 	}
 	if fixture.Service != bedrockService {
 		t.Fatalf("fixture service = %q", fixture.Service)

--- a/examples/chat-completion-tool-calling/main.go
+++ b/examples/chat-completion-tool-calling/main.go
@@ -61,9 +61,9 @@ func main() {
 		if toolCall.Function.Name == "get_weather" {
 			// Extract the location from the function call arguments
 			var args map[string]interface{}
-			err := json.Unmarshal([]byte(toolCall.Function.Arguments), &args)
-			if err != nil {
-				panic(err)
+			unmarshalErr := json.Unmarshal([]byte(toolCall.Function.Arguments), &args)
+			if unmarshalErr != nil {
+				panic(unmarshalErr)
 			}
 			location := args["location"].(string)
 

--- a/examples/mutual-tls/main_test.go
+++ b/examples/mutual-tls/main_test.go
@@ -187,8 +187,8 @@ func TestNativeMutualTLSHTTPClient(t *testing.T) {
 			t.Errorf("Authorization header = %q, want %q", got, want)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		if _, err := w.Write([]byte(`{"object":"list","data":[{"id":"test-model","object":"model","created":1,"owned_by":"openai"}]}`)); err != nil {
-			t.Errorf("ResponseWriter.Write() error = %v", err)
+		if _, writeErr := w.Write([]byte(`{"object":"list","data":[{"id":"test-model","object":"model","created":1,"owned_by":"openai"}]}`)); writeErr != nil {
+			t.Errorf("ResponseWriter.Write() error = %v", writeErr)
 		}
 	}))
 	server.TLS = &tls.Config{
@@ -204,12 +204,12 @@ func TestNativeMutualTLSHTTPClient(t *testing.T) {
 			for _, certificate := range state.PeerCertificates[1:] {
 				intermediates.AddCert(certificate)
 			}
-			_, err := state.PeerCertificates[0].Verify(x509.VerifyOptions{
+			_, verifyErr := state.PeerCertificates[0].Verify(x509.VerifyOptions{
 				Roots:         rootPool,
 				Intermediates: intermediates,
 				KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 			})
-			return err
+			return verifyErr
 		},
 	}
 	server.StartTLS()

--- a/internal/apijson/encoder.go
+++ b/internal/apijson/encoder.go
@@ -269,9 +269,9 @@ func (e *encoder) newStructTypeEncoder(t reflect.Type) encoderFunc {
 
 		for _, ef := range encoderFields {
 			field := value.FieldByIndex(ef.idx)
-			encoded, err := ef.fn(field)
-			if err != nil {
-				return nil, err
+			encoded, encodeErr := ef.fn(field)
+			if encodeErr != nil {
+				return nil, encodeErr
 			}
 			if ef.tag.defaultValue != nil && (!field.IsValid() || field.IsZero()) {
 				encoded, err = shimjson.Marshal(ef.tag.defaultValue)

--- a/internal/apijson/port.go
+++ b/internal/apijson/port.go
@@ -10,16 +10,16 @@ func Port(from any, to any) error {
 	toVal := reflect.ValueOf(to)
 	fromVal := reflect.ValueOf(from)
 
-	if toVal.Kind() != reflect.Ptr || toVal.IsNil() {
+	if toVal.Kind() != reflect.Pointer || toVal.IsNil() {
 		return fmt.Errorf("destination must be a non-nil pointer")
 	}
 
-	for toVal.Kind() == reflect.Ptr {
+	for toVal.Kind() == reflect.Pointer {
 		toVal = toVal.Elem()
 	}
 	toType := toVal.Type()
 
-	for fromVal.Kind() == reflect.Ptr {
+	for fromVal.Kind() == reflect.Pointer {
 		fromVal = fromVal.Elem()
 	}
 	fromType := fromVal.Type()

--- a/internal/apijson/union.go
+++ b/internal/apijson/union.go
@@ -93,7 +93,7 @@ func (d *decoderBuilder) newStructUnionDecoder(t reflect.Type) decoderFunc {
 		bestVariant := -1
 		for i, decoder := range decoders {
 			// Pointers are used to discern JSON object variants from value variants
-			if n.Type != gjson.JSON && decoder.field.Type.Kind() == reflect.Ptr {
+			if n.Type != gjson.JSON && decoder.field.Type.Kind() == reflect.Pointer {
 				continue
 			}
 

--- a/internal/encoding/json/encode.go
+++ b/internal/encoding/json/encode.go
@@ -1172,11 +1172,11 @@ func typeFields(t reflect.Type) structFields {
 			for i := 0; i < f.typ.NumField(); i++ {
 				sf := f.typ.Field(i)
 				if sf.Anonymous {
-					t := sf.Type
-					if t.Kind() == reflect.Pointer {
-						t = t.Elem()
+					embeddedType := sf.Type
+					if embeddedType.Kind() == reflect.Pointer {
+						embeddedType = embeddedType.Elem()
 					}
-					if !sf.IsExported() && t.Kind() != reflect.Struct {
+					if !sf.IsExported() && embeddedType.Kind() != reflect.Struct {
 						// Ignore embedded fields of unexported non-struct types.
 						continue
 					}
@@ -1223,7 +1223,7 @@ func typeFields(t reflect.Type) structFields {
 					if name == "" {
 						name = sf.Name
 					}
-					field := field{
+					jsonField := field{
 						name:      name,
 						tag:       tagged,
 						index:     index,
@@ -1235,36 +1235,36 @@ func typeFields(t reflect.Type) structFields {
 						timefmt: sf.Tag.Get("format"),
 						// EDIT(end)
 					}
-					field.nameBytes = []byte(field.name)
+					jsonField.nameBytes = []byte(jsonField.name)
 
 					// Build nameEscHTML and nameNonEsc ahead of time.
-					nameEscBuf = appendHTMLEscape(nameEscBuf[:0], field.nameBytes)
-					field.nameEscHTML = `"` + string(nameEscBuf) + `":`
-					field.nameNonEsc = `"` + field.name + `":`
+					nameEscBuf = appendHTMLEscape(nameEscBuf[:0], jsonField.nameBytes)
+					jsonField.nameEscHTML = `"` + string(nameEscBuf) + `":`
+					jsonField.nameNonEsc = `"` + jsonField.name + `":`
 
-					if field.omitZero {
-						t := sf.Type
+					if jsonField.omitZero {
+						fieldType := sf.Type
 						// Provide a function that uses a type's IsZero method.
 						switch {
-						case t.Kind() == reflect.Interface && t.Implements(isZeroerType):
-							field.isZero = func(v reflect.Value) bool {
+						case fieldType.Kind() == reflect.Interface && fieldType.Implements(isZeroerType):
+							jsonField.isZero = func(v reflect.Value) bool {
 								// Avoid panics calling IsZero on a nil interface or
 								// non-nil interface with nil pointer.
 								return v.IsNil() ||
 									(v.Elem().Kind() == reflect.Pointer && v.Elem().IsNil()) ||
 									v.Interface().(isZeroer).IsZero()
 							}
-						case t.Kind() == reflect.Pointer && t.Implements(isZeroerType):
-							field.isZero = func(v reflect.Value) bool {
+						case fieldType.Kind() == reflect.Pointer && fieldType.Implements(isZeroerType):
+							jsonField.isZero = func(v reflect.Value) bool {
 								// Avoid panics calling IsZero on nil pointer.
 								return v.IsNil() || v.Interface().(isZeroer).IsZero()
 							}
-						case t.Implements(isZeroerType):
-							field.isZero = func(v reflect.Value) bool {
+						case fieldType.Implements(isZeroerType):
+							jsonField.isZero = func(v reflect.Value) bool {
 								return v.Interface().(isZeroer).IsZero()
 							}
-						case reflect.PointerTo(t).Implements(isZeroerType):
-							field.isZero = func(v reflect.Value) bool {
+						case reflect.PointerTo(fieldType).Implements(isZeroerType):
+							jsonField.isZero = func(v reflect.Value) bool {
 								if !v.CanAddr() {
 									// Temporarily box v so we can take the address.
 									v2 := reflect.New(v.Type()).Elem()
@@ -1276,7 +1276,7 @@ func typeFields(t reflect.Type) structFields {
 						}
 					}
 
-					fields = append(fields, field)
+					fields = append(fields, jsonField)
 					if count[f.typ] > 1 {
 						// If there were multiple instances, add a second,
 						// so that the annihilation code will see a duplicate.

--- a/internal/paramutil/union.go
+++ b/internal/paramutil/union.go
@@ -11,7 +11,7 @@ var paramUnionType = reflect.TypeOf(param.APIUnion{})
 // VariantFromUnion can be used to extract the present variant from a param union type.
 // A param union type is a struct with an embedded field of [APIUnion].
 func VariantFromUnion(u reflect.Value) (any, error) {
-	if u.Kind() == reflect.Ptr {
+	if u.Kind() == reflect.Pointer {
 		u = u.Elem()
 	}
 

--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -542,8 +542,8 @@ func (cfg *RequestConfig) Execute() (err error) {
 		case *bytes.Reader:
 			cfg.Request.ContentLength = int64(body.Len())
 			cfg.Request.GetBody = func() (io.ReadCloser, error) {
-				_, err := body.Seek(0, 0)
-				return io.NopCloser(body), err
+				_, seekErr := body.Seek(0, 0)
+				return io.NopCloser(body), seekErr
 			}
 			cfg.Request.Body, _ = cfg.Request.GetBody()
 		default:
@@ -641,10 +641,10 @@ func (cfg *RequestConfig) Execute() (err error) {
 	}
 
 	if res.StatusCode >= 400 {
-		contents, err := io.ReadAll(res.Body)
+		contents, readErr := io.ReadAll(res.Body)
 		_ = res.Body.Close()
-		if err != nil {
-			return err
+		if readErr != nil {
+			return readErr
 		}
 
 		// If there is an APIError, re-populate the response body so that debugging

--- a/option/middleware.go
+++ b/option/middleware.go
@@ -38,7 +38,7 @@ func WithDebugLog(logger *log.Logger) RequestOption {
 			return resp, err
 		}
 
-		if respBytes, err := dumpRedactedResponse(resp); err == nil {
+		if respBytes, dumpErr := dumpRedactedResponse(resp); dumpErr == nil {
 			logger.Printf("Response Content:\n%s\n", respBytes)
 		}
 

--- a/packages/pagination/pagination.go
+++ b/packages/pagination/pagination.go
@@ -37,28 +37,10 @@ func (r *Page[T]) UnmarshalJSON(data []byte) error {
 	return apijson.UnmarshalRoot(data, r)
 }
 
-// GetNextPage returns the next page as defined by this pagination style. When
-// there is no next page, this function will return a 'nil' for the page value, but
-// will not return an error
-func (r *Page[T]) GetNextPage() (res *Page[T], err error) {
-	if len(r.Data) == 0 {
-		return nil, nil
-	}
-	// This page represents a response that isn't actually paginated at the API level
-	// so there will never be a next page.
-	cfg := (*requestconfig.RequestConfig)(nil)
-	if cfg == nil {
-		return nil, nil
-	}
-	var raw *http.Response
-	cfg.ResponseInto = &raw
-	cfg.ResponseBodyInto = &res
-	err = cfg.Execute()
-	if err != nil {
-		return nil, err
-	}
-	res.SetPageConfig(cfg, raw)
-	return res, nil
+// GetNextPage returns nil because Page represents a response that is not
+// paginated at the API level.
+func (*Page[T]) GetNextPage() (*Page[T], error) {
+	return nil, nil
 }
 
 func (r *Page[T]) SetPageConfig(cfg *requestconfig.RequestConfig, res *http.Response) {


### PR DESCRIPTION
## Summary

- enable every applicable `govet` analyzer, including optional analyzers such as `shadow` and `nilness`
- fix all 32 actionable findings directly: deprecated `reflect.Ptr` aliases, shadowed variables, and unreachable pagination code
- explicitly exclude `fieldalignment`, whose 1,902 generated public-struct findings are layout advice rather than correctness diagnostics
- keep issue-count caps disabled so repeated findings cannot be hidden

## Why

`go vet` is the Go toolchain's primary correctness analyzer. Enabling its applicable analyzer set before optional style checks keeps the ratchet focused on language- and standard-library-backed diagnostics.

`fieldalignment` is intentionally excluded. The SDK's generated public structs preserve schema field order; reordering them solely for memory layout would create compatibility risk and generator churn without improving correctness.

## Quality ratchet

- Rule family: all applicable `govet` analyzers
- Baseline actionable findings: 32 — 5 deprecated aliases, 26 shadowing findings, and 1 nilness finding
- Final actionable findings: 0
- Explicit analyzer exclusions: `fieldalignment` only — 1,902 generated public-struct layout suggestions
- Affected ownership: repository-owned runtime, tests, examples, and vendored JSON support code
- Generated model/resource changes: none
- Regeneration: no generated source is patched; current generated service and model output passes the enabled analyzers
- Castiron impact: no compiler update required; the changed files are SDK-owned support code, and current Castiron output does not emit the removed pagination implementation
- Public API and runtime behavior: unchanged
- Issue caps: disabled, so all findings remain visible

## Validation

- `go tool -modfile=tools/go.mod golangci-lint config verify --config .golangci.yml`
- `GOTOOLCHAIN=local ./scripts/lint` — 0 issues in all three analyzed modules
- `GOTOOLCHAIN=local ./scripts/test`
- `GOTOOLCHAIN=local go -C examples test ./...`
- `GOTOOLCHAIN=local go -C internal/testdata/consumer test -mod=readonly ./...`
- `GOTOOLCHAIN=local ./scripts/check-go-mod`
- `git diff --check`
- thermo-nuclear code quality review

## Stack

This is a five-PR stack. Review and merge from top to bottom:

1. [#770 — enforce gofmt across the repository](https://github.com/openai/openai-go/pull/770) — base: `main`
2. [#771 — enforce Go lint suppression hygiene](https://github.com/openai/openai-go/pull/771) — base: #770
3. [#774 — preserve query map encoding errors and enable ineffassign](https://github.com/openai/openai-go/pull/774) — base: #771
4. [#772 — enable full go vet analysis](https://github.com/openai/openai-go/pull/772) — base: #774
5. [#773 — enable staticcheck correctness rules](https://github.com/openai/openai-go/pull/773) — base: #772
