### PR TITLE
lint: close HTTP response bodies and enable bodyclose

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ issues:
 linters:
   default: none
   enable:
+    - bodyclose
     - errcheck
     - govet
     - ineffassign

--- a/bedrock/auth_additional_test.go
+++ b/bedrock/auth_additional_test.go
@@ -508,10 +508,15 @@ func TestSigV4MiddlewareRejectsUnsafeRequests(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			transportCalls := 0
-			_, err := sigV4Middleware(baseURL, test.config, v4.NewSigner(), time.Now)(test.request(), func(req *http.Request) (*http.Response, error) {
+			response, err := sigV4Middleware(baseURL, test.config, v4.NewSigner(), time.Now)(test.request(), func(req *http.Request) (*http.Response, error) {
 				transportCalls++
 				return successfulResponse(req), nil
 			})
+			if response != nil {
+				if closeErr := response.Body.Close(); closeErr != nil {
+					t.Fatalf("close response body: %v", closeErr)
+				}
+			}
 			if err == nil || !strings.Contains(err.Error(), test.message) {
 				t.Fatalf("error = %v, want substring %q", err, test.message)
 			}
@@ -562,10 +567,15 @@ func TestSigV4MiddlewareCredentialAndSignerFailures(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			req, _ := http.NewRequest(http.MethodPost, "https://bedrock-mantle.us-east-1.api.aws/openai/v1/responses", strings.NewReader("body"))
 			contentLength := req.ContentLength
-			_, err := sigV4Middleware(baseURL, test.config, test.signer, time.Now)(req, func(req *http.Request) (*http.Response, error) {
+			response, err := sigV4Middleware(baseURL, test.config, test.signer, time.Now)(req, func(req *http.Request) (*http.Response, error) {
 				t.Fatal("transport must not be called")
 				return nil, nil
 			})
+			if response != nil {
+				if closeErr := response.Body.Close(); closeErr != nil {
+					t.Fatalf("close response body: %v", closeErr)
+				}
+			}
 			if err == nil || !strings.Contains(err.Error(), test.message) {
 				t.Fatalf("error = %v, want substring %q", err, test.message)
 			}

--- a/bedrock/auth_test.go
+++ b/bedrock/auth_test.go
@@ -216,12 +216,15 @@ func TestSigV4Fixture(t *testing.T) {
 	}
 
 	called := false
-	_, err = sigV4Middleware(baseURL, awsConfig, v4.NewSigner(), func() time.Time { return signingDate })(request, func(req *http.Request) (*http.Response, error) {
+	response, err := sigV4Middleware(baseURL, awsConfig, v4.NewSigner(), func() time.Time { return signingDate })(request, func(req *http.Request) (*http.Response, error) {
 		called = true
 		return successfulResponse(req), nil
 	})
 	if err != nil {
 		t.Fatal(err)
+	}
+	if closeErr := response.Body.Close(); closeErr != nil {
+		t.Fatalf("close response body: %v", closeErr)
 	}
 	if !called {
 		t.Fatal("transport was not called")

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -8,7 +8,8 @@ import (
 )
 
 func CheckTestServer(t *testing.T, url string) bool {
-	if _, err := http.Get(url); err != nil {
+	response, err := http.Get(url)
+	if err != nil {
 		const SKIP_MOCK_TESTS = "SKIP_MOCK_TESTS"
 		if str, ok := os.LookupEnv(SKIP_MOCK_TESTS); ok {
 			skip, err := strconv.ParseBool(str)
@@ -22,6 +23,9 @@ func CheckTestServer(t *testing.T, url string) bool {
 			t.Errorf("The test will not run without a mock server running against your OpenAPI spec. You can set the environment variable %s to true to skip running any tests that require the mock server", SKIP_MOCK_TESTS)
 			return false
 		}
+	} else if closeErr := response.Body.Close(); closeErr != nil {
+		t.Errorf("close mock-server response body: %v", closeErr)
+		return false
 	}
 	return true
 }


### PR DESCRIPTION
## Summary
- enable `bodyclose` across the generated SDK, handwritten code, tests, examples, and external consumer
- close the successful mock-server health-check response in `internal/testutil`
- close Bedrock middleware test responses on success and defensive unexpected-response paths
- check every close error consistently with the parent `errcheck` policy

## Quality-ratchet baseline
- Root module: **4 → 0** `bodyclose` findings.
- Examples and external consumer: **0 → 0**.
- No analyzer exclusions, generated-code exclusions, or inline suppressions added.

## Generated-code ownership
All four findings are handwritten SDK test or test-helper code. A Castiron repository search found no generated `CheckTestServer`, `SKIP_MOCK_TESTS`, or corresponding Bedrock test source; no additional generator change is required.

## Validation
- `./scripts/lint` passes across root, examples, and consumer with both `errcheck` and `bodyclose` enabled.
- Full Bedrock test suite passes.