### PR TITLE
docs(api): describe response stream event unions

### DIFF
--- a/.castiron.stats.yml
+++ b/.castiron.stats.yml
@@ -1,6 +1,6 @@
 schema_version: 1
-generation_id: d4af6273-9a09-40bd-85c6-42f349d7a1a5
-openapi_spec_hash: 15849b9fe3deb3c72da0825905cc0ad9
-openapi_transformed_spec_hash: 9a60ddf3a1c752e15eb43fce666d6da8
+generation_id: 627bcca5-cfae-4f2f-b0d1-0e86366fa2fe
+openapi_spec_hash: 143aa2ed6323d61a1834c74044e29d30
+openapi_transformed_spec_hash: 5af6fa4fd590fcc79ba2fdd69b9f7b82
 config_hash: fcda4ecfe265daddba6fad25a8504a3f
-codegen_sha: e5e26af4e1222861016b4927756fc6219dad71f8
+codegen_sha: 141e4f8e7fdeaee0f9ac9b3b0a6c612da3552e7a

--- a/api_reference/openapi.transformed.yml
+++ b/api_reference/openapi.transformed.yml
@@ -54296,6 +54296,7 @@ components:
             "sequence_number": 1
           }
     ResponseStreamEvent:
+      description: Event emitted while a response is streamed.
       anyOf:
       - $ref: '#/components/schemas/ResponseAudioDeltaEvent'
       - $ref: '#/components/schemas/ResponseAudioDoneEvent'
@@ -77148,6 +77149,7 @@ components:
               when the originating `response.create` event supplied a
               `stream_id`.
     BetaResponseStreamEvent:
+      description: Event emitted while a response is streamed.
       anyOf:
       - $ref: '#/components/schemas/BetaResponseAudioDeltaEvent'
       - $ref: '#/components/schemas/BetaResponseAudioDoneEvent'


### PR DESCRIPTION
## Summary
- Accurately describe stable and beta Responses streaming event unions.
- Refresh the generated OpenAPI reference using real, recoverable Castiron dry-run checkpoint provenance.
- Source: https://github.com/openai/openai/pull/1277036
- OpenAPI commit: bc61c5299f7f6fdd6061ccad0ac7e4ec0f659098

## Validation
- The generated Go implementation is unchanged; the shared transformed API reference and provenance hashes were verified.
- git diff --check and transformed-reference MD5 verified; no internal PR created.