### PR TITLE
docs: define Go ignored-error handling policy

### DIFF
--- a/GO_CODE_QUALITY_POLICY.md
+++ b/GO_CODE_QUALITY_POLICY.md
@@ -83,8 +83,8 @@ Every discarded error must be an intentional, documented ownership decision.
   fully consumed or an earlier request error is being returned, explicitly
   discard a non-actionable cleanup error with `_ = body.Close()`.
 - Generated union accessors without an error return cannot expose decode errors
-  without changing their public API. Preserve their existing zero-value
-  behavior and make the intentional discard explicit in the Castiron template.
+  without changing their public API. Preserve their existing return behavior
+  and make the intentional discard explicit in the Castiron template.
 - In tests, fail setup, fixture writes, finalization, and required cleanup with
   `t.Fatal`, `t.Error`, or a checked `t.Cleanup` callback, as appropriate. Do
   not add an inline lint suppression when ordinary error handling is clearer.

--- a/GO_CODE_QUALITY_POLICY.md
+++ b/GO_CODE_QUALITY_POLICY.md
@@ -70,6 +70,27 @@ The initial rollout order is:
 Existing build, test, module-tidiness, supported-Go, vulnerability, and public
 API checks remain authoritative throughout the rollout.
 
+## Error handling
+
+Every discarded error must be an intentional, documented ownership decision.
+
+- Return actionable encoding, decoding, request, and finalization errors to the
+  caller. On a successful multipart write, return any error from `Close`.
+- If encoding already failed, close the multipart writer as best-effort cleanup
+  and preserve the original failure. Use `_ = writer.Close()` rather than
+  overwriting or obscuring the primary error.
+- Close HTTP response bodies on every ownership path. If a response is already
+  fully consumed or an earlier request error is being returned, explicitly
+  discard a non-actionable cleanup error with `_ = body.Close()`.
+- Generated union accessors without an error return cannot expose decode errors
+  without changing their public API. Preserve their existing zero-value
+  behavior and make the intentional discard explicit in the Castiron template.
+- In tests, fail setup, fixture writes, finalization, and required cleanup with
+  `t.Fatal`, `t.Error`, or a checked `t.Cleanup` callback, as appropriate. Do
+  not add an inline lint suppression when ordinary error handling is clearer.
+- Fix generated models, resource methods, and generated tests in Castiron;
+  correct repository-owned runtime, examples, and handwritten tests in the SDK.
+
 ## Exceptions
 
 Exceptions are a last resort. They must:


### PR DESCRIPTION
## Summary
- define when encoding, finalization, cleanup, and test-helper errors must be returned, asserted, or intentionally discarded
- preserve public union accessor signatures and primary multipart failures while requiring explicit ignored-error syntax
- require generator-owned findings to be fixed in Castiron and handwritten findings in the SDK

## Baseline
- Root: **1,055** `errcheck` findings, including 1,012 generated union accessors and 14 generated multipart cleanup calls.
- Examples: **2** findings. External consumer: **0** findings.
- Generated-code exclusions: none. This policy-only step does not enable `errcheck` or alter generated output.

## Verification
- `git diff --check`
- Full foundation `./scripts/lint` passes with generated and handwritten code included.
- Mandatory thermo-nuclear maintainability review completed.

Depends on the approved-analyzer recovery in https://github.com/openai/openai-go/pull/782; original lint infrastructure https://github.com/openai/openai-go/pull/771 is now merged into `main`.

Tracking: https://app.notion.com/p/3ba8e50b62b08121bcbcc84f9d20ca3a?pvs=204