### PR TITLE
lint: reject multiplied time durations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,7 @@ linters:
     - govet
     - ineffassign
     - nilerr
+    - nilnesserr
     - nolintlint
     - staticcheck
   exclusions:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,7 @@ linters:
   enable:
     - bodyclose
     - errcheck
+    - errchkjson
     - errorlint
     - govet
     - ineffassign

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,7 @@ linters:
     - errorlint
     - govet
     - ineffassign
+    - makezero
     - nilerr
     - nilnesserr
     - nolintlint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
   default: none
   enable:
     - bodyclose
+    - durationcheck
     - errcheck
     - errchkjson
     - errorlint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,7 @@ linters:
   enable:
     - bodyclose
     - errcheck
+    - errorlint
     - govet
     - ineffassign
     - nilerr
@@ -17,6 +18,16 @@ linters:
   exclusions:
     generated: disable
   settings:
+    errorlint:
+      # Wrapping an existing public error changes its errors.Is/As contract.
+      # Keep format-verb checks disabled until wrapping is reviewed separately.
+      errorf: false
+      allowed-errors:
+        # io.Reader EOF and net/http redirect sentinels require identity.
+        - err: io.EOF
+          fun: (*github.com/openai/openai-go/v3/internal/encoding/json.Decoder).refill
+        - err: net/http.ErrUseLastResponse
+          fun: (*net/http.Client).CheckRedirect
     govet:
       enable-all: true
       disable:

--- a/auth/subjecttokenprovider_test.go
+++ b/auth/subjecttokenprovider_test.go
@@ -2,6 +2,7 @@ package auth_test
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"os"
@@ -47,8 +48,8 @@ func TestK8sProviderDefaultPath(t *testing.T) {
 		return
 	}
 
-	providerErr, ok := err.(*auth.SubjectTokenProviderError)
-	if !ok {
+	var providerErr *auth.SubjectTokenProviderError
+	if !errors.As(err, &providerErr) {
 		t.Fatalf("Expected *SubjectTokenProviderError, got %T", err)
 	}
 
@@ -69,8 +70,8 @@ func TestK8sProviderErrorHandling(t *testing.T) {
 		t.Fatal("Expected error, got nil")
 	}
 
-	providerErr, ok := err.(*auth.SubjectTokenProviderError)
-	if !ok {
+	var providerErr *auth.SubjectTokenProviderError
+	if !errors.As(err, &providerErr) {
 		t.Fatalf("Expected *SubjectTokenProviderError, got %T", err)
 	}
 
@@ -96,8 +97,8 @@ func TestK8sProviderEmptyToken(t *testing.T) {
 		t.Fatal("Expected error for empty token, got nil")
 	}
 
-	providerErr, ok := err.(*auth.SubjectTokenProviderError)
-	if !ok {
+	var providerErr *auth.SubjectTokenProviderError
+	if !errors.As(err, &providerErr) {
 		t.Fatalf("Expected *SubjectTokenProviderError, got %T", err)
 	}
 

--- a/auth/workloadidentity_test.go
+++ b/auth/workloadidentity_test.go
@@ -3,6 +3,7 @@ package auth_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -444,13 +445,14 @@ func TestOAuthErrorHandling(t *testing.T) {
 			continue
 		}
 
-		_, isOAuthError := err.(*auth.OAuthError)
+		var oauthErr *auth.OAuthError
+		isOAuthError := errors.As(err, &oauthErr)
 		if isOAuthError != tc.shouldBeOAuthError {
 			t.Errorf("Status %d: isOAuthError = %v, want %v", tc.statusCode, isOAuthError, tc.shouldBeOAuthError)
+			continue
 		}
 
 		if tc.shouldBeOAuthError {
-			oauthErr := err.(*auth.OAuthError)
 			if oauthErr.StatusCode != tc.statusCode {
 				t.Errorf("StatusCode = %d, want %d", oauthErr.StatusCode, tc.statusCode)
 			}

--- a/auth_test.go
+++ b/auth_test.go
@@ -68,7 +68,10 @@ func TestClientWorkloadIdentityInitialization(t *testing.T) {
 						"access_token": "exchanged-token-123",
 						"expires_in":   3600,
 					}
-					body, _ := json.Marshal(tokenResp)
+					body, err := json.Marshal(tokenResp)
+					if err != nil {
+						return nil, fmt.Errorf("marshal OAuth token response: %w", err)
+					}
 					headers := make(http.Header)
 					headers.Set("Content-Type", "application/json")
 					return &http.Response{
@@ -146,7 +149,10 @@ func TestWorkloadIdentity401Retry(t *testing.T) {
 						"access_token": tokenID,
 						"expires_in":   3600,
 					}
-					body, _ := json.Marshal(tokenResp)
+					body, err := json.Marshal(tokenResp)
+					if err != nil {
+						return nil, fmt.Errorf("marshal OAuth token response: %w", err)
+					}
 					return &http.Response{
 						StatusCode: 200,
 						Body:       io.NopCloser(strings.NewReader(string(body))),
@@ -225,7 +231,10 @@ func TestWorkloadIdentitySingleRetry(t *testing.T) {
 						"access_token": "test-token",
 						"expires_in":   3600,
 					}
-					body, _ := json.Marshal(tokenResp)
+					body, err := json.Marshal(tokenResp)
+					if err != nil {
+						return nil, fmt.Errorf("marshal OAuth token response: %w", err)
+					}
 					return &http.Response{
 						StatusCode: 200,
 						Body:       io.NopCloser(strings.NewReader(string(body))),
@@ -290,7 +299,10 @@ func TestWorkloadIdentityTokenInjection(t *testing.T) {
 						"access_token": "exchanged-token-789",
 						"expires_in":   3600,
 					}
-					body, _ := json.Marshal(tokenResp)
+					body, err := json.Marshal(tokenResp)
+					if err != nil {
+						return nil, fmt.Errorf("marshal OAuth token response: %w", err)
+					}
 					return &http.Response{
 						StatusCode: 200,
 						Body:       io.NopCloser(strings.NewReader(string(body))),

--- a/internal/encoding/json/decode.go
+++ b/internal/encoding/json/decode.go
@@ -13,6 +13,7 @@ package json
 import (
 	"encoding"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"github.com/openai/openai-go/v3/internal/encoding/json/shims"
 	"reflect"
@@ -256,14 +257,14 @@ func (d *decodeState) saveError(err error) {
 // addErrorContext returns a new error enhanced with information from d.errorContext
 func (d *decodeState) addErrorContext(err error) error {
 	if d.errorContext != nil && (d.errorContext.Struct != nil || len(d.errorContext.FieldStack) > 0) {
-		switch err := err.(type) {
-		case *UnmarshalTypeError:
-			err.Struct = d.errorContext.Struct.Name()
+		var typeError *UnmarshalTypeError
+		if errors.As(err, &typeError) {
+			typeError.Struct = d.errorContext.Struct.Name()
 			fieldStack := d.errorContext.FieldStack
-			if err.Field != "" {
-				fieldStack = append(fieldStack, err.Field)
+			if typeError.Field != "" {
+				fieldStack = append(fieldStack, typeError.Field)
 			}
-			err.Field = strings.Join(fieldStack, ".")
+			typeError.Field = strings.Join(fieldStack, ".")
 		}
 	}
 	return err

--- a/internal/encoding/json/error_handling_test.go
+++ b/internal/encoding/json/error_handling_test.go
@@ -1,0 +1,54 @@
+package json
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestAddErrorContextRecognizesWrappedTypeErrors(t *testing.T) {
+	type example struct{}
+
+	cause := &UnmarshalTypeError{Field: "value"}
+	wrapped := fmt.Errorf("decode: %w", cause)
+	state := decodeState{
+		errorContext: &errorContext{
+			Struct:     reflect.TypeOf(example{}),
+			FieldStack: []string{"nested"},
+		},
+	}
+
+	if got := state.addErrorContext(wrapped); !errors.Is(got, wrapped) {
+		t.Fatalf("addErrorContext() = %v, want original wrapped error %v", got, wrapped)
+	}
+	if got, want := cause.Struct, "example"; got != want {
+		t.Errorf("UnmarshalTypeError.Struct = %q, want %q", got, want)
+	}
+	if got, want := cause.Field, "nested.value"; got != want {
+		t.Errorf("UnmarshalTypeError.Field = %q, want %q", got, want)
+	}
+}
+
+func TestDecoderPreservesWrappedEOF(t *testing.T) {
+	decoder := NewDecoder(&wrappedEOFReader{reader: strings.NewReader("false")})
+	var value bool
+
+	if err := decoder.Decode(&value); !errors.Is(err, io.EOF) {
+		t.Errorf("Decode() error = %v, want wrapped io.EOF", err)
+	}
+}
+
+type wrappedEOFReader struct {
+	reader *strings.Reader
+}
+
+func (reader *wrappedEOFReader) Read(p []byte) (int, error) {
+	n, err := reader.reader.Read(p)
+	if errors.Is(err, io.EOF) {
+		return n, fmt.Errorf("read: %w", err)
+	}
+	return n, err
+}


### PR DESCRIPTION
## Summary
- enable `durationcheck`, which catches accidental multiplication of two `time.Duration` values
- protect request/retry timing calculations using a focused correctness check without modifying SDK behavior or enabling style rules

## Baseline → final
- SDK root, examples, and consumer **0 → 0**.

## Stack dependency
- Depends on #786.

## Castiron impact
No Castiron compiler change is required. This correctness-only change does not edit generated files or shared pagination scaffolding; generated and handwritten code remain equally covered. The policy's `unused`-before-style sequence is preserved, with generated `unused` cleanup separately blocked on its Castiron source-of-truth fix.

## Validation
- `go tool -modfile=tools/go.mod golangci-lint config verify --config .golangci.yml`
- `./scripts/lint` across the root, examples, and external-consumer modules
- Focused affected-package tests; full examples and external-consumer tests
- Mandatory thermo-nuclear code-quality review completed
