### PR TITLE
fix: recover approved Go correctness analyzers after stacked merges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,9 +138,12 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           # Scan with a patched current toolchain so old standard-library
-          # findings do not obscure dependency findings.
+          # findings do not obscure dependency findings. Resolve the range
+          # against Go's official feed: its vulnerability database can publish
+          # new advisories before setup-go's version mirror lists the fix.
           go-version: '1.26.x'
           check-latest: true
+          go-download-base-url: https://go.dev/dl
 
       - name: Install govulncheck
         # Keep the scanner in its own module so Dependabot can update it without

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,14 +1,30 @@
 version: "2"
 
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
 linters:
   default: none
   enable:
+    - govet
+    - ineffassign
     - nolintlint
+    - staticcheck
   exclusions:
     generated: disable
   settings:
+    govet:
+      enable-all: true
+      disable:
+        # Generated public API structs preserve schema field order; layout-only
+        # reordering would create compatibility risk without improving safety.
+        - fieldalignment
     nolintlint:
       # A disabled analyzer cannot reliably prove whether its directive is stale.
       allow-unused: true
       require-explanation: true
       require-specific: true
+    staticcheck:
+      checks:
+        - "SA*"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,8 +17,10 @@ linters:
     govet:
       enable-all: true
       disable:
-        # Generated public API structs preserve schema field order; layout-only
-        # reordering would create compatibility risk without improving safety.
+        # fieldalignment is not part of normal go vet or gopls: layout advice
+        # rarely identifies a real problem and may introduce false sharing.
+        # Reordering exported handwritten or generated structs also breaks
+        # positional literals and compatibility-critical schema field order.
         - fieldalignment
     nolintlint:
       # A disabled analyzer cannot reliably prove whether its directive is stale.

--- a/auth/subjecttokenprovider_test.go
+++ b/auth/subjecttokenprovider_test.go
@@ -19,8 +19,8 @@ func TestK8sProviderFileReading(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 
 	tokenContent := "  test-jwt-token-123  \n"
-	if _, err := tmpFile.WriteString(tokenContent); err != nil {
-		t.Fatalf("Failed to write to temp file: %v", err)
+	if _, writeErr := tmpFile.WriteString(tokenContent); writeErr != nil {
+		t.Fatalf("Failed to write to temp file: %v", writeErr)
 	}
 	tmpFile.Close()
 
@@ -95,8 +95,8 @@ func TestK8sProviderEmptyToken(t *testing.T) {
 	}
 	defer os.Remove(tmpFile.Name())
 
-	if _, err := tmpFile.WriteString("   \n   "); err != nil {
-		t.Fatalf("Failed to write to temp file: %v", err)
+	if _, writeErr := tmpFile.WriteString("   \n   "); writeErr != nil {
+		t.Fatalf("Failed to write to temp file: %v", writeErr)
 	}
 	tmpFile.Close()
 

--- a/azure/azure_test.go
+++ b/azure/azure_test.go
@@ -64,12 +64,12 @@ func TestGetAudioMultipartRoute(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := mw.WriteField("model", "arbitraryDeployment"); err != nil {
-		t.Fatal(err)
+	if writeErr := mw.WriteField("model", "arbitraryDeployment"); writeErr != nil {
+		t.Fatal(writeErr)
 	}
 
-	if err := mw.Close(); err != nil {
-		t.Fatal(err)
+	if closeErr := mw.Close(); closeErr != nil {
+		t.Fatal(closeErr)
 	}
 
 	req, err := http.NewRequest("POST", "/audio/transcriptions", bytes.NewReader(buff.Bytes()))
@@ -378,11 +378,11 @@ func newMultipartRouteRequest(t *testing.T, route string, model string) *http.Re
 	if _, err = fw.Write([]byte("ignore me")); err != nil {
 		t.Fatal(err)
 	}
-	if err := mw.WriteField("model", model); err != nil {
-		t.Fatal(err)
+	if writeErr := mw.WriteField("model", model); writeErr != nil {
+		t.Fatal(writeErr)
 	}
-	if err := mw.Close(); err != nil {
-		t.Fatal(err)
+	if closeErr := mw.Close(); closeErr != nil {
+		t.Fatal(closeErr)
 	}
 
 	req, err := http.NewRequest("POST", route, bytes.NewReader(buff.Bytes()))

--- a/bedrock/auth.go
+++ b/bedrock/auth.go
@@ -120,8 +120,8 @@ func resolveConfig(ctx context.Context, cfg Config, now func() time.Time) (resol
 	if err != nil {
 		return resolvedConfig{}, err
 	}
-	if err := validateAWSRegion(region); err != nil {
-		return resolvedConfig{}, err
+	if regionErr := validateAWSRegion(region); regionErr != nil {
+		return resolvedConfig{}, regionErr
 	}
 	baseURLValue, err := resolveOptionalConfigValue("BaseURL", cfg.BaseURL, "AWS_BEDROCK_BASE_URL")
 	if err != nil {
@@ -137,8 +137,8 @@ func resolveConfig(ctx context.Context, cfg Config, now func() time.Time) (resol
 		if err != nil {
 			return resolvedConfig{}, err
 		}
-		if err := validateAWSRegion(region); err != nil {
-			return resolvedConfig{}, err
+		if regionErr := validateAWSRegion(region); regionErr != nil {
+			return resolvedConfig{}, regionErr
 		}
 	}
 
@@ -158,17 +158,17 @@ func resolveConfig(ctx context.Context, cfg Config, now func() time.Time) (resol
 		if region == "" {
 			return resolvedConfig{}, errors.New(missingRegionMessage)
 		}
-		if err := validateAWSRegion(region); err != nil {
-			return resolvedConfig{}, err
+		if regionErr := validateAWSRegion(region); regionErr != nil {
+			return resolvedConfig{}, regionErr
 		}
 		if baseURL != nil {
-			if _, err := reconcileEndpointRegion(baseURL, region); err != nil {
-				return resolvedConfig{}, err
+			if _, endpointErr := reconcileEndpointRegion(baseURL, region); endpointErr != nil {
+				return resolvedConfig{}, endpointErr
 			}
 		}
 		awsCfg.Region = region
-		if err := verifyAWSCredentials(ctx, awsCfg, explicitAWS); err != nil {
-			return resolvedConfig{}, err
+		if credentialErr := verifyAWSCredentials(ctx, awsCfg, explicitAWS); credentialErr != nil {
+			return resolvedConfig{}, credentialErr
 		}
 		resolved.region = region
 	default:

--- a/bedrock/auth_additional_test.go
+++ b/bedrock/auth_additional_test.go
@@ -17,7 +17,8 @@ import (
 )
 
 func TestNewClientOptionsRejectsNilContext(t *testing.T) {
-	_, err := newClientOptions(nil, Config{}, time.Now)
+	var nilContext context.Context
+	_, err := newClientOptions(nilContext, Config{}, time.Now)
 	if err == nil || !strings.Contains(err.Error(), "nil context") {
 		t.Fatalf("error = %v", err)
 	}
@@ -165,21 +166,21 @@ func TestEnvironmentBearerRefreshesAndFailsSafelyWhenRemoved(t *testing.T) {
 	}
 
 	var response *http.Response
-	if err := client.Get(context.Background(), "/models", nil, &response); err != nil {
-		t.Fatal(err)
+	if requestErr := client.Get(context.Background(), "/models", nil, &response); requestErr != nil {
+		t.Fatal(requestErr)
 	}
-	if err := os.Setenv("AWS_BEARER_TOKEN_BEDROCK", "second-token"); err != nil {
-		t.Fatal(err)
+	if setEnvErr := os.Setenv("AWS_BEARER_TOKEN_BEDROCK", "second-token"); setEnvErr != nil {
+		t.Fatal(setEnvErr)
 	}
-	if err := client.Get(context.Background(), "/models", nil, &response); err != nil {
-		t.Fatal(err)
+	if requestErr := client.Get(context.Background(), "/models", nil, &response); requestErr != nil {
+		t.Fatal(requestErr)
 	}
 	if got := strings.Join(authorizations, ","); got != "Bearer first-token,Bearer second-token" {
 		t.Fatalf("authorizations = %q", got)
 	}
 
-	if err := os.Unsetenv("AWS_BEARER_TOKEN_BEDROCK"); err != nil {
-		t.Fatal(err)
+	if unsetEnvErr := os.Unsetenv("AWS_BEARER_TOKEN_BEDROCK"); unsetEnvErr != nil {
+		t.Fatal(unsetEnvErr)
 	}
 	err = client.Get(context.Background(), "/models", nil, &response)
 	if err == nil || !strings.Contains(err.Error(), "failed to resolve a bearer credential") {

--- a/bedrock/auth_test.go
+++ b/bedrock/auth_test.go
@@ -189,8 +189,8 @@ func TestSigV4Fixture(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := json.Unmarshal(contents, &fixture); err != nil {
-		t.Fatal(err)
+	if unmarshalErr := json.Unmarshal(contents, &fixture); unmarshalErr != nil {
+		t.Fatal(unmarshalErr)
 	}
 	if fixture.Service != bedrockService {
 		t.Fatalf("fixture service = %q", fixture.Service)

--- a/examples/audio-text-to-speech/main.go
+++ b/examples/audio-text-to-speech/main.go
@@ -22,10 +22,10 @@ func main() {
 			OfAudioSpeechNewsVoiceString2: openai.String("alloy"),
 		},
 	})
-	defer res.Body.Close()
 	if err != nil {
 		panic(err)
 	}
+	defer res.Body.Close()
 
 	op := &oto.NewContextOptions{}
 	op.SampleRate = 24000
@@ -43,9 +43,5 @@ func main() {
 	player.Play()
 	for player.IsPlaying() {
 		time.Sleep(time.Millisecond)
-	}
-	err = player.Close()
-	if err != nil {
-		panic("player.Close failed: " + err.Error())
 	}
 }

--- a/examples/chat-completion-tool-calling/main.go
+++ b/examples/chat-completion-tool-calling/main.go
@@ -61,9 +61,9 @@ func main() {
 		if toolCall.Function.Name == "get_weather" {
 			// Extract the location from the function call arguments
 			var args map[string]interface{}
-			err := json.Unmarshal([]byte(toolCall.Function.Arguments), &args)
-			if err != nil {
-				panic(err)
+			unmarshalErr := json.Unmarshal([]byte(toolCall.Function.Arguments), &args)
+			if unmarshalErr != nil {
+				panic(unmarshalErr)
 			}
 			location := args["location"].(string)
 

--- a/examples/fine-tuning/main.go
+++ b/examples/fine-tuning/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/openai/openai-go/v3"
@@ -27,6 +28,27 @@ func main() {
 		panic(err)
 	}
 	fmt.Printf("Uploaded file with ID: %s\n", file.ID)
+
+	fmt.Println("Waiting for file to be processed")
+	for {
+		file, err = client.Files.Get(ctx, file.ID)
+		if err != nil {
+			panic(err)
+		}
+
+		status, statusErr := strconv.Unquote(file.JSON.Status.Raw())
+		if statusErr != nil {
+			panic(fmt.Errorf("decode file processing status: %w", statusErr))
+		}
+		fmt.Printf("File status: %s\n", status)
+		if status == string(openai.FileObjectStatusProcessed) {
+			break
+		}
+		if status == string(openai.FileObjectStatusError) {
+			panic(fmt.Errorf("training file %s failed processing", file.ID))
+		}
+		time.Sleep(time.Second)
+	}
 
 	fmt.Println("")
 	fmt.Println("==> Starting fine-tuning")

--- a/examples/fine-tuning/main.go
+++ b/examples/fine-tuning/main.go
@@ -28,19 +28,6 @@ func main() {
 	}
 	fmt.Printf("Uploaded file with ID: %s\n", file.ID)
 
-	fmt.Println("Waiting for file to be processed")
-	for {
-		file, err = client.Files.Get(ctx, file.ID)
-		if err != nil {
-			panic(err)
-		}
-		fmt.Printf("File status: %s\n", file.Status)
-		if file.Status == "processed" {
-			break
-		}
-		time.Sleep(time.Second)
-	}
-
 	fmt.Println("")
 	fmt.Println("==> Starting fine-tuning")
 	fineTune, err := client.FineTuning.Jobs.New(ctx, openai.FineTuningJobNewParams{

--- a/examples/mutual-tls/main.go
+++ b/examples/mutual-tls/main.go
@@ -63,7 +63,7 @@ func newMutualTLSHTTPClient(certificate tls.Certificate) (*http.Client, error) {
 	}
 	transport := defaultTransport.Clone()
 	transport.Proxy = nil
-	transport.DialTLS = nil
+	transport.DialTLS = nil //nolint:staticcheck // SA1019: Clear an inherited legacy hook so TLSClientConfig remains authoritative.
 	transport.DialTLSContext = nil
 	transport.ResponseHeaderTimeout = responseHeaderTimeout
 

--- a/examples/mutual-tls/main_test.go
+++ b/examples/mutual-tls/main_test.go
@@ -65,7 +65,7 @@ func TestNativeMutualTLSHTTPClient(t *testing.T) {
 	defaultTLSConfig.ClientSessionCache = inheritedSessionCache
 	defaultTransport.TLSClientConfig = defaultTLSConfig
 	defaultTransport.Proxy = http.ProxyFromEnvironment
-	defaultTransport.DialTLS = func(string, string) (net.Conn, error) {
+	defaultTransport.DialTLS = func(string, string) (net.Conn, error) { //nolint:staticcheck // SA1019: Exercise clearing an inherited legacy hook.
 		return nil, nil
 	}
 	defaultTransport.DialTLSContext = func(context.Context, string, string) (net.Conn, error) {
@@ -94,7 +94,7 @@ func TestNativeMutualTLSHTTPClient(t *testing.T) {
 	if transport.Proxy != nil {
 		t.Error("newMutualTLSHTTPClient().Transport.Proxy is non-nil")
 	}
-	if transport.DialTLS != nil {
+	if transport.DialTLS != nil { //nolint:staticcheck // SA1019: Verify the legacy hook cannot bypass the dedicated TLS configuration.
 		t.Error("newMutualTLSHTTPClient().Transport.DialTLS is non-nil")
 	}
 	if transport.DialTLSContext != nil {
@@ -132,7 +132,7 @@ func TestNativeMutualTLSHTTPClient(t *testing.T) {
 	if defaultTransport.Proxy == nil {
 		t.Error("newMutualTLSHTTPClient() cleared http.DefaultTransport.Proxy")
 	}
-	if defaultTransport.DialTLS == nil {
+	if defaultTransport.DialTLS == nil { //nolint:staticcheck // SA1019: Verify cloning did not mutate the original legacy hook.
 		t.Error("newMutualTLSHTTPClient() cleared http.DefaultTransport.DialTLS")
 	}
 	if defaultTransport.DialTLSContext == nil {
@@ -187,8 +187,8 @@ func TestNativeMutualTLSHTTPClient(t *testing.T) {
 			t.Errorf("Authorization header = %q, want %q", got, want)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		if _, err := w.Write([]byte(`{"object":"list","data":[{"id":"test-model","object":"model","created":1,"owned_by":"openai"}]}`)); err != nil {
-			t.Errorf("ResponseWriter.Write() error = %v", err)
+		if _, writeErr := w.Write([]byte(`{"object":"list","data":[{"id":"test-model","object":"model","created":1,"owned_by":"openai"}]}`)); writeErr != nil {
+			t.Errorf("ResponseWriter.Write() error = %v", writeErr)
 		}
 	}))
 	server.TLS = &tls.Config{
@@ -204,12 +204,12 @@ func TestNativeMutualTLSHTTPClient(t *testing.T) {
 			for _, certificate := range state.PeerCertificates[1:] {
 				intermediates.AddCert(certificate)
 			}
-			_, err := state.PeerCertificates[0].Verify(x509.VerifyOptions{
+			_, verifyErr := state.PeerCertificates[0].Verify(x509.VerifyOptions{
 				Roots:         rootPool,
 				Intermediates: intermediates,
 				KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 			})
-			return err
+			return verifyErr
 		},
 	}
 	server.StartTLS()

--- a/examples/video-generation/main.go
+++ b/examples/video-generation/main.go
@@ -12,6 +12,7 @@ func main() {
 
 	ctx := context.Background()
 
+	//nolint:staticcheck // SA1019: the SDK team keeps this example until the Sora API shuts down on 2026-09-24.
 	video, err := client.Videos.NewAndPoll(ctx, openai.VideoNewParams{
 		Model:  openai.VideoModelSora2,
 		Prompt: "A video of the words 'Thank you' in sparkling letters",

--- a/internal/apijson/encoder.go
+++ b/internal/apijson/encoder.go
@@ -269,9 +269,9 @@ func (e *encoder) newStructTypeEncoder(t reflect.Type) encoderFunc {
 
 		for _, ef := range encoderFields {
 			field := value.FieldByIndex(ef.idx)
-			encoded, err := ef.fn(field)
-			if err != nil {
-				return nil, err
+			encoded, encodeErr := ef.fn(field)
+			if encodeErr != nil {
+				return nil, encodeErr
 			}
 			if ef.tag.defaultValue != nil && (!field.IsValid() || field.IsZero()) {
 				encoded, err = shimjson.Marshal(ef.tag.defaultValue)

--- a/internal/apijson/port.go
+++ b/internal/apijson/port.go
@@ -10,16 +10,16 @@ func Port(from any, to any) error {
 	toVal := reflect.ValueOf(to)
 	fromVal := reflect.ValueOf(from)
 
-	if toVal.Kind() != reflect.Ptr || toVal.IsNil() {
+	if toVal.Kind() != reflect.Pointer || toVal.IsNil() {
 		return fmt.Errorf("destination must be a non-nil pointer")
 	}
 
-	for toVal.Kind() == reflect.Ptr {
+	for toVal.Kind() == reflect.Pointer {
 		toVal = toVal.Elem()
 	}
 	toType := toVal.Type()
 
-	for fromVal.Kind() == reflect.Ptr {
+	for fromVal.Kind() == reflect.Pointer {
 		fromVal = fromVal.Elem()
 	}
 	fromType := fromVal.Type()

--- a/internal/apijson/union.go
+++ b/internal/apijson/union.go
@@ -93,7 +93,7 @@ func (d *decoderBuilder) newStructUnionDecoder(t reflect.Type) decoderFunc {
 		bestVariant := -1
 		for i, decoder := range decoders {
 			// Pointers are used to discern JSON object variants from value variants
-			if n.Type != gjson.JSON && decoder.field.Type.Kind() == reflect.Ptr {
+			if n.Type != gjson.JSON && decoder.field.Type.Kind() == reflect.Pointer {
 				continue
 			}
 

--- a/internal/apiquery/encoder.go
+++ b/internal/apiquery/encoder.go
@@ -238,7 +238,8 @@ func (e *encoder) newStructUnionTypeEncoder(t reflect.Type) encoderFunc {
 func (e *encoder) newMapEncoder(t reflect.Type) encoderFunc {
 	keyEncoder := e.typeEncoder(t.Key())
 	elementEncoder := e.typeEncoder(t.Elem())
-	return func(key string, value reflect.Value) (pairs []Pair, err error) {
+	return func(key string, value reflect.Value) ([]Pair, error) {
+		var pairs []Pair
 		iter := value.MapRange()
 		for iter.Next() {
 			encodedKey, err := keyEncoder("", iter.Key())
@@ -250,13 +251,13 @@ func (e *encoder) newMapEncoder(t reflect.Type) encoderFunc {
 			}
 			subkey := encodedKey[0].value
 			keyPath := e.renderKeyPath(key, subkey)
-			subpairs, suberr := elementEncoder(keyPath, iter.Value())
-			if suberr != nil {
-				err = suberr
+			subpairs, err := elementEncoder(keyPath, iter.Value())
+			if err != nil {
+				return nil, err
 			}
 			pairs = append(pairs, subpairs...)
 		}
-		return pairs, err
+		return pairs, nil
 	}
 }
 

--- a/internal/apiquery/query_test.go
+++ b/internal/apiquery/query_test.go
@@ -1,6 +1,7 @@
 package apiquery
 
 import (
+	"errors"
 	"net/url"
 	"testing"
 	"time"
@@ -110,6 +111,19 @@ type RichPrimitives struct {
 type QueryOmitTest struct {
 	A param.Opt[string] `query:"a,omitzero"`
 	B string            `query:"b,omitzero"`
+}
+
+type firstErrorMarshaler struct {
+	calls *int
+	err   error
+}
+
+func (m firstErrorMarshaler) MarshalJSON() ([]byte, error) {
+	*m.calls++
+	if *m.calls == 1 {
+		return nil, m.err
+	}
+	return []byte(`"ok"`), nil
 }
 
 type NamedEnum string
@@ -432,5 +446,21 @@ func TestEncode(t *testing.T) {
 				t.Fatalf("expected %+#v to serialize to %s but got %s", test.val, test.enc, str)
 			}
 		})
+	}
+}
+
+func TestEncodeMapElementError(t *testing.T) {
+	calls := 0
+	wantErr := errors.New("marshal failed")
+	values := map[string]firstErrorMarshaler{
+		"first":  {calls: &calls, err: wantErr},
+		"second": {calls: &calls, err: wantErr},
+	}
+
+	if _, err := Marshal(values); err == nil {
+		t.Fatalf("Marshal(%v) error = nil, want non-nil", values)
+	}
+	if calls != 1 {
+		t.Fatalf("Marshal marshaler calls = %d, want 1", calls)
 	}
 }

--- a/internal/encoding/json/encode.go
+++ b/internal/encoding/json/encode.go
@@ -1172,11 +1172,11 @@ func typeFields(t reflect.Type) structFields {
 			for i := 0; i < f.typ.NumField(); i++ {
 				sf := f.typ.Field(i)
 				if sf.Anonymous {
-					t := sf.Type
-					if t.Kind() == reflect.Pointer {
-						t = t.Elem()
+					embeddedType := sf.Type
+					if embeddedType.Kind() == reflect.Pointer {
+						embeddedType = embeddedType.Elem()
 					}
-					if !sf.IsExported() && t.Kind() != reflect.Struct {
+					if !sf.IsExported() && embeddedType.Kind() != reflect.Struct {
 						// Ignore embedded fields of unexported non-struct types.
 						continue
 					}
@@ -1223,7 +1223,7 @@ func typeFields(t reflect.Type) structFields {
 					if name == "" {
 						name = sf.Name
 					}
-					field := field{
+					jsonField := field{
 						name:      name,
 						tag:       tagged,
 						index:     index,
@@ -1235,36 +1235,36 @@ func typeFields(t reflect.Type) structFields {
 						timefmt: sf.Tag.Get("format"),
 						// EDIT(end)
 					}
-					field.nameBytes = []byte(field.name)
+					jsonField.nameBytes = []byte(jsonField.name)
 
 					// Build nameEscHTML and nameNonEsc ahead of time.
-					nameEscBuf = appendHTMLEscape(nameEscBuf[:0], field.nameBytes)
-					field.nameEscHTML = `"` + string(nameEscBuf) + `":`
-					field.nameNonEsc = `"` + field.name + `":`
+					nameEscBuf = appendHTMLEscape(nameEscBuf[:0], jsonField.nameBytes)
+					jsonField.nameEscHTML = `"` + string(nameEscBuf) + `":`
+					jsonField.nameNonEsc = `"` + jsonField.name + `":`
 
-					if field.omitZero {
-						t := sf.Type
+					if jsonField.omitZero {
+						fieldType := sf.Type
 						// Provide a function that uses a type's IsZero method.
 						switch {
-						case t.Kind() == reflect.Interface && t.Implements(isZeroerType):
-							field.isZero = func(v reflect.Value) bool {
+						case fieldType.Kind() == reflect.Interface && fieldType.Implements(isZeroerType):
+							jsonField.isZero = func(v reflect.Value) bool {
 								// Avoid panics calling IsZero on a nil interface or
 								// non-nil interface with nil pointer.
 								return v.IsNil() ||
 									(v.Elem().Kind() == reflect.Pointer && v.Elem().IsNil()) ||
 									v.Interface().(isZeroer).IsZero()
 							}
-						case t.Kind() == reflect.Pointer && t.Implements(isZeroerType):
-							field.isZero = func(v reflect.Value) bool {
+						case fieldType.Kind() == reflect.Pointer && fieldType.Implements(isZeroerType):
+							jsonField.isZero = func(v reflect.Value) bool {
 								// Avoid panics calling IsZero on nil pointer.
 								return v.IsNil() || v.Interface().(isZeroer).IsZero()
 							}
-						case t.Implements(isZeroerType):
-							field.isZero = func(v reflect.Value) bool {
+						case fieldType.Implements(isZeroerType):
+							jsonField.isZero = func(v reflect.Value) bool {
 								return v.Interface().(isZeroer).IsZero()
 							}
-						case reflect.PointerTo(t).Implements(isZeroerType):
-							field.isZero = func(v reflect.Value) bool {
+						case reflect.PointerTo(fieldType).Implements(isZeroerType):
+							jsonField.isZero = func(v reflect.Value) bool {
 								if !v.CanAddr() {
 									// Temporarily box v so we can take the address.
 									v2 := reflect.New(v.Type()).Elem()
@@ -1276,7 +1276,7 @@ func typeFields(t reflect.Type) structFields {
 						}
 					}
 
-					fields = append(fields, field)
+					fields = append(fields, jsonField)
 					if count[f.typ] > 1 {
 						// If there were multiple instances, add a second,
 						// so that the annihilation code will see a duplicate.

--- a/internal/paramutil/union.go
+++ b/internal/paramutil/union.go
@@ -11,7 +11,7 @@ var paramUnionType = reflect.TypeOf(param.APIUnion{})
 // VariantFromUnion can be used to extract the present variant from a param union type.
 // A param union type is a struct with an embedded field of [APIUnion].
 func VariantFromUnion(u reflect.Value) (any, error) {
-	if u.Kind() == reflect.Ptr {
+	if u.Kind() == reflect.Pointer {
 		u = u.Elem()
 	}
 

--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -542,8 +542,8 @@ func (cfg *RequestConfig) Execute() (err error) {
 		case *bytes.Reader:
 			cfg.Request.ContentLength = int64(body.Len())
 			cfg.Request.GetBody = func() (io.ReadCloser, error) {
-				_, err := body.Seek(0, 0)
-				return io.NopCloser(body), err
+				_, seekErr := body.Seek(0, 0)
+				return io.NopCloser(body), seekErr
 			}
 			cfg.Request.Body, _ = cfg.Request.GetBody()
 		default:
@@ -641,10 +641,10 @@ func (cfg *RequestConfig) Execute() (err error) {
 	}
 
 	if res.StatusCode >= 400 {
-		contents, err := io.ReadAll(res.Body)
+		contents, readErr := io.ReadAll(res.Body)
 		_ = res.Body.Close()
-		if err != nil {
-			return err
+		if readErr != nil {
+			return readErr
 		}
 
 		// If there is an APIError, re-populate the response body so that debugging

--- a/option/middleware.go
+++ b/option/middleware.go
@@ -38,7 +38,7 @@ func WithDebugLog(logger *log.Logger) RequestOption {
 			return resp, err
 		}
 
-		if respBytes, err := dumpRedactedResponse(resp); err == nil {
+		if respBytes, dumpErr := dumpRedactedResponse(resp); dumpErr == nil {
 			logger.Printf("Response Content:\n%s\n", respBytes)
 		}
 

--- a/packages/pagination/pagination.go
+++ b/packages/pagination/pagination.go
@@ -37,28 +37,10 @@ func (r *Page[T]) UnmarshalJSON(data []byte) error {
 	return apijson.UnmarshalRoot(data, r)
 }
 
-// GetNextPage returns the next page as defined by this pagination style. When
-// there is no next page, this function will return a 'nil' for the page value, but
-// will not return an error
-func (r *Page[T]) GetNextPage() (res *Page[T], err error) {
-	if len(r.Data) == 0 {
-		return nil, nil
-	}
-	// This page represents a response that isn't actually paginated at the API level
-	// so there will never be a next page.
-	cfg := (*requestconfig.RequestConfig)(nil)
-	if cfg == nil {
-		return nil, nil
-	}
-	var raw *http.Response
-	cfg.ResponseInto = &raw
-	cfg.ResponseBodyInto = &res
-	err = cfg.Execute()
-	if err != nil {
-		return nil, err
-	}
-	res.SetPageConfig(cfg, raw)
-	return res, nil
+// GetNextPage returns nil because Page represents a response that is not
+// paginated at the API level.
+func (*Page[T]) GetNextPage() (*Page[T], error) {
+	return nil, nil
 }
 
 func (r *Page[T]) SetPageConfig(cfg *requestconfig.RequestConfig, res *http.Response) {

--- a/packages/ssestream/ssestream.go
+++ b/packages/ssestream/ssestream.go
@@ -73,20 +73,20 @@ func (s *eventStreamDecoder) Next() bool {
 	}
 
 	event := ""
-	data := bytes.NewBuffer(nil)
+	var data []byte
 
 	for s.scn.Scan() {
 		txt := s.scn.Bytes()
 
 		// Dispatch event on an empty line
 		if len(txt) == 0 {
-			if data.Len() == 0 {
+			if len(data) == 0 {
 				event = ""
 				continue
 			}
 			s.evt = Event{
 				Type: event,
-				Data: data.Bytes(),
+				Data: data,
 			}
 			return true
 		}
@@ -106,14 +106,8 @@ func (s *eventStreamDecoder) Next() bool {
 		case "event":
 			event = string(value)
 		case "data":
-			_, s.err = data.Write(value)
-			if s.err != nil {
-				break
-			}
-			_, s.err = data.WriteRune('\n')
-			if s.err != nil {
-				break
-			}
+			data = append(data, value...)
+			data = append(data, '\n')
 		}
 	}
 

--- a/webhooks/webhook_test.go
+++ b/webhooks/webhook_test.go
@@ -256,11 +256,11 @@ func TestWebhookService_UnwrapWithToleranceAndTime(t *testing.T) {
 	fixedTime := time.Unix(testTimestamp, 0)
 	webhookEvent, err := client.Webhooks.UnwrapWithToleranceAndTime([]byte(testPayload), createTestHeaders(), 5*time.Minute, fixedTime)
 	if err != nil {
-		t.Errorf("UnwrapWithToleranceAndTime should have succeeded with valid signature: %v", err)
+		t.Fatalf("UnwrapWithToleranceAndTime should have succeeded with valid signature: %v", err)
 	}
 
 	if webhookEvent == nil {
-		t.Error("UnwrapWithToleranceAndTime should return parsed event")
+		t.Fatal("UnwrapWithToleranceAndTime should return parsed event")
 	}
 
 	parsed := webhookEvent.AsResponseCompleted()


### PR DESCRIPTION
## Summary
- restore the previously reviewed and approved `ineffassign`, full `govet`, and Staticcheck `SA*` quality-ratchet changes
- preserve the exact approved query-map error propagation regression fix, correctness cleanup, focused tests, and narrow `fieldalignment` exception
- keep generated and handwritten Go code subject to the same enabled analyzers

## Why this recovery PR is required
Original PRs https://github.com/openai/openai-[go/pull/774](https://www.golinks.io/pull/774?trackSource=github), https://github.com/openai/openai-[go/pull/772](https://www.golinks.io/pull/772?trackSource=github), and https://github.com/openai/openai-[go/pull/773](https://www.golinks.io/pull/773?trackSource=github) were approved and merged into stacked feature branches. When https://github.com/openai/openai-[go/pull/771](https://www.golinks.io/pull/771?trackSource=github) subsequently merged to `main`, only its own `nolintlint` infrastructure reached `main`; the three approved analyzer changes remained stranded in the intermediate branch history.

This PR reapplies the exact combined, already-reviewed commit onto the current `main`. `git range-diff` confirms the recovered change is patch-identical to the approved stacked merge commit (`78c6ebd = cd526e8`).

## Quality-ratchet baseline
- `ineffassign`: **1 → 0**.
- Full actionable `govet`: **32 → 0**.
- Staticcheck `SA*`: **12 → 0** across root/examples.
- Narrow `govet` `fieldalignment` exception only: generated public schema structs retain compatibility-critical field order.

## Validation
- Existing complete SDK lint passes for root, examples, and external consumer.
- Approved regression tests and generated-code inclusion are preserved verbatim.
- Current `main` compatibility-workflow fix remains intact.