### PR TITLE
lint: reject mismatched nil errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,7 @@ linters:
     - govet
     - ineffassign
     - nilerr
+    - nilnesserr
     - nolintlint
     - staticcheck
   exclusions:


### PR DESCRIPTION
## Summary
- enable `nilnesserr`, which detects checking one error while mistakenly returning a different nil error
- complement the existing `nilerr` analyzer with a distinct correctness check
- replace the superseded premature `S1002` style change; no generated/shared pagination code is modified

## Baseline → final
- SDK root, examples, and consumer **0 → 0**.

## Stack dependency
- Depends on #784.

## Castiron impact
No Castiron compiler change is required. This correctness-only change does not edit generated files or shared pagination scaffolding; generated and handwritten code remain equally covered. The policy's `unused`-before-style sequence is preserved, with generated `unused` cleanup separately blocked on its Castiron source-of-truth fix.

## Validation
- `go tool -modfile=tools/go.mod golangci-lint config verify --config .golangci.yml`
- `./scripts/lint` across the root, examples, and external-consumer modules
- Focused affected-package tests; full examples and external-consumer tests
- Mandatory thermo-nuclear code-quality review completed
