### PR TITLE
lint: check JSON encoding errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,7 @@ linters:
     - govet
     - ineffassign
     - nilerr
+    - nilnesserr
     - nolintlint
     - staticcheck
   exclusions:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,7 @@ linters:
   enable:
     - bodyclose
     - errcheck
+    - errchkjson
     - errorlint
     - govet
     - ineffassign

--- a/auth_test.go
+++ b/auth_test.go
@@ -68,7 +68,10 @@ func TestClientWorkloadIdentityInitialization(t *testing.T) {
 						"access_token": "exchanged-token-123",
 						"expires_in":   3600,
 					}
-					body, _ := json.Marshal(tokenResp)
+					body, err := json.Marshal(tokenResp)
+					if err != nil {
+						return nil, fmt.Errorf("marshal OAuth token response: %w", err)
+					}
 					headers := make(http.Header)
 					headers.Set("Content-Type", "application/json")
 					return &http.Response{
@@ -146,7 +149,10 @@ func TestWorkloadIdentity401Retry(t *testing.T) {
 						"access_token": tokenID,
 						"expires_in":   3600,
 					}
-					body, _ := json.Marshal(tokenResp)
+					body, err := json.Marshal(tokenResp)
+					if err != nil {
+						return nil, fmt.Errorf("marshal OAuth token response: %w", err)
+					}
 					return &http.Response{
 						StatusCode: 200,
 						Body:       io.NopCloser(strings.NewReader(string(body))),
@@ -225,7 +231,10 @@ func TestWorkloadIdentitySingleRetry(t *testing.T) {
 						"access_token": "test-token",
 						"expires_in":   3600,
 					}
-					body, _ := json.Marshal(tokenResp)
+					body, err := json.Marshal(tokenResp)
+					if err != nil {
+						return nil, fmt.Errorf("marshal OAuth token response: %w", err)
+					}
 					return &http.Response{
 						StatusCode: 200,
 						Body:       io.NopCloser(strings.NewReader(string(body))),
@@ -290,7 +299,10 @@ func TestWorkloadIdentityTokenInjection(t *testing.T) {
 						"access_token": "exchanged-token-789",
 						"expires_in":   3600,
 					}
-					body, _ := json.Marshal(tokenResp)
+					body, err := json.Marshal(tokenResp)
+					if err != nil {
+						return nil, fmt.Errorf("marshal OAuth token response: %w", err)
+					}
 					return &http.Response{
 						StatusCode: 200,
 						Body:       io.NopCloser(strings.NewReader(string(body))),


### PR DESCRIPTION
## Summary
- enable `errchkjson` for unsafe ignored JSON encoding errors across generated and handwritten code
- handle four previously discarded `json.Marshal` failures in handwritten workload-identity HTTP transport fixtures
- propagate each fixture failure through the existing `http.RoundTripper` error contract without suppressions

## Baseline → final
- SDK root **4 → 0**; examples and consumer **0 → 0**.

## Stack dependency
- Depends on #785.

## Castiron impact
No Castiron compiler change is required. This correctness-only change does not edit generated files or shared pagination scaffolding; generated and handwritten code remain equally covered. The policy's `unused`-before-style sequence is preserved, with generated `unused` cleanup separately blocked on its Castiron source-of-truth fix.

## Validation
- `go tool -modfile=tools/go.mod golangci-lint config verify --config .golangci.yml`
- `./scripts/lint` across the root, examples, and external-consumer modules
- Focused affected-package tests; full examples and external-consumer tests
- Mandatory thermo-nuclear code-quality review completed
