### PR TITLE
lint: reject nil errors returned after failed checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,7 @@ linters:
     - errcheck
     - govet
     - ineffassign
+    - nilerr
     - nolintlint
     - staticcheck
   exclusions:


### PR DESCRIPTION
## Summary
- enable the focused `nilerr` correctness analyzer across root, examples, external consumer, generated code, handwritten code, and tests
- prevent future regressions that observe a non-nil error and accidentally return `nil`
- keep this quality-ratchet step to one analyzer and one configuration line

## Quality-ratchet baseline
- Root SDK: **0 → 0** findings.
- Examples: **0 → 0**.
- External consumer: **0 → 0**.
- No source edits, exclusions, suppressions, or public API changes.

## Generated-code ownership
Current Castiron-generated output is already `nilerr` clean. No generator template, shared scaffolding, or fixture update is required for this analyzer.

## Validation
- `go tool -modfile=tools/go.mod golangci-lint run --config .golangci.yml --enable-only nilerr`: 0 issues.
- Full `./scripts/lint`: 0 issues across root, examples, and consumer modules.