### PR TITLE
feat(auth): add X.509 workload identity federation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1091,22 +1091,24 @@ this X.509 mode defaults to `https://mtls.api.openai.com/v1`. Token exchange is
 always an exact `POST https://mtls.auth.openai.com/oauth/token`, refuses HTTP
 redirects, and structurally omits `subject_token`. The configured HTTP client
 must therefore be suitable for both mTLS hosts. A custom exchange URL is not
-supported. The SDK disables redirects on a native `*http.Client`; custom
-`option.HTTPClient` implementations must also refuse redirects internally.
+supported. X.509 mode requires a native `*http.Client` and `*http.Transport` so
+the SDK can verify the transport's immutable client identity and disable
+redirects.
 An explicit API base must be an absolute HTTPS URL without userinfo. The SDK
 binds the bearer to that normalized origin before exchange and again after
 request middleware, so absolute request URLs and middleware cannot move it to
 another origin. X.509 authentication cannot be combined with Azure or Bedrock
 provider authentication.
+Known Azure and Amazon Bedrock provider-owned API hostnames are rejected even
+when supplied through a raw base-URL option or `OPENAI_BASE_URL`.
 
 Each native `*http.Transport` used for X.509 workload identity must contain
 exactly one static client certificate and must not use custom TLS dial or
-certificate-selection hooks. This keeps cached and single-flight tokens bound
-to one client identity. The static certificate's `PrivateKey` may be backed by
-an HSM through Go's `crypto.Signer` interface. Do not mutate a transport after
-use; replace the transport and client to rotate identities. A custom HTTP
-transport likewise must represent one immutable client identity per comparable
-transport instance.
+certificate-selection hooks or a client TLS session cache. This keeps cached
+and single-flight tokens bound to one client identity, including after
+rotation. The static certificate's `PrivateKey` may be backed by an HSM through
+Go's `crypto.Signer` interface. Do not mutate a transport after use; replace the
+transport and client to rotate identities.
 
 The exchange is lazy, cached against Go's monotonic clock, refreshed with a
 buffer clamped to half the returned TTL, and single-flighted across concurrent

--- a/README.md
+++ b/README.md
@@ -988,6 +988,7 @@ transport.DialTLSContext = nil
 transport.ResponseHeaderTimeout = 10 * time.Minute
 transport.TLSClientConfig = &tls.Config{
 	Certificates: []tls.Certificate{certificate},
+	MinVersion:   tls.VersionTLS12,
 	GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
 		return &certificate, nil
 	},
@@ -1010,8 +1011,8 @@ if _, err := client.Models.List(context.Background()); err != nil {
 }
 ```
 
-The SDK does not select an mTLS endpoint automatically when a custom HTTP
-client is used. The explicit `option.WithBaseURL` above overrides
+API-key authentication does not select an mTLS endpoint automatically when a
+custom HTTP client is used. The explicit `option.WithBaseURL` above overrides
 `OPENAI_BASE_URL`; replace it with `https://mtls-eu.api.openai.com/v1` for the
 EU endpoint, or remove it to use `OPENAI_BASE_URL`. Keep server trust separate
 by configuring `RootCAs` on the fresh `tls.Config` when custom roots are
@@ -1039,7 +1040,74 @@ The complete tested recipe is in
 
 ## Workload Identity Authentication
 
-For cloud workloads (Kubernetes, Azure, Google Cloud Platform), you can use workload identity authentication instead of API keys. This provides short-lived tokens that are automatically refreshed.
+For cloud workloads, you can use workload identity authentication instead of API keys. This provides short-lived tokens that are automatically refreshed. JWT/ID-token providers and X.509 workload identity use separate typed configuration.
+
+### X.509 certificates (beta)
+
+X.509 workload identity federation uses the caller-configured native Go HTTP
+transport for both certificate-authenticated token exchange and API requests.
+The SDK does not load or retain certificate files, private keys, passphrases,
+custom trust, proxy configuration, or HSM state. Configure those concerns on a
+dedicated `*http.Client`, then select the X.509 credential branch:
+
+```go
+certificate, err := tls.LoadX509KeyPair(
+	os.Getenv("OPENAI_MTLS_CERTIFICATE_CHAIN"),
+	os.Getenv("OPENAI_MTLS_PRIVATE_KEY"),
+)
+if err != nil {
+	return err
+}
+
+baseTransport, ok := http.DefaultTransport.(*http.Transport)
+if !ok {
+	return errors.New("http.DefaultTransport is not an *http.Transport")
+}
+transport := baseTransport.Clone()
+transport.TLSClientConfig = &tls.Config{
+	Certificates: []tls.Certificate{certificate},
+	GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+		return &certificate, nil
+	},
+}
+httpClient := &http.Client{
+	Transport: transport,
+	CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	},
+}
+
+client := openai.NewClient(
+	option.WithHTTPClient(httpClient),
+	option.WithX509WorkloadIdentity(auth.X509WorkloadIdentity{
+		IdentityProviderID: os.Getenv("OPENAI_IDENTITY_PROVIDER_ID"),
+		ServiceAccountID:   os.Getenv("OPENAI_SERVICE_ACCOUNT_ID"),
+	}),
+)
+```
+
+When no explicit `option.WithBaseURL` or `OPENAI_BASE_URL` is present, only
+this X.509 mode defaults to `https://mtls.api.openai.com/v1`. Token exchange is
+always an exact `POST https://mtls.auth.openai.com/oauth/token`, refuses HTTP
+redirects, and structurally omits `subject_token`. The configured HTTP client
+must therefore be suitable for both mTLS hosts. A custom exchange URL is not
+supported. The SDK disables redirects on a native `*http.Client`; custom
+`option.HTTPClient` implementations must also refuse redirects internally.
+
+The exchange is lazy, cached against Go's monotonic clock, refreshed with a
+buffer clamped to half the returned TTL, and single-flighted across concurrent
+callers. Transient exchange failures receive bounded retries honoring
+`Retry-After`. An API `401` invalidates the rejected token and is retried once
+only when the request has no body or has a `GetBody` replay function. Realtime
+WebSocket authentication is not part of this HTTP-only phase.
+
+For an application-owned rollout, set `OPENAI_AUTH_MODE=api_key` (the default)
+or `OPENAI_AUTH_MODE=x509`. X.509 mode also uses
+`OPENAI_IDENTITY_PROVIDER_ID`, `OPENAI_SERVICE_ACCOUNT_ID`,
+`OPENAI_MTLS_CERTIFICATE_CHAIN`, and `OPENAI_MTLS_PRIVATE_KEY`. The SDK does not
+read the certificate variables implicitly. See the complete toggle in
+[`examples/x509-workload-identity`](./examples/x509-workload-identity/main.go)
+and the [X.509 workload identity guide](https://developers.openai.com/api/docs/guides/workload-identity-federation/x509).
 
 ### Kubernetes
 

--- a/README.md
+++ b/README.md
@@ -1064,6 +1064,8 @@ if !ok {
 	return errors.New("http.DefaultTransport is not an *http.Transport")
 }
 transport := baseTransport.Clone()
+transport.DialTLS = nil
+transport.DialTLSContext = nil
 transport.TLSClientConfig = &tls.Config{
 	Certificates: []tls.Certificate{certificate},
 	GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {

--- a/README.md
+++ b/README.md
@@ -1064,6 +1064,7 @@ if !ok {
 	return errors.New("http.DefaultTransport is not an *http.Transport")
 }
 transport := baseTransport.Clone()
+transport.Proxy = nil
 transport.DialTLS = nil
 transport.DialTLSContext = nil
 transport.TLSClientConfig = &tls.Config{
@@ -1095,6 +1096,11 @@ redirects, and structurally omits `subject_token`. The configured HTTP client
 must therefore be suitable for both mTLS hosts. A custom exchange URL is not
 supported. The SDK disables redirects on a native `*http.Client`; custom
 `option.HTTPClient` implementations must also refuse redirects internally.
+An explicit API base must be an absolute HTTPS URL without userinfo. The SDK
+binds the bearer to that normalized origin before exchange and again after
+request middleware, so absolute request URLs and middleware cannot move it to
+another origin. X.509 authentication cannot be combined with Azure or Bedrock
+provider authentication.
 
 The exchange is lazy, cached against Go's monotonic clock, refreshed with a
 buffer clamped to half the returned TTL, and single-flighted across concurrent

--- a/README.md
+++ b/README.md
@@ -1069,9 +1069,6 @@ transport.DialTLS = nil
 transport.DialTLSContext = nil
 transport.TLSClientConfig = &tls.Config{
 	Certificates: []tls.Certificate{certificate},
-	GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
-		return &certificate, nil
-	},
 }
 httpClient := &http.Client{
 	Transport: transport,
@@ -1101,6 +1098,13 @@ binds the bearer to that normalized origin before exchange and again after
 request middleware, so absolute request URLs and middleware cannot move it to
 another origin. X.509 authentication cannot be combined with Azure or Bedrock
 provider authentication.
+
+Each native `*http.Transport` used for X.509 workload identity must contain
+exactly one static client certificate and must not use custom TLS dial or
+certificate-selection hooks. This keeps cached and single-flight tokens bound
+to one client identity. Do not mutate a transport after use; replace the
+transport and client to rotate identities. A custom HTTP transport likewise
+must represent one immutable client identity per comparable transport instance.
 
 The exchange is lazy, cached against Go's monotonic clock, refreshed with a
 buffer clamped to half the returned TTL, and single-flighted across concurrent

--- a/README.md
+++ b/README.md
@@ -1102,9 +1102,11 @@ provider authentication.
 Each native `*http.Transport` used for X.509 workload identity must contain
 exactly one static client certificate and must not use custom TLS dial or
 certificate-selection hooks. This keeps cached and single-flight tokens bound
-to one client identity. Do not mutate a transport after use; replace the
-transport and client to rotate identities. A custom HTTP transport likewise
-must represent one immutable client identity per comparable transport instance.
+to one client identity. The static certificate's `PrivateKey` may be backed by
+an HSM through Go's `crypto.Signer` interface. Do not mutate a transport after
+use; replace the transport and client to rotate identities. A custom HTTP
+transport likewise must represent one immutable client identity per comparable
+transport instance.
 
 The exchange is lazy, cached against Go's monotonic clock, refreshed with a
 buffer clamped to half the returned TTL, and single-flighted across concurrent

--- a/auth/error.go
+++ b/auth/error.go
@@ -33,5 +33,8 @@ type OAuthError struct {
 }
 
 func (e *OAuthError) Error() string {
+	if e.ErrorCode == "" && e.ErrorDescription == "" {
+		return fmt.Sprintf("OAuth error (status %d)", e.StatusCode)
+	}
 	return fmt.Sprintf("OAuth error (status %d): %s - %s", e.StatusCode, e.ErrorCode, e.ErrorDescription)
 }

--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -17,7 +17,9 @@ func WorkloadIdentityMiddleware(
 		return nil, err
 	}
 
-	req.Header.Set("Authorization", "Bearer "+token)
+	authorization := "Bearer " + token
+	req = internal.WithExpectedAuthorization(req, authorization)
+	req.Header.Set("Authorization", authorization)
 	var retryReq *http.Request
 	if req.Body == nil || req.GetBody != nil {
 		retryReq = req.Clone(req.Context())
@@ -39,7 +41,9 @@ func WorkloadIdentityMiddleware(
 		_ = resp.Body.Close()
 		return nil, err
 	}
-	retryReq.Header.Set("Authorization", "Bearer "+token)
+	authorization = "Bearer " + token
+	retryReq.Header.Set("Authorization", authorization)
+	retryReq = internal.WithExpectedAuthorization(retryReq, authorization)
 
 	if retryReq.GetBody != nil {
 		retryReq.Body, err = retryReq.GetBody()
@@ -56,6 +60,9 @@ func WorkloadIdentityMiddleware(
 	resp, err = next(retryReq)
 	if err != nil && retryReq.Body != nil {
 		_ = retryReq.Body.Close()
+	}
+	if resp != nil && resp.StatusCode == http.StatusUnauthorized {
+		wia.invalidateToken(token)
 	}
 	return resp, err
 }

--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -48,5 +48,9 @@ func WorkloadIdentityMiddleware(
 	}
 
 	_ = resp.Body.Close()
-	return next(retryReq)
+	resp, err = next(retryReq)
+	if err != nil && retryReq.Body != nil {
+		_ = retryReq.Body.Close()
+	}
+	return resp, err
 }

--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -16,6 +16,10 @@ func WorkloadIdentityMiddleware(
 	}
 
 	req.Header.Set("Authorization", "Bearer "+token)
+	var retryReq *http.Request
+	if req.Body == nil || req.GetBody != nil {
+		retryReq = req.Clone(req.Context())
+	}
 
 	resp, err := next(req)
 	if err != nil || resp == nil || resp.StatusCode != http.StatusUnauthorized {
@@ -24,11 +28,9 @@ func WorkloadIdentityMiddleware(
 
 	wia.invalidateToken(token)
 
-	if req.Body != nil && req.GetBody == nil {
+	if retryReq == nil {
 		return resp, nil
 	}
-
-	retryReq := req.Clone(req.Context())
 
 	token, err = wia.GetToken(req.Context(), httpClient)
 	if err != nil {
@@ -37,8 +39,8 @@ func WorkloadIdentityMiddleware(
 	}
 	retryReq.Header.Set("Authorization", "Bearer "+token)
 
-	if req.GetBody != nil {
-		retryReq.Body, err = req.GetBody()
+	if retryReq.GetBody != nil {
+		retryReq.Body, err = retryReq.GetBody()
 		if err != nil {
 			_ = resp.Body.Close()
 			return nil, err

--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -22,7 +22,7 @@ func WorkloadIdentityMiddleware(
 		return resp, err
 	}
 
-	wia.invalidateToken()
+	wia.invalidateToken(token)
 
 	if req.Body != nil && req.GetBody == nil {
 		return resp, nil

--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -2,6 +2,8 @@ package auth
 
 import (
 	"net/http"
+
+	"github.com/openai/openai-go/v3/internal"
 )
 
 func WorkloadIdentityMiddleware(
@@ -48,6 +50,9 @@ func WorkloadIdentityMiddleware(
 	}
 
 	_ = resp.Body.Close()
+	if retryReq.Body != nil {
+		retryReq.Body = internal.NewCloseOnceReadCloser(retryReq.Body)
+	}
 	resp, err = next(retryReq)
 	if err != nil && retryReq.Body != nil {
 		_ = retryReq.Body.Close()

--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/openai/openai-go/v3/internal"
@@ -12,6 +13,9 @@ func WorkloadIdentityMiddleware(
 	req *http.Request,
 	next func(*http.Request) (*http.Response, error),
 ) (*http.Response, error) {
+	if wia.source.kind() == workloadIdentityCredentialSourceX509 && !internal.HasX509RequestPolicy(req) {
+		return nil, errors.New("X.509 workload identity middleware requires the SDK X.509 request policy")
+	}
 	token, err := wia.GetToken(req.Context(), httpClient)
 	if err != nil {
 		return nil, err

--- a/auth/tokenexchange.go
+++ b/auth/tokenexchange.go
@@ -1,0 +1,109 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+const tokenExchangeMaxRetryDelay = 60 * time.Second
+
+func exchangeToken(
+	ctx context.Context,
+	httpClient HTTPDoer,
+	url string,
+	body []byte,
+	maxRetries int,
+) (*http.Response, error) {
+	for retry := 0; ; retry++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+		if err != nil {
+			return nil, fmt.Errorf("failed to create token exchange request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := httpClient.Do(req)
+		if err == nil && (resp == nil || resp.Body == nil) {
+			return nil, fmt.Errorf("token exchange returned an invalid HTTP response")
+		}
+		if !shouldRetryTokenExchange(resp, err) || retry >= maxRetries {
+			if err != nil {
+				if resp != nil && resp.Body != nil {
+					_ = resp.Body.Close()
+				}
+				return nil, fmt.Errorf("failed to exchange token: %w", err)
+			}
+			return resp, nil
+		}
+
+		if resp != nil && resp.Body != nil {
+			_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+			_ = resp.Body.Close()
+		}
+		if err := waitForTokenExchangeRetry(ctx, tokenExchangeRetryDelay(resp, retry)); err != nil {
+			return nil, err
+		}
+	}
+}
+
+func readTokenExchangeResponse(reader io.Reader, maxBytes int64) ([]byte, error) {
+	responseBody := reader
+	if maxBytes > 0 {
+		responseBody = io.LimitReader(reader, maxBytes+1)
+	}
+	body, err := io.ReadAll(responseBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read token exchange response: %w", err)
+	}
+	if maxBytes > 0 && int64(len(body)) > maxBytes {
+		return nil, fmt.Errorf("token exchange response exceeded %d bytes", maxBytes)
+	}
+	return body, nil
+}
+
+func shouldRetryTokenExchange(resp *http.Response, err error) bool {
+	if err != nil {
+		return true
+	}
+	return resp != nil && (resp.StatusCode == http.StatusRequestTimeout ||
+		resp.StatusCode == http.StatusConflict ||
+		resp.StatusCode == http.StatusTooManyRequests ||
+		resp.StatusCode >= http.StatusInternalServerError)
+}
+
+func tokenExchangeRetryDelay(resp *http.Response, retry int) time.Duration {
+	if resp != nil {
+		if value := resp.Header.Get("Retry-After"); value != "" {
+			if seconds, err := strconv.ParseFloat(value, 64); err == nil && !math.IsNaN(seconds) {
+				switch {
+				case seconds <= 0:
+					return 0
+				case math.IsInf(seconds, 1) || seconds >= tokenExchangeMaxRetryDelay.Seconds():
+					return tokenExchangeMaxRetryDelay
+				default:
+					return time.Duration(seconds * float64(time.Second))
+				}
+			}
+			if retryAt, err := http.ParseTime(value); err == nil {
+				return min(max(0, time.Until(retryAt)), tokenExchangeMaxRetryDelay)
+			}
+		}
+	}
+	return min(time.Duration(1<<retry)*250*time.Millisecond, tokenExchangeMaxRetryDelay)
+}
+
+func waitForTokenExchangeRetry(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/auth/types.go
+++ b/auth/types.go
@@ -32,8 +32,9 @@ type WorkloadIdentity struct {
 
 // X509WorkloadIdentity configures X.509 workload identity federation. Client
 // certificate and TLS configuration remain the responsibility of the HTTP
-// transport supplied to the OpenAI client. A native *http.Transport must use
-// exactly one static client certificate per transport instance.
+// transport supplied to the OpenAI client. The client must use a native
+// *http.Transport with exactly one static client certificate and no client TLS
+// session cache.
 type X509WorkloadIdentity struct {
 	IdentityProviderID string
 	ServiceAccountID   string

--- a/auth/types.go
+++ b/auth/types.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"net/http"
+	"time"
 )
 
 type HTTPDoer interface {
@@ -27,6 +28,15 @@ type WorkloadIdentity struct {
 	ServiceAccountID     string
 	Provider             SubjectTokenProvider
 	RefreshBufferSeconds int
+}
+
+// X509WorkloadIdentity configures X.509 workload identity federation. Client
+// certificate and TLS configuration remain the responsibility of the HTTP
+// transport supplied to the OpenAI client.
+type X509WorkloadIdentity struct {
+	IdentityProviderID string
+	ServiceAccountID   string
+	RefreshBuffer      time.Duration
 }
 
 type TokenExchangeResponse struct {

--- a/auth/types.go
+++ b/auth/types.go
@@ -32,7 +32,8 @@ type WorkloadIdentity struct {
 
 // X509WorkloadIdentity configures X.509 workload identity federation. Client
 // certificate and TLS configuration remain the responsibility of the HTTP
-// transport supplied to the OpenAI client.
+// transport supplied to the OpenAI client. A native *http.Transport must use
+// exactly one static client certificate per transport instance.
 type X509WorkloadIdentity struct {
 	IdentityProviderID string
 	ServiceAccountID   string

--- a/auth/workloadidentity.go
+++ b/auth/workloadidentity.go
@@ -35,12 +35,11 @@ type WorkloadIdentityAuth struct {
 	serviceAccountID   string
 	source             workloadIdentityCredentialSource
 
-	// Protects boundHTTPDoer, boundHTTPTransport, boundX509Identity,
-	// cachedToken, tokenExpiry, tokenRefreshAt, and refreshInFlight.
+	// Protects boundHTTPDoer, boundHTTPTransport, cachedToken, tokenExpiry,
+	// tokenRefreshAt, and refreshInFlight.
 	mu                 sync.Mutex
 	boundHTTPDoer      HTTPDoer
 	boundHTTPTransport http.RoundTripper
-	boundX509Identity  x509HTTPTransportIdentity
 	cachedToken        string
 	tokenExpiry        time.Time
 	tokenRefreshAt     time.Time
@@ -265,14 +264,12 @@ func (w *WorkloadIdentityAuth) bindHTTPDoerLocked(httpClient HTTPDoer) error {
 	if httpTransport != nil && !reflect.ValueOf(httpTransport).Comparable() {
 		return fmt.Errorf("X.509 workload identity requires a comparable HTTP transport")
 	}
-	identity, err := x509HTTPTransportIdentityFor(httpTransport)
-	if err != nil {
+	if err := validateX509HTTPTransportIdentity(httpTransport); err != nil {
 		return err
 	}
 	if w.boundHTTPDoer == nil {
 		w.boundHTTPDoer = httpClient
 		w.boundHTTPTransport = httpTransport
-		w.boundX509Identity = identity
 		return nil
 	}
 	if w.boundHTTPDoer != httpClient {
@@ -280,9 +277,6 @@ func (w *WorkloadIdentityAuth) bindHTTPDoerLocked(httpClient HTTPDoer) error {
 	}
 	if w.boundHTTPTransport != httpTransport {
 		return fmt.Errorf("X.509 workload identity auth cannot change HTTP transports")
-	}
-	if w.boundX509Identity != identity {
-		return fmt.Errorf("X.509 workload identity auth cannot change native HTTP transport client identities")
 	}
 	return nil
 }

--- a/auth/workloadidentity.go
+++ b/auth/workloadidentity.go
@@ -255,7 +255,7 @@ func (w *WorkloadIdentityAuth) bindHTTPDoerLocked(httpClient HTTPDoer) error {
 	if w.source.kind() != workloadIdentityCredentialSourceX509 {
 		return nil
 	}
-	if !reflect.TypeOf(httpClient).Comparable() {
+	if !reflect.ValueOf(httpClient).Comparable() {
 		return fmt.Errorf("X.509 workload identity requires a comparable HTTP client")
 	}
 	if w.boundHTTPDoer == nil {

--- a/auth/workloadidentity.go
+++ b/auth/workloadidentity.go
@@ -35,11 +35,12 @@ type WorkloadIdentityAuth struct {
 	serviceAccountID   string
 	source             workloadIdentityCredentialSource
 
-	// Protects boundHTTPDoer, boundHTTPTransport, cachedToken, tokenExpiry,
-	// tokenRefreshAt, and refreshInFlight.
+	// Protects boundHTTPDoer, boundHTTPTransport, boundX509Identity,
+	// cachedToken, tokenExpiry, tokenRefreshAt, and refreshInFlight.
 	mu                 sync.Mutex
 	boundHTTPDoer      HTTPDoer
 	boundHTTPTransport http.RoundTripper
+	boundX509Identity  x509HTTPTransportIdentity
 	cachedToken        string
 	tokenExpiry        time.Time
 	tokenRefreshAt     time.Time
@@ -264,9 +265,14 @@ func (w *WorkloadIdentityAuth) bindHTTPDoerLocked(httpClient HTTPDoer) error {
 	if httpTransport != nil && !reflect.ValueOf(httpTransport).Comparable() {
 		return fmt.Errorf("X.509 workload identity requires a comparable HTTP transport")
 	}
+	identity, err := x509HTTPTransportIdentityFor(httpTransport)
+	if err != nil {
+		return err
+	}
 	if w.boundHTTPDoer == nil {
 		w.boundHTTPDoer = httpClient
 		w.boundHTTPTransport = httpTransport
+		w.boundX509Identity = identity
 		return nil
 	}
 	if w.boundHTTPDoer != httpClient {
@@ -274,6 +280,9 @@ func (w *WorkloadIdentityAuth) bindHTTPDoerLocked(httpClient HTTPDoer) error {
 	}
 	if w.boundHTTPTransport != httpTransport {
 		return fmt.Errorf("X.509 workload identity auth cannot change HTTP transports")
+	}
+	if w.boundX509Identity != identity {
+		return fmt.Errorf("X.509 workload identity auth cannot change native HTTP transport client identities")
 	}
 	return nil
 }

--- a/auth/workloadidentity.go
+++ b/auth/workloadidentity.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/openai/openai-go/v3/internal"
 	"github.com/openai/openai-go/v3/shared"
 )
 
@@ -34,14 +35,15 @@ type WorkloadIdentityAuth struct {
 	serviceAccountID   string
 	source             workloadIdentityCredentialSource
 
-	// Protects boundHTTPDoer, cachedToken, tokenExpiry, tokenRefreshAt, and
-	// refreshInFlight.
-	mu              sync.Mutex
-	boundHTTPDoer   HTTPDoer
-	cachedToken     string
-	tokenExpiry     time.Time
-	tokenRefreshAt  time.Time
-	refreshInFlight *tokenRefreshState
+	// Protects boundHTTPDoer, boundHTTPTransport, cachedToken, tokenExpiry,
+	// tokenRefreshAt, and refreshInFlight.
+	mu                 sync.Mutex
+	boundHTTPDoer      HTTPDoer
+	boundHTTPTransport http.RoundTripper
+	cachedToken        string
+	tokenExpiry        time.Time
+	tokenRefreshAt     time.Time
+	refreshInFlight    *tokenRefreshState
 }
 
 type tokenRefreshResult struct {
@@ -214,7 +216,7 @@ func (w *WorkloadIdentityAuth) GetToken(ctx context.Context, httpClient HTTPDoer
 	// Proactive background refresh: start if within refresh window and no refresh active
 	if !now.Before(w.tokenRefreshAt) && w.refreshInFlight == nil {
 		state := w.beginRefreshLocked()
-		w.startSharedRefresh(state, httpClient)
+		w.startSharedRefresh(ctx, state, httpClient)
 	}
 
 	token := w.cachedToken
@@ -227,7 +229,7 @@ func (w *WorkloadIdentityAuth) handleLockedRefresh(ctx context.Context, httpClie
 	if w.refreshInFlight == nil {
 		state := w.beginRefreshLocked()
 		if w.source.kind() == workloadIdentityCredentialSourceX509 {
-			w.startSharedRefresh(state, httpClient)
+			w.startSharedRefresh(ctx, state, httpClient)
 			return w.waitForLockedRefresh(ctx, state)
 		}
 
@@ -258,12 +260,20 @@ func (w *WorkloadIdentityAuth) bindHTTPDoerLocked(httpClient HTTPDoer) error {
 	if !reflect.ValueOf(httpClient).Comparable() {
 		return fmt.Errorf("X.509 workload identity requires a comparable HTTP client")
 	}
+	httpTransport := internal.NativeHTTPTransport(httpClient)
+	if httpTransport != nil && !reflect.ValueOf(httpTransport).Comparable() {
+		return fmt.Errorf("X.509 workload identity requires a comparable HTTP transport")
+	}
 	if w.boundHTTPDoer == nil {
 		w.boundHTTPDoer = httpClient
+		w.boundHTTPTransport = httpTransport
 		return nil
 	}
 	if w.boundHTTPDoer != httpClient {
 		return fmt.Errorf("X.509 workload identity auth cannot change HTTP clients")
+	}
+	if w.boundHTTPTransport != httpTransport {
+		return fmt.Errorf("X.509 workload identity auth cannot change HTTP transports")
 	}
 	return nil
 }
@@ -284,8 +294,8 @@ func (w *WorkloadIdentityAuth) beginRefreshLocked() *tokenRefreshState {
 	return w.refreshInFlight
 }
 
-func (w *WorkloadIdentityAuth) startSharedRefresh(state *tokenRefreshState, httpClient HTTPDoer) {
-	refreshCtx, cancel := context.WithTimeout(context.Background(), w.source.refreshTimeout())
+func (w *WorkloadIdentityAuth) startSharedRefresh(ctx context.Context, state *tokenRefreshState, httpClient HTTPDoer) {
+	refreshCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), w.source.refreshTimeout())
 	state.cancel = cancel
 	go func() {
 		defer cancel()

--- a/auth/workloadidentity.go
+++ b/auth/workloadidentity.go
@@ -238,6 +238,12 @@ func (w *WorkloadIdentityAuth) GetToken(ctx context.Context, httpClient HTTPDoer
 // Single-flight pattern: ensures only one refresh runs, others wait for result
 func (w *WorkloadIdentityAuth) handleLockedRefresh(ctx context.Context, httpClient HTTPDoer) (string, error) {
 	if w.refreshInFlight == nil {
+		if w.source.kind() == workloadIdentityCredentialSourceX509 {
+			if err := ctx.Err(); err != nil {
+				w.mu.Unlock()
+				return "", err
+			}
+		}
 		state := w.beginRefreshLocked(0)
 		if w.source.kind() == workloadIdentityCredentialSourceX509 {
 			w.startSharedRefresh(ctx, state, httpClient)

--- a/auth/workloadidentity.go
+++ b/auth/workloadidentity.go
@@ -2,10 +2,11 @@ package auth
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
-	"reflect"
 	"sync"
 	"time"
 
@@ -35,15 +36,18 @@ type WorkloadIdentityAuth struct {
 	serviceAccountID   string
 	source             workloadIdentityCredentialSource
 
-	// Protects boundHTTPDoer, boundHTTPTransport, cachedToken, tokenExpiry,
-	// tokenRefreshAt, and refreshInFlight.
-	mu                 sync.Mutex
-	boundHTTPDoer      HTTPDoer
-	boundHTTPTransport http.RoundTripper
-	cachedToken        string
-	tokenExpiry        time.Time
-	tokenRefreshAt     time.Time
-	refreshInFlight    *tokenRefreshState
+	// Protects boundHTTPDoer, boundHTTPTransport, boundCertificateFingerprint,
+	// cachedToken, tokenExpiry, tokenRefreshAt, tokenGeneration, and
+	// refreshInFlight.
+	mu                          sync.Mutex
+	boundHTTPDoer               *http.Client
+	boundHTTPTransport          *http.Transport
+	boundCertificateFingerprint [sha256.Size]byte
+	cachedToken                 string
+	tokenExpiry                 time.Time
+	tokenRefreshAt              time.Time
+	tokenGeneration             uint64
+	refreshInFlight             *tokenRefreshState
 }
 
 type tokenRefreshResult struct {
@@ -56,11 +60,14 @@ type tokenRefreshResult struct {
 // Coordinates concurrent access to a single in-flight refresh operation
 // done channel signals completion to all waiting goroutines
 type tokenRefreshState struct {
-	done    chan struct{}
-	result  tokenRefreshResult
-	cancel  context.CancelFunc
-	waiters int
+	done                 chan struct{}
+	result               tokenRefreshResult
+	cancel               context.CancelFunc
+	waiters              int
+	refreshForGeneration uint64
 }
+
+var errTokenRefreshInvalidated = errors.New("workload identity token refresh was invalidated")
 
 type subjectTokenExchangeRequest struct {
 	GrantType          string `json:"grant_type"`
@@ -215,7 +222,11 @@ func (w *WorkloadIdentityAuth) GetToken(ctx context.Context, httpClient HTTPDoer
 
 	// Proactive background refresh: start if within refresh window and no refresh active
 	if !now.Before(w.tokenRefreshAt) && w.refreshInFlight == nil {
-		state := w.beginRefreshLocked()
+		refreshForGeneration := uint64(0)
+		if w.source.kind() == workloadIdentityCredentialSourceX509 {
+			refreshForGeneration = w.tokenGeneration
+		}
+		state := w.beginRefreshLocked(refreshForGeneration)
 		w.startSharedRefresh(ctx, state, httpClient)
 	}
 
@@ -227,7 +238,7 @@ func (w *WorkloadIdentityAuth) GetToken(ctx context.Context, httpClient HTTPDoer
 // Single-flight pattern: ensures only one refresh runs, others wait for result
 func (w *WorkloadIdentityAuth) handleLockedRefresh(ctx context.Context, httpClient HTTPDoer) (string, error) {
 	if w.refreshInFlight == nil {
-		state := w.beginRefreshLocked()
+		state := w.beginRefreshLocked(0)
 		if w.source.kind() == workloadIdentityCredentialSourceX509 {
 			w.startSharedRefresh(ctx, state, httpClient)
 			return w.waitForLockedRefresh(ctx, state)
@@ -257,26 +268,32 @@ func (w *WorkloadIdentityAuth) bindHTTPDoerLocked(httpClient HTTPDoer) error {
 	if w.source.kind() != workloadIdentityCredentialSourceX509 {
 		return nil
 	}
-	if !reflect.ValueOf(httpClient).Comparable() {
-		return fmt.Errorf("X.509 workload identity requires a comparable HTTP client")
+	nativeHTTPClient, ok := httpClient.(*http.Client)
+	if !ok {
+		return errX509NativeHTTPTransport
 	}
-	httpTransport := internal.NativeHTTPTransport(httpClient)
-	if httpTransport != nil && !reflect.ValueOf(httpTransport).Comparable() {
-		return fmt.Errorf("X.509 workload identity requires a comparable HTTP transport")
+	httpTransport, ok := internal.NativeHTTPTransport(nativeHTTPClient).(*http.Transport)
+	if !ok {
+		return errX509NativeHTTPTransport
 	}
-	if err := validateX509HTTPTransportIdentity(httpTransport); err != nil {
+	certificateFingerprint, err := x509HTTPTransportIdentity(httpTransport)
+	if err != nil {
 		return err
 	}
 	if w.boundHTTPDoer == nil {
-		w.boundHTTPDoer = httpClient
+		w.boundHTTPDoer = nativeHTTPClient
 		w.boundHTTPTransport = httpTransport
+		w.boundCertificateFingerprint = certificateFingerprint
 		return nil
 	}
-	if w.boundHTTPDoer != httpClient {
+	if w.boundHTTPDoer != nativeHTTPClient {
 		return fmt.Errorf("X.509 workload identity auth cannot change HTTP clients")
 	}
 	if w.boundHTTPTransport != httpTransport {
 		return fmt.Errorf("X.509 workload identity auth cannot change HTTP transports")
+	}
+	if w.boundCertificateFingerprint != certificateFingerprint {
+		return fmt.Errorf("X.509 workload identity auth cannot change client certificates")
 	}
 	return nil
 }
@@ -290,10 +307,22 @@ func (w *WorkloadIdentityAuth) invalidateToken(token string) {
 	w.cachedToken = ""
 	w.tokenExpiry = time.Time{}
 	w.tokenRefreshAt = time.Time{}
+	if state := w.refreshInFlight; state != nil &&
+		state.refreshForGeneration != 0 && state.refreshForGeneration == w.tokenGeneration {
+		w.refreshInFlight = nil
+		state.result.err = errTokenRefreshInvalidated
+		if state.cancel != nil {
+			state.cancel()
+		}
+		close(state.done)
+	}
 }
 
-func (w *WorkloadIdentityAuth) beginRefreshLocked() *tokenRefreshState {
-	w.refreshInFlight = &tokenRefreshState{done: make(chan struct{})}
+func (w *WorkloadIdentityAuth) beginRefreshLocked(refreshForGeneration uint64) *tokenRefreshState {
+	w.refreshInFlight = &tokenRefreshState{
+		done:                 make(chan struct{}),
+		refreshForGeneration: refreshForGeneration,
+	}
 	return w.refreshInFlight
 }
 
@@ -318,6 +347,12 @@ func (w *WorkloadIdentityAuth) finishRefresh(state *tokenRefreshState, result to
 		w.cachedToken = result.token
 		w.tokenExpiry = result.expiresAt
 		w.tokenRefreshAt = result.refreshAt
+		if w.source.kind() == workloadIdentityCredentialSourceX509 {
+			w.tokenGeneration++
+			if w.tokenGeneration == 0 {
+				w.tokenGeneration++
+			}
+		}
 	}
 	close(state.done) // Broadcasts completion to all waiters
 	w.refreshInFlight = nil

--- a/auth/workloadidentity.go
+++ b/auth/workloadidentity.go
@@ -1,11 +1,9 @@
 package auth
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"sync"
 	"time"
@@ -23,18 +21,23 @@ const (
 )
 
 type WorkloadIdentityAuth struct {
-	config WorkloadIdentity
+	identityProviderID string
+	serviceAccountID   string
+	source             workloadIdentityCredentialSource
 
-	// Protects cachedToken, tokenExpiry, and refreshInFlight
+	// Protects cachedToken, tokenExpiry, tokenRefreshAt, and refreshInFlight.
 	mu              sync.Mutex
 	cachedToken     string
 	tokenExpiry     time.Time
+	tokenRefreshAt  time.Time
 	refreshInFlight *tokenRefreshState
 }
 
 type tokenRefreshResult struct {
-	token string
-	err   error
+	token     string
+	expiresAt time.Time
+	refreshAt time.Time
+	err       error
 }
 
 // Coordinates concurrent access to a single in-flight refresh operation
@@ -44,7 +47,7 @@ type tokenRefreshState struct {
 	result tokenRefreshResult
 }
 
-type tokenExchangeRequest struct {
+type subjectTokenExchangeRequest struct {
 	GrantType          string `json:"grant_type"`
 	ClientID           string `json:"client_id,omitempty"`
 	SubjectToken       string `json:"subject_token"`
@@ -53,12 +56,77 @@ type tokenExchangeRequest struct {
 	ServiceAccountID   string `json:"service_account_id"`
 }
 
-func NewWorkloadIdentityAuth(config WorkloadIdentity) (*WorkloadIdentityAuth, error) {
-	if config.IdentityProviderID == "" {
-		return nil, fmt.Errorf("WorkloadIdentity: IdentityProviderID is required")
+type exchangedToken struct {
+	accessToken string
+	expiresIn   time.Duration
+}
+
+type workloadIdentityCredentialSource interface {
+	exchange(context.Context, HTTPDoer, string, string) (exchangedToken, error)
+	refreshBuffer(time.Duration) time.Duration
+}
+
+type subjectTokenCredentialSource struct {
+	clientID      string
+	provider      SubjectTokenProvider
+	refreshBefore time.Duration
+}
+
+func (s subjectTokenCredentialSource) exchange(
+	ctx context.Context,
+	httpClient HTTPDoer,
+	identityProviderID string,
+	serviceAccountID string,
+) (exchangedToken, error) {
+	subjectToken, err := s.provider.GetToken(ctx, httpClient)
+	if err != nil {
+		return exchangedToken{}, err
 	}
-	if config.ServiceAccountID == "" {
-		return nil, fmt.Errorf("WorkloadIdentity: ServiceAccountID is required")
+
+	providerTokenType := s.provider.TokenType()
+	var subjectTokenType string
+	switch providerTokenType {
+	case SubjectTokenTypeJWT:
+		subjectTokenType = JWTTokenType
+	case SubjectTokenTypeID:
+		subjectTokenType = IDTokenType
+	default:
+		return exchangedToken{}, fmt.Errorf("unsupported subject token type %q", providerTokenType)
+	}
+
+	body, err := json.Marshal(subjectTokenExchangeRequest{
+		GrantType:          TokenExchangeGrantType,
+		ClientID:           s.clientID,
+		SubjectToken:       subjectToken,
+		SubjectTokenType:   subjectTokenType,
+		IdentityProviderID: identityProviderID,
+		ServiceAccountID:   serviceAccountID,
+	})
+	if err != nil {
+		return exchangedToken{}, fmt.Errorf("failed to marshal token exchange request: %w", err)
+	}
+	resp, err := exchangeToken(ctx, httpClient, TokenExchangeURL, body, 0)
+	if err != nil {
+		return exchangedToken{}, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	responseBody, err := readTokenExchangeResponse(resp.Body, 0)
+	if err != nil {
+		return exchangedToken{}, err
+	}
+	return parseSubjectTokenExchangeResponse(resp.StatusCode, responseBody)
+}
+
+func (s subjectTokenCredentialSource) refreshBuffer(time.Duration) time.Duration {
+	if s.refreshBefore == 0 {
+		return DefaultRefreshBuffer
+	}
+	return s.refreshBefore
+}
+
+func NewWorkloadIdentityAuth(config WorkloadIdentity) (*WorkloadIdentityAuth, error) {
+	if err := validateWorkloadIdentity("WorkloadIdentity", config.IdentityProviderID, config.ServiceAccountID); err != nil {
+		return nil, err
 	}
 	if config.Provider == nil {
 		return nil, fmt.Errorf("WorkloadIdentity: Provider is required")
@@ -66,9 +134,37 @@ func NewWorkloadIdentityAuth(config WorkloadIdentity) (*WorkloadIdentityAuth, er
 	if config.RefreshBufferSeconds < 0 {
 		return nil, fmt.Errorf("WorkloadIdentity: RefreshBufferSeconds must be non-negative")
 	}
+	return newWorkloadIdentityAuth(
+		config.IdentityProviderID,
+		config.ServiceAccountID,
+		subjectTokenCredentialSource{
+			clientID:      config.ClientID,
+			provider:      config.Provider,
+			refreshBefore: time.Duration(config.RefreshBufferSeconds) * time.Second,
+		},
+	), nil
+}
+
+func validateWorkloadIdentity(configName string, identityProviderID string, serviceAccountID string) error {
+	if identityProviderID == "" {
+		return fmt.Errorf("%s: IdentityProviderID is required", configName)
+	}
+	if serviceAccountID == "" {
+		return fmt.Errorf("%s: ServiceAccountID is required", configName)
+	}
+	return nil
+}
+
+func newWorkloadIdentityAuth(
+	identityProviderID string,
+	serviceAccountID string,
+	source workloadIdentityCredentialSource,
+) *WorkloadIdentityAuth {
 	return &WorkloadIdentityAuth{
-		config: config,
-	}, nil
+		identityProviderID: identityProviderID,
+		serviceAccountID:   serviceAccountID,
+		source:             source,
+	}
 }
 
 func (w *WorkloadIdentityAuth) GetToken(ctx context.Context, httpClient HTTPDoer) (string, error) {
@@ -84,25 +180,18 @@ func (w *WorkloadIdentityAuth) GetToken(ctx context.Context, httpClient HTTPDoer
 	}
 
 	now := time.Now()
-	if now.After(w.tokenExpiry) {
+	if !now.Before(w.tokenExpiry) {
 		return w.handleLockedRefresh(ctx, httpClient)
 	}
 
-	refreshBuffer := w.config.RefreshBufferSeconds
-	if refreshBuffer == 0 {
-		refreshBuffer = int(DefaultRefreshBuffer / time.Second)
-	}
-	refreshTime := w.tokenExpiry.Add(-time.Duration(refreshBuffer) * time.Second)
-
 	// Proactive background refresh: start if within refresh window and no refresh active
-	if now.After(refreshTime) && w.refreshInFlight == nil {
+	if !now.Before(w.tokenRefreshAt) && w.refreshInFlight == nil {
 		state := w.beginRefreshLocked()
 		// Background goroutine with independent context, lock released before spawn
 		go func() {
 			refreshCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
-			token, err := w.refreshToken(refreshCtx, httpClient)
-			w.finishRefresh(state, token, err)
+			w.finishRefresh(state, w.refreshToken(refreshCtx, httpClient))
 		}()
 	}
 
@@ -117,7 +206,9 @@ func (w *WorkloadIdentityAuth) handleLockedRefresh(ctx context.Context, httpClie
 		// No refresh running: start foreground refresh, unlock before blocking operation
 		state := w.beginRefreshLocked()
 		w.mu.Unlock()
-		return w.completeForegroundRefresh(ctx, state, httpClient)
+		result := w.refreshToken(ctx, httpClient)
+		w.finishRefresh(state, result)
+		return result.token, result.err
 	}
 
 	// Refresh already running: unlock and wait for its completion
@@ -126,11 +217,15 @@ func (w *WorkloadIdentityAuth) handleLockedRefresh(ctx context.Context, httpClie
 	return w.waitForRefresh(ctx, state)
 }
 
-func (w *WorkloadIdentityAuth) invalidateToken() {
+func (w *WorkloadIdentityAuth) invalidateToken(token string) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	if w.cachedToken != token {
+		return
+	}
 	w.cachedToken = ""
 	w.tokenExpiry = time.Time{}
+	w.tokenRefreshAt = time.Time{}
 }
 
 func (w *WorkloadIdentityAuth) beginRefreshLocked() *tokenRefreshState {
@@ -138,20 +233,19 @@ func (w *WorkloadIdentityAuth) beginRefreshLocked() *tokenRefreshState {
 	return w.refreshInFlight
 }
 
-func (w *WorkloadIdentityAuth) completeForegroundRefresh(ctx context.Context, state *tokenRefreshState, httpClient HTTPDoer) (string, error) {
-	token, err := w.refreshToken(ctx, httpClient)
-	w.finishRefresh(state, token, err)
-	return token, err
-}
-
 // Atomically publishes refresh result and signals all waiting goroutines via channel close
-func (w *WorkloadIdentityAuth) finishRefresh(state *tokenRefreshState, token string, err error) {
+func (w *WorkloadIdentityAuth) finishRefresh(state *tokenRefreshState, result tokenRefreshResult) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if w.refreshInFlight != state {
 		return
 	}
-	state.result = tokenRefreshResult{token: token, err: err}
+	state.result = result
+	if result.err == nil {
+		w.cachedToken = result.token
+		w.tokenExpiry = result.expiresAt
+		w.tokenRefreshAt = result.refreshAt
+	}
 	close(state.done) // Broadcasts completion to all waiters
 	w.refreshInFlight = nil
 }
@@ -166,95 +260,54 @@ func (w *WorkloadIdentityAuth) waitForRefresh(ctx context.Context, state *tokenR
 	}
 }
 
-func (w *WorkloadIdentityAuth) refreshToken(ctx context.Context, httpClient HTTPDoer) (string, error) {
+func (w *WorkloadIdentityAuth) refreshToken(ctx context.Context, httpClient HTTPDoer) tokenRefreshResult {
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
 
-	subjectToken, err := w.config.Provider.GetToken(ctx, httpClient)
+	token, err := w.source.exchange(ctx, httpClient, w.identityProviderID, w.serviceAccountID)
 	if err != nil {
-		return "", err
+		return tokenRefreshResult{err: err}
 	}
 
-	subjectTokenType := w.config.Provider.TokenType()
-	var subjectTokenTypeURN string
-	switch subjectTokenType {
-	case SubjectTokenTypeJWT:
-		subjectTokenTypeURN = JWTTokenType
-	case SubjectTokenTypeID:
-		subjectTokenTypeURN = IDTokenType
-	default:
-		return "", fmt.Errorf("unsupported subject token type %q", subjectTokenType)
-	}
+	now := time.Now()
+	expiresAt := now.Add(token.expiresIn)
 
-	requestBody := tokenExchangeRequest{
-		GrantType:          TokenExchangeGrantType,
-		ClientID:           w.config.ClientID,
-		SubjectToken:       subjectToken,
-		SubjectTokenType:   subjectTokenTypeURN,
-		IdentityProviderID: w.config.IdentityProviderID,
-		ServiceAccountID:   w.config.ServiceAccountID,
+	return tokenRefreshResult{
+		token:     token.accessToken,
+		expiresAt: expiresAt,
+		refreshAt: expiresAt.Add(-w.source.refreshBuffer(token.expiresIn)),
 	}
+}
 
-	jsonBody, err := json.Marshal(requestBody)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal token exchange request: %w", err)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, "POST", TokenExchangeURL, bytes.NewReader(jsonBody))
-	if err != nil {
-		return "", fmt.Errorf("failed to create token exchange request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("failed to exchange token: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("failed to read token exchange response: %w", err)
-	}
-
-	if resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+func parseSubjectTokenExchangeResponse(statusCode int, body []byte) (exchangedToken, error) {
+	if statusCode == http.StatusBadRequest || statusCode == http.StatusUnauthorized || statusCode == http.StatusForbidden {
 		var oauthErr struct {
 			Error            string `json:"error"`
 			ErrorDescription string `json:"error_description"`
 		}
 		if json.Unmarshal(body, &oauthErr) == nil {
-			return "", &OAuthError{
-				StatusCode:       resp.StatusCode,
+			return exchangedToken{}, &OAuthError{
+				StatusCode:       statusCode,
 				ErrorCode:        shared.OAuthErrorCode(oauthErr.Error),
 				ErrorDescription: oauthErr.ErrorDescription,
 			}
 		}
 	}
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("token exchange failed with status %d: %s", resp.StatusCode, string(body))
+	if statusCode != http.StatusOK {
+		return exchangedToken{}, fmt.Errorf("token exchange failed with status %d: %s", statusCode, string(body))
 	}
 
 	var tokenResp TokenExchangeResponse
 	if err := json.Unmarshal(body, &tokenResp); err != nil {
-		return "", fmt.Errorf("failed to decode token exchange response: %w", err)
+		return exchangedToken{}, fmt.Errorf("failed to decode token exchange response: %w", err)
 	}
-
 	if tokenResp.AccessToken == "" {
-		return "", fmt.Errorf("token exchange response missing 'access_token' field. Response: %s", string(body))
+		return exchangedToken{}, fmt.Errorf("token exchange response missing 'access_token' field. Response: %s", string(body))
 	}
-
-	expiresIn := int(DefaultTokenExpiry / time.Second)
+	expiresIn := DefaultTokenExpiry
 	if tokenResp.ExpiresIn != nil {
-		expiresIn = *tokenResp.ExpiresIn
+		expiresIn = time.Duration(*tokenResp.ExpiresIn) * time.Second
 	}
-
-	// Atomically update cached token and expiry
-	w.mu.Lock()
-	w.cachedToken = tokenResp.AccessToken
-	w.tokenExpiry = time.Now().Add(time.Duration(expiresIn) * time.Second)
-	w.mu.Unlock()
-
-	return tokenResp.AccessToken, nil
+	return exchangedToken{accessToken: tokenResp.AccessToken, expiresIn: expiresIn}, nil
 }

--- a/auth/workloadidentity.go
+++ b/auth/workloadidentity.go
@@ -13,13 +13,13 @@ import (
 )
 
 const (
-	TokenExchangeGrantType         = "urn:ietf:params:oauth:grant-type:token-exchange"
-	JWTTokenType                   = "urn:ietf:params:oauth:token-type:jwt"
-	IDTokenType                    = "urn:ietf:params:oauth:token-type:id_token"
-	DefaultTokenExpiry             = 60 * time.Minute
-	DefaultRefreshBuffer           = 20 * time.Minute
-	TokenExchangeURL               = "https://auth.openai.com/oauth/token"
-	workloadIdentityRefreshTimeout = 30 * time.Second
+	TokenExchangeGrantType              = "urn:ietf:params:oauth:grant-type:token-exchange"
+	JWTTokenType                        = "urn:ietf:params:oauth:token-type:jwt"
+	IDTokenType                         = "urn:ietf:params:oauth:token-type:id_token"
+	DefaultTokenExpiry                  = 60 * time.Minute
+	DefaultRefreshBuffer                = 20 * time.Minute
+	TokenExchangeURL                    = "https://auth.openai.com/oauth/token"
+	subjectTokenWorkloadIdentityTimeout = 30 * time.Second
 )
 
 type workloadIdentityCredentialSourceKind uint8
@@ -77,6 +77,7 @@ type exchangedToken struct {
 type workloadIdentityCredentialSource interface {
 	exchange(context.Context, HTTPDoer, string, string) (exchangedToken, error)
 	refreshBuffer(time.Duration) time.Duration
+	refreshTimeout() time.Duration
 	kind() workloadIdentityCredentialSourceKind
 }
 
@@ -136,6 +137,10 @@ func (s subjectTokenCredentialSource) refreshBuffer(time.Duration) time.Duration
 		return DefaultRefreshBuffer
 	}
 	return s.refreshBefore
+}
+
+func (subjectTokenCredentialSource) refreshTimeout() time.Duration {
+	return subjectTokenWorkloadIdentityTimeout
 }
 
 func (subjectTokenCredentialSource) kind() workloadIdentityCredentialSourceKind {
@@ -280,7 +285,7 @@ func (w *WorkloadIdentityAuth) beginRefreshLocked() *tokenRefreshState {
 }
 
 func (w *WorkloadIdentityAuth) startSharedRefresh(state *tokenRefreshState, httpClient HTTPDoer) {
-	refreshCtx, cancel := context.WithTimeout(context.Background(), workloadIdentityRefreshTimeout)
+	refreshCtx, cancel := context.WithTimeout(context.Background(), w.source.refreshTimeout())
 	state.cancel = cancel
 	go func() {
 		defer cancel()

--- a/auth/workloadidentity.go
+++ b/auth/workloadidentity.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"reflect"
 	"sync"
 	"time"
 
@@ -12,12 +13,20 @@ import (
 )
 
 const (
-	TokenExchangeGrantType = "urn:ietf:params:oauth:grant-type:token-exchange"
-	JWTTokenType           = "urn:ietf:params:oauth:token-type:jwt"
-	IDTokenType            = "urn:ietf:params:oauth:token-type:id_token"
-	DefaultTokenExpiry     = 60 * time.Minute
-	DefaultRefreshBuffer   = 20 * time.Minute
-	TokenExchangeURL       = "https://auth.openai.com/oauth/token"
+	TokenExchangeGrantType         = "urn:ietf:params:oauth:grant-type:token-exchange"
+	JWTTokenType                   = "urn:ietf:params:oauth:token-type:jwt"
+	IDTokenType                    = "urn:ietf:params:oauth:token-type:id_token"
+	DefaultTokenExpiry             = 60 * time.Minute
+	DefaultRefreshBuffer           = 20 * time.Minute
+	TokenExchangeURL               = "https://auth.openai.com/oauth/token"
+	workloadIdentityRefreshTimeout = 30 * time.Second
+)
+
+type workloadIdentityCredentialSourceKind uint8
+
+const (
+	workloadIdentityCredentialSourceSubjectToken workloadIdentityCredentialSourceKind = iota + 1
+	workloadIdentityCredentialSourceX509
 )
 
 type WorkloadIdentityAuth struct {
@@ -25,8 +34,10 @@ type WorkloadIdentityAuth struct {
 	serviceAccountID   string
 	source             workloadIdentityCredentialSource
 
-	// Protects cachedToken, tokenExpiry, tokenRefreshAt, and refreshInFlight.
+	// Protects boundHTTPDoer, cachedToken, tokenExpiry, tokenRefreshAt, and
+	// refreshInFlight.
 	mu              sync.Mutex
+	boundHTTPDoer   HTTPDoer
 	cachedToken     string
 	tokenExpiry     time.Time
 	tokenRefreshAt  time.Time
@@ -43,8 +54,10 @@ type tokenRefreshResult struct {
 // Coordinates concurrent access to a single in-flight refresh operation
 // done channel signals completion to all waiting goroutines
 type tokenRefreshState struct {
-	done   chan struct{}
-	result tokenRefreshResult
+	done    chan struct{}
+	result  tokenRefreshResult
+	cancel  context.CancelFunc
+	waiters int
 }
 
 type subjectTokenExchangeRequest struct {
@@ -64,6 +77,7 @@ type exchangedToken struct {
 type workloadIdentityCredentialSource interface {
 	exchange(context.Context, HTTPDoer, string, string) (exchangedToken, error)
 	refreshBuffer(time.Duration) time.Duration
+	kind() workloadIdentityCredentialSourceKind
 }
 
 type subjectTokenCredentialSource struct {
@@ -124,6 +138,10 @@ func (s subjectTokenCredentialSource) refreshBuffer(time.Duration) time.Duration
 	return s.refreshBefore
 }
 
+func (subjectTokenCredentialSource) kind() workloadIdentityCredentialSourceKind {
+	return workloadIdentityCredentialSourceSubjectToken
+}
+
 func NewWorkloadIdentityAuth(config WorkloadIdentity) (*WorkloadIdentityAuth, error) {
 	if err := validateWorkloadIdentity("WorkloadIdentity", config.IdentityProviderID, config.ServiceAccountID); err != nil {
 		return nil, err
@@ -174,6 +192,10 @@ func (w *WorkloadIdentityAuth) GetToken(ctx context.Context, httpClient HTTPDoer
 
 	// Lock for entire decision: check cache, decide refresh strategy, potentially start background refresh
 	w.mu.Lock()
+	if err := w.bindHTTPDoerLocked(httpClient); err != nil {
+		w.mu.Unlock()
+		return "", err
+	}
 
 	if w.cachedToken == "" {
 		return w.handleLockedRefresh(ctx, httpClient)
@@ -187,12 +209,7 @@ func (w *WorkloadIdentityAuth) GetToken(ctx context.Context, httpClient HTTPDoer
 	// Proactive background refresh: start if within refresh window and no refresh active
 	if !now.Before(w.tokenRefreshAt) && w.refreshInFlight == nil {
 		state := w.beginRefreshLocked()
-		// Background goroutine with independent context, lock released before spawn
-		go func() {
-			refreshCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cancel()
-			w.finishRefresh(state, w.refreshToken(refreshCtx, httpClient))
-		}()
+		w.startSharedRefresh(state, httpClient)
 	}
 
 	token := w.cachedToken
@@ -203,8 +220,13 @@ func (w *WorkloadIdentityAuth) GetToken(ctx context.Context, httpClient HTTPDoer
 // Single-flight pattern: ensures only one refresh runs, others wait for result
 func (w *WorkloadIdentityAuth) handleLockedRefresh(ctx context.Context, httpClient HTTPDoer) (string, error) {
 	if w.refreshInFlight == nil {
-		// No refresh running: start foreground refresh, unlock before blocking operation
 		state := w.beginRefreshLocked()
+		if w.source.kind() == workloadIdentityCredentialSourceX509 {
+			w.startSharedRefresh(state, httpClient)
+			return w.waitForLockedRefresh(ctx, state)
+		}
+
+		// Preserve subject-token WIF's foreground context behavior.
 		w.mu.Unlock()
 		result := w.refreshToken(ctx, httpClient)
 		w.finishRefresh(state, result)
@@ -213,8 +235,32 @@ func (w *WorkloadIdentityAuth) handleLockedRefresh(ctx context.Context, httpClie
 
 	// Refresh already running: unlock and wait for its completion
 	state := w.refreshInFlight
+	return w.waitForLockedRefresh(ctx, state)
+}
+
+func (w *WorkloadIdentityAuth) waitForLockedRefresh(ctx context.Context, state *tokenRefreshState) (string, error) {
+	if state.cancel != nil {
+		state.waiters++
+	}
 	w.mu.Unlock()
 	return w.waitForRefresh(ctx, state)
+}
+
+func (w *WorkloadIdentityAuth) bindHTTPDoerLocked(httpClient HTTPDoer) error {
+	if w.source.kind() != workloadIdentityCredentialSourceX509 {
+		return nil
+	}
+	if !reflect.TypeOf(httpClient).Comparable() {
+		return fmt.Errorf("X.509 workload identity requires a comparable HTTP client")
+	}
+	if w.boundHTTPDoer == nil {
+		w.boundHTTPDoer = httpClient
+		return nil
+	}
+	if w.boundHTTPDoer != httpClient {
+		return fmt.Errorf("X.509 workload identity auth cannot change HTTP clients")
+	}
+	return nil
 }
 
 func (w *WorkloadIdentityAuth) invalidateToken(token string) {
@@ -231,6 +277,15 @@ func (w *WorkloadIdentityAuth) invalidateToken(token string) {
 func (w *WorkloadIdentityAuth) beginRefreshLocked() *tokenRefreshState {
 	w.refreshInFlight = &tokenRefreshState{done: make(chan struct{})}
 	return w.refreshInFlight
+}
+
+func (w *WorkloadIdentityAuth) startSharedRefresh(state *tokenRefreshState, httpClient HTTPDoer) {
+	refreshCtx, cancel := context.WithTimeout(context.Background(), workloadIdentityRefreshTimeout)
+	state.cancel = cancel
+	go func() {
+		defer cancel()
+		w.finishRefresh(state, w.refreshToken(refreshCtx, httpClient))
+	}()
 }
 
 // Atomically publishes refresh result and signals all waiting goroutines via channel close
@@ -256,7 +311,21 @@ func (w *WorkloadIdentityAuth) waitForRefresh(ctx context.Context, state *tokenR
 	case <-state.done: // Refresh completed
 		return state.result.token, state.result.err
 	case <-ctx.Done(): // Caller context canceled
+		w.cancelRefreshWaiter(state)
 		return "", ctx.Err()
+	}
+}
+
+func (w *WorkloadIdentityAuth) cancelRefreshWaiter(state *tokenRefreshState) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.refreshInFlight != state || state.cancel == nil {
+		return
+	}
+	state.waiters--
+	if state.waiters == 0 {
+		w.refreshInFlight = nil
+		state.cancel()
 	}
 }
 

--- a/auth/workloadidentity_internal_test.go
+++ b/auth/workloadidentity_internal_test.go
@@ -36,6 +36,22 @@ func TestTokenExchangeRetryDelayHonorsRetryAfter(t *testing.T) {
 		}
 	})
 
+	t.Run("far future date", func(t *testing.T) {
+		resp := &http.Response{Header: http.Header{"Retry-After": []string{"Fri, 31 Dec 9999 23:59:59 GMT"}}}
+		if got, want := tokenExchangeRetryDelay(resp, 0), tokenExchangeMaxRetryDelay; got != want {
+			t.Errorf("tokenExchangeRetryDelay() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("malformed values remain bounded", func(t *testing.T) {
+		for _, retryAfter := range []string{"1e999", "NaN", "+Inf", "-Inf", "+999999999999999999999", "-1"} {
+			resp := &http.Response{Header: http.Header{"Retry-After": []string{retryAfter}}}
+			if got := tokenExchangeRetryDelay(resp, 0); got < 0 || got > tokenExchangeMaxRetryDelay {
+				t.Errorf("tokenExchangeRetryDelay(%q) = %v, want a bounded delay", retryAfter, got)
+			}
+		}
+	})
+
 	t.Run("http date", func(t *testing.T) {
 		retryAt := time.Now().Add(5 * time.Second).UTC().Truncate(time.Second)
 		resp := &http.Response{Header: http.Header{"Retry-After": []string{retryAt.Format(http.TimeFormat)}}}
@@ -144,5 +160,40 @@ func TestX509CanceledLeaderDoesNotCancelSharedRefresh(t *testing.T) {
 	}
 	if got, want := calls.Load(), int32(1); got != want {
 		t.Errorf("token exchange calls = %d, want %d", got, want)
+	}
+}
+
+func TestX509SharedRefreshPreservesInitiatorContextValues(t *testing.T) {
+	type tenantContextKey struct{}
+	const tenant = "tenant-a"
+	httpClient := &internalHTTPDoer{do: func(req *http.Request) (*http.Response, error) {
+		if got := req.Context().Value(tenantContextKey{}); got != tenant {
+			return &http.Response{
+				StatusCode: http.StatusBadRequest,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"error":"missing_tenant"}`)),
+			}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"access_token":"tenant-token","expires_in":60}`)),
+		}, nil
+	}}
+	wia, err := NewX509WorkloadIdentityAuth(X509WorkloadIdentity{
+		IdentityProviderID: "idp-test",
+		ServiceAccountID:   "svc-test",
+	})
+	if err != nil {
+		t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
+	}
+	ctx := context.WithValue(t.Context(), tenantContextKey{}, tenant)
+
+	token, err := wia.GetToken(ctx, httpClient)
+	if err != nil {
+		t.Fatalf("GetToken() error = %v", err)
+	}
+	if got, want := token, "tenant-token"; got != want {
+		t.Fatalf("GetToken() = %q, want %q", got, want)
 	}
 }

--- a/auth/workloadidentity_internal_test.go
+++ b/auth/workloadidentity_internal_test.go
@@ -39,11 +39,33 @@ func TestTokenExchangeRetryDelayHonorsRetryAfter(t *testing.T) {
 	t.Run("http date", func(t *testing.T) {
 		retryAt := time.Now().Add(5 * time.Second).UTC().Truncate(time.Second)
 		resp := &http.Response{Header: http.Header{"Retry-After": []string{retryAt.Format(http.TimeFormat)}}}
+		before := time.Until(retryAt)
 		got := tokenExchangeRetryDelay(resp, 0)
-		if got < 4*time.Second || got > 5*time.Second {
-			t.Errorf("tokenExchangeRetryDelay() = %v, want between 4s and 5s", got)
+		after := time.Until(retryAt)
+		if got < after || got > before {
+			t.Errorf("tokenExchangeRetryDelay() = %v, want between %v and %v", got, after, before)
 		}
 	})
+}
+
+func TestX509RefreshTimeoutCoversRetryDelayBudget(t *testing.T) {
+	retryDelayBudget := tokenExchangeMaxRetryDelay * tokenExchangeMaxRetries
+	if x509WorkloadIdentityRefreshTimeout <= retryDelayBudget {
+		t.Fatalf(
+			"X.509 refresh timeout = %v, must exceed retry delay budget %v",
+			x509WorkloadIdentityRefreshTimeout,
+			retryDelayBudget,
+		)
+	}
+}
+
+func TestCredentialSourcesHaveIndependentRefreshTimeouts(t *testing.T) {
+	if got, want := (subjectTokenCredentialSource{}).refreshTimeout(), 30*time.Second; got != want {
+		t.Errorf("subject-token refresh timeout = %v, want %v", got, want)
+	}
+	if got, want := (x509CredentialSource{}).refreshTimeout(), x509WorkloadIdentityRefreshTimeout; got != want {
+		t.Errorf("X.509 refresh timeout = %v, want %v", got, want)
+	}
 }
 
 func TestX509CanceledLeaderDoesNotCancelSharedRefresh(t *testing.T) {

--- a/auth/workloadidentity_internal_test.go
+++ b/auth/workloadidentity_internal_test.go
@@ -235,6 +235,28 @@ func TestX509CanceledOnlyWaiterCancelsSharedRefresh(t *testing.T) {
 	}
 }
 
+func TestX509PreCanceledContextDoesNotStartRefresh(t *testing.T) {
+	exchangeStarted := make(chan struct{}, 1)
+	source := &internalX509CredentialSource{exchangeFunc: func(ctx context.Context) (exchangedToken, error) {
+		exchangeStarted <- struct{}{}
+		<-ctx.Done()
+		return exchangedToken{}, ctx.Err()
+	}}
+	wia := newWorkloadIdentityAuth("idp-test", "svc-test", source)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err := wia.GetToken(ctx, internalNativeX509HTTPClient())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("GetToken() error = %v, want context.Canceled", err)
+	}
+	select {
+	case <-exchangeStarted:
+		t.Fatal("token exchange started for an already-canceled context")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
 func TestX509SharedRefreshPreservesInitiatorContextValues(t *testing.T) {
 	type tenantContextKey struct{}
 	const tenant = "tenant-a"

--- a/auth/workloadidentity_internal_test.go
+++ b/auth/workloadidentity_internal_test.go
@@ -1,10 +1,23 @@
 package auth
 
 import (
+	"context"
+	"errors"
+	"io"
 	"net/http"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
+
+type internalHTTPDoer struct {
+	do func(*http.Request) (*http.Response, error)
+}
+
+func (d *internalHTTPDoer) Do(req *http.Request) (*http.Response, error) {
+	return d.do(req)
+}
 
 func TestTokenExchangeRetryDelayHonorsRetryAfter(t *testing.T) {
 	t.Run("seconds", func(t *testing.T) {
@@ -31,4 +44,83 @@ func TestTokenExchangeRetryDelayHonorsRetryAfter(t *testing.T) {
 			t.Errorf("tokenExchangeRetryDelay() = %v, want between 4s and 5s", got)
 		}
 	})
+}
+
+func TestX509CanceledLeaderDoesNotCancelSharedRefresh(t *testing.T) {
+	exchangeStarted := make(chan struct{})
+	releaseExchange := make(chan struct{})
+	var calls atomic.Int32
+	httpClient := &internalHTTPDoer{do: func(req *http.Request) (*http.Response, error) {
+		calls.Add(1)
+		close(exchangeStarted)
+		select {
+		case <-releaseExchange:
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"access_token":"shared-token","expires_in":60}`)),
+			}, nil
+		case <-req.Context().Done():
+			return nil, req.Context().Err()
+		}
+	}}
+	wia, err := NewX509WorkloadIdentityAuth(X509WorkloadIdentity{
+		IdentityProviderID: "idp-test",
+		ServiceAccountID:   "svc-test",
+	})
+	if err != nil {
+		t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
+	}
+	leaderCtx, cancelLeader := context.WithCancel(t.Context())
+	leaderDone := make(chan error, 1)
+	go func() {
+		_, getTokenErr := wia.GetToken(leaderCtx, httpClient)
+		leaderDone <- getTokenErr
+	}()
+	<-exchangeStarted
+
+	type tokenResult struct {
+		token string
+		err   error
+	}
+	waiterDone := make(chan tokenResult, 1)
+	go func() {
+		token, getTokenErr := wia.GetToken(t.Context(), httpClient)
+		waiterDone <- tokenResult{token: token, err: getTokenErr}
+	}()
+	deadline := time.Now().Add(time.Second)
+	for {
+		wia.mu.Lock()
+		waiters := wia.refreshInFlight.waiters
+		wia.mu.Unlock()
+		if waiters == 2 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for second refresh waiter")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	cancelLeader()
+	if err := <-leaderDone; !errors.Is(err, context.Canceled) {
+		t.Errorf("leader GetToken() error = %v, want context.Canceled", err)
+	}
+	select {
+	case result := <-waiterDone:
+		t.Fatalf("waiter completed before shared exchange release: %+v", result)
+	default:
+	}
+
+	close(releaseExchange)
+	result := <-waiterDone
+	if result.err != nil {
+		t.Fatalf("waiter GetToken() error = %v", result.err)
+	}
+	if got, want := result.token, "shared-token"; got != want {
+		t.Errorf("waiter GetToken() = %q, want %q", got, want)
+	}
+	if got, want := calls.Load(), int32(1); got != want {
+		t.Errorf("token exchange calls = %d, want %d", got, want)
+	}
 }

--- a/auth/workloadidentity_internal_test.go
+++ b/auth/workloadidentity_internal_test.go
@@ -1,0 +1,34 @@
+package auth
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestTokenExchangeRetryDelayHonorsRetryAfter(t *testing.T) {
+	t.Run("seconds", func(t *testing.T) {
+		resp := &http.Response{Header: http.Header{"Retry-After": []string{"2"}}}
+		if got, want := tokenExchangeRetryDelay(resp, 0), 2*time.Second; got != want {
+			t.Errorf("tokenExchangeRetryDelay() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("capped", func(t *testing.T) {
+		for _, retryAfter := range []string{"120", "1e300"} {
+			resp := &http.Response{Header: http.Header{"Retry-After": []string{retryAfter}}}
+			if got, want := tokenExchangeRetryDelay(resp, 0), tokenExchangeMaxRetryDelay; got != want {
+				t.Errorf("tokenExchangeRetryDelay(%q) = %v, want %v", retryAfter, got, want)
+			}
+		}
+	})
+
+	t.Run("http date", func(t *testing.T) {
+		retryAt := time.Now().Add(5 * time.Second).UTC().Truncate(time.Second)
+		resp := &http.Response{Header: http.Header{"Retry-After": []string{retryAt.Format(http.TimeFormat)}}}
+		got := tokenExchangeRetryDelay(resp, 0)
+		if got < 4*time.Second || got > 5*time.Second {
+			t.Errorf("tokenExchangeRetryDelay() = %v, want between 4s and 5s", got)
+		}
+	})
+}

--- a/auth/workloadidentity_internal_test.go
+++ b/auth/workloadidentity_internal_test.go
@@ -2,14 +2,41 @@ package auth
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
-	"io"
 	"net/http"
-	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 )
+
+type x509RefreshGenerationSource struct {
+	calls         atomic.Int32
+	firstStarted  chan struct{}
+	firstCanceled chan struct{}
+}
+
+func (s *x509RefreshGenerationSource) exchange(ctx context.Context, _ HTTPDoer, _, _ string) (exchangedToken, error) {
+	if s.calls.Add(1) == 1 {
+		close(s.firstStarted)
+		<-ctx.Done()
+		close(s.firstCanceled)
+		return exchangedToken{}, ctx.Err()
+	}
+	return exchangedToken{accessToken: "replacement-token", expiresIn: time.Hour}, nil
+}
+
+func (*x509RefreshGenerationSource) refreshBuffer(time.Duration) time.Duration {
+	return time.Minute
+}
+
+func (*x509RefreshGenerationSource) refreshTimeout() time.Duration {
+	return time.Minute
+}
+
+func (*x509RefreshGenerationSource) kind() workloadIdentityCredentialSourceKind {
+	return workloadIdentityCredentialSourceX509
+}
 
 type internalHTTPDoer struct {
 	do func(*http.Request) (*http.Response, error)
@@ -17,6 +44,32 @@ type internalHTTPDoer struct {
 
 func (d *internalHTTPDoer) Do(req *http.Request) (*http.Response, error) {
 	return d.do(req)
+}
+
+type internalX509CredentialSource struct {
+	exchangeFunc func(context.Context) (exchangedToken, error)
+}
+
+func (s *internalX509CredentialSource) exchange(ctx context.Context, _ HTTPDoer, _, _ string) (exchangedToken, error) {
+	return s.exchangeFunc(ctx)
+}
+
+func (*internalX509CredentialSource) refreshBuffer(time.Duration) time.Duration {
+	return time.Minute
+}
+
+func (*internalX509CredentialSource) refreshTimeout() time.Duration {
+	return time.Minute
+}
+
+func (*internalX509CredentialSource) kind() workloadIdentityCredentialSourceKind {
+	return workloadIdentityCredentialSourceX509
+}
+
+func internalNativeX509HTTPClient() *http.Client {
+	return &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{
+		Certificates: []tls.Certificate{{Certificate: [][]byte{{1}}}},
+	}}}
 }
 
 func TestTokenExchangeRetryDelayHonorsRetryAfter(t *testing.T) {
@@ -88,27 +141,18 @@ func TestX509CanceledLeaderDoesNotCancelSharedRefresh(t *testing.T) {
 	exchangeStarted := make(chan struct{})
 	releaseExchange := make(chan struct{})
 	var calls atomic.Int32
-	httpClient := &internalHTTPDoer{do: func(req *http.Request) (*http.Response, error) {
+	source := &internalX509CredentialSource{exchangeFunc: func(ctx context.Context) (exchangedToken, error) {
 		calls.Add(1)
 		close(exchangeStarted)
 		select {
 		case <-releaseExchange:
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Header:     http.Header{"Content-Type": []string{"application/json"}},
-				Body:       io.NopCloser(strings.NewReader(`{"access_token":"shared-token","expires_in":60}`)),
-			}, nil
-		case <-req.Context().Done():
-			return nil, req.Context().Err()
+			return exchangedToken{accessToken: "shared-token", expiresIn: time.Minute}, nil
+		case <-ctx.Done():
+			return exchangedToken{}, ctx.Err()
 		}
 	}}
-	wia, err := NewX509WorkloadIdentityAuth(X509WorkloadIdentity{
-		IdentityProviderID: "idp-test",
-		ServiceAccountID:   "svc-test",
-	})
-	if err != nil {
-		t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
-	}
+	httpClient := internalNativeX509HTTPClient()
+	wia := newWorkloadIdentityAuth("idp-test", "svc-test", source)
 	leaderCtx, cancelLeader := context.WithCancel(t.Context())
 	leaderDone := make(chan error, 1)
 	go func() {
@@ -163,30 +207,45 @@ func TestX509CanceledLeaderDoesNotCancelSharedRefresh(t *testing.T) {
 	}
 }
 
+func TestX509CanceledOnlyWaiterCancelsSharedRefresh(t *testing.T) {
+	exchangeStarted := make(chan struct{})
+	exchangeCanceled := make(chan struct{})
+	source := &internalX509CredentialSource{exchangeFunc: func(ctx context.Context) (exchangedToken, error) {
+		close(exchangeStarted)
+		<-ctx.Done()
+		close(exchangeCanceled)
+		return exchangedToken{}, ctx.Err()
+	}}
+	wia := newWorkloadIdentityAuth("idp-test", "svc-test", source)
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() {
+		_, getTokenErr := wia.GetToken(ctx, internalNativeX509HTTPClient())
+		done <- getTokenErr
+	}()
+	<-exchangeStarted
+	cancel()
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Errorf("GetToken() error = %v, want context.Canceled", err)
+	}
+	select {
+	case <-exchangeCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("shared exchange context was not canceled")
+	}
+}
+
 func TestX509SharedRefreshPreservesInitiatorContextValues(t *testing.T) {
 	type tenantContextKey struct{}
 	const tenant = "tenant-a"
-	httpClient := &internalHTTPDoer{do: func(req *http.Request) (*http.Response, error) {
-		if got := req.Context().Value(tenantContextKey{}); got != tenant {
-			return &http.Response{
-				StatusCode: http.StatusBadRequest,
-				Header:     make(http.Header),
-				Body:       io.NopCloser(strings.NewReader(`{"error":"missing_tenant"}`)),
-			}, nil
+	source := &internalX509CredentialSource{exchangeFunc: func(ctx context.Context) (exchangedToken, error) {
+		if got := ctx.Value(tenantContextKey{}); got != tenant {
+			return exchangedToken{}, errors.New("missing tenant context")
 		}
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Header:     http.Header{"Content-Type": []string{"application/json"}},
-			Body:       io.NopCloser(strings.NewReader(`{"access_token":"tenant-token","expires_in":60}`)),
-		}, nil
+		return exchangedToken{accessToken: "tenant-token", expiresIn: time.Minute}, nil
 	}}
-	wia, err := NewX509WorkloadIdentityAuth(X509WorkloadIdentity{
-		IdentityProviderID: "idp-test",
-		ServiceAccountID:   "svc-test",
-	})
-	if err != nil {
-		t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
-	}
+	httpClient := internalNativeX509HTTPClient()
+	wia := newWorkloadIdentityAuth("idp-test", "svc-test", source)
 	ctx := context.WithValue(t.Context(), tenantContextKey{}, tenant)
 
 	token, err := wia.GetToken(ctx, httpClient)
@@ -195,5 +254,48 @@ func TestX509SharedRefreshPreservesInitiatorContextValues(t *testing.T) {
 	}
 	if got, want := token, "tenant-token"; got != want {
 		t.Fatalf("GetToken() = %q, want %q", got, want)
+	}
+}
+
+func TestX509InvalidationCancelsObsoleteProactiveRefresh(t *testing.T) {
+	source := &x509RefreshGenerationSource{
+		firstStarted:  make(chan struct{}),
+		firstCanceled: make(chan struct{}),
+	}
+	wia := newWorkloadIdentityAuth("idp-test", "svc-test", source)
+	wia.cachedToken = "stale-token"
+	wia.tokenExpiry = time.Now().Add(time.Hour)
+	wia.tokenRefreshAt = time.Now().Add(-time.Second)
+	wia.tokenGeneration = 1
+	httpClient := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{
+		Certificates: []tls.Certificate{{Certificate: [][]byte{{1}}}},
+	}}}
+
+	token, err := wia.GetToken(t.Context(), httpClient)
+	if err != nil {
+		t.Fatalf("proactive GetToken() error = %v", err)
+	}
+	if token != "stale-token" {
+		t.Fatalf("proactive GetToken() = %q, want stale-token", token)
+	}
+	<-source.firstStarted
+
+	wia.invalidateToken("stale-token")
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	token, err = wia.GetToken(ctx, httpClient)
+	if err != nil {
+		t.Fatalf("forced GetToken() error = %v", err)
+	}
+	if token != "replacement-token" {
+		t.Fatalf("forced GetToken() = %q, want replacement-token", token)
+	}
+	select {
+	case <-source.firstCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("obsolete proactive refresh was not canceled")
+	}
+	if got, want := source.calls.Load(), int32(2); got != want {
+		t.Fatalf("exchange calls = %d, want %d", got, want)
 	}
 }

--- a/auth/workloadidentity_test.go
+++ b/auth/workloadidentity_test.go
@@ -57,18 +57,14 @@ func (t *closureTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	return t.fn(req)
 }
 
-func mockOAuthServer(responseBody string, statusCode int) *http.Client {
-	return &http.Client{
-		Transport: &closureTransport{
-			fn: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: statusCode,
-					Body:       io.NopCloser(strings.NewReader(responseBody)),
-					Header:     make(http.Header),
-				}, nil
-			},
-		},
-	}
+func mockOAuthServer(t *testing.T, responseBody string, statusCode int) *http.Client {
+	return nativeX509HTTPClient(t, func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: statusCode,
+			Body:       io.NopCloser(strings.NewReader(responseBody)),
+			Header:     make(http.Header),
+		}, nil
+	})
 }
 
 func TestWorkloadIdentityClientIDOptional(t *testing.T) {
@@ -175,7 +171,7 @@ func TestTokenCaching(t *testing.T) {
 	}
 
 	responseBody := `{"access_token": "exchanged-token-123", "expires_in": 3600}`
-	httpClient := mockOAuthServer(responseBody, 200)
+	httpClient := mockOAuthServer(t, responseBody, 200)
 
 	config := auth.WorkloadIdentity{ClientID: "client-id", IdentityProviderID: "idp-id", ServiceAccountID: "sa-id", Provider: provider}
 	wa, err := auth.NewWorkloadIdentityAuth(config)
@@ -431,7 +427,7 @@ func TestOAuthErrorHandling(t *testing.T) {
 
 	for _, tc := range testCases {
 		errorBody := `{"error": "invalid_grant", "error_description": "Token exchange failed"}`
-		httpClient := mockOAuthServer(errorBody, tc.statusCode)
+		httpClient := mockOAuthServer(t, errorBody, tc.statusCode)
 
 		config := auth.WorkloadIdentity{ClientID: "client-id", IdentityProviderID: "idp-id", ServiceAccountID: "sa-id", Provider: provider}
 		wa, err := auth.NewWorkloadIdentityAuth(config)
@@ -473,7 +469,7 @@ func TestDefaultValues(t *testing.T) {
 	}
 
 	responseBody := `{"access_token": "test-token"}`
-	httpClient := mockOAuthServer(responseBody, 200)
+	httpClient := mockOAuthServer(t, responseBody, 200)
 
 	config := auth.WorkloadIdentity{ClientID: "client-id", IdentityProviderID: "idp-id", ServiceAccountID: "sa-id", Provider: provider}
 	wa, err := auth.NewWorkloadIdentityAuth(config)

--- a/auth/x509_native_transport_test.go
+++ b/auth/x509_native_transport_test.go
@@ -1,0 +1,12 @@
+package auth_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/openai/openai-go/v3/internal/testutil"
+)
+
+func nativeX509HTTPClient(t testing.TB, roundTrip func(*http.Request) (*http.Response, error)) *http.Client {
+	return testutil.NewNativeX509HTTPClient(t, roundTrip)
+}

--- a/auth/x509workloadidentity.go
+++ b/auth/x509workloadidentity.go
@@ -2,7 +2,9 @@ package auth
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"net/http"
@@ -34,6 +36,11 @@ type x509CredentialSource struct {
 	refreshBefore time.Duration
 }
 
+type x509HTTPTransportIdentity struct {
+	native            bool
+	certificateSHA256 [sha256.Size]byte
+}
+
 // x509TokenExchangeError prevents the generic API request loop from repeating
 // an exchange that has already exhausted the X.509 exchange retry policy.
 type x509TokenExchangeError struct {
@@ -54,7 +61,9 @@ func noRetryX509TokenExchangeError(err error) error {
 // NewX509WorkloadIdentityAuth creates the HTTP authentication state for an
 // X.509 workload identity. Token exchange remains lazy until GetToken is called.
 // The state binds to the first comparable HTTPDoer used and rejects later doer
-// changes so cached tokens cannot cross certificate-backed transports.
+// changes so cached tokens cannot cross certificate-backed transports. A native
+// *http.Transport must use exactly one static client certificate; replace the
+// transport rather than mutating it when rotating the identity.
 func NewX509WorkloadIdentityAuth(config X509WorkloadIdentity) (*WorkloadIdentityAuth, error) {
 	if err := validateWorkloadIdentity("X509WorkloadIdentity", config.IdentityProviderID, config.ServiceAccountID); err != nil {
 		return nil, err
@@ -67,6 +76,25 @@ func NewX509WorkloadIdentityAuth(config X509WorkloadIdentity) (*WorkloadIdentity
 		config.ServiceAccountID,
 		x509CredentialSource{refreshBefore: config.RefreshBuffer},
 	), nil
+}
+
+func x509HTTPTransportIdentityFor(roundTripper http.RoundTripper) (x509HTTPTransportIdentity, error) {
+	transport, ok := roundTripper.(*http.Transport)
+	if !ok {
+		return x509HTTPTransportIdentity{}, nil
+	}
+	legacyTLSDialConfigured := transport.DialTLS != nil //nolint:staticcheck // Reject a legacy hook that can select another client identity.
+	tlsConfig := transport.TLSClientConfig
+	if tlsConfig != nil && len(tlsConfig.Certificates) == 1 &&
+		len(tlsConfig.Certificates[0].Certificate) != 0 &&
+		tlsConfig.GetClientCertificate == nil &&
+		!legacyTLSDialConfigured && transport.DialTLSContext == nil {
+		return x509HTTPTransportIdentity{
+			native:            true,
+			certificateSHA256: sha256.Sum256(tlsConfig.Certificates[0].Certificate[0]),
+		}, nil
+	}
+	return x509HTTPTransportIdentity{}, errors.New("X.509 workload identity requires one immutable client identity per native HTTP transport; configure exactly one static TLS certificate without TLS dial or certificate-selection hooks, and replace the transport to rotate identities")
 }
 
 func (s x509CredentialSource) exchange(

--- a/auth/x509workloadidentity.go
+++ b/auth/x509workloadidentity.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/openai/openai-go/v3/internal"
 )
 
 const (
@@ -37,23 +39,6 @@ type x509CredentialSource struct {
 }
 
 var errX509NativeHTTPTransport = errors.New("X.509 workload identity requires an *http.Client with a native *http.Transport so its client identity can be verified")
-
-// x509TokenExchangeError prevents the generic API request loop from repeating
-// an exchange that has already exhausted the X.509 exchange retry policy.
-type x509TokenExchangeError struct {
-	err error
-}
-
-func (e *x509TokenExchangeError) Error() string { return e.err.Error() }
-func (e *x509TokenExchangeError) Unwrap() error { return e.err }
-func (e *x509TokenExchangeError) NoRetry()      {}
-
-func noRetryX509TokenExchangeError(err error) error {
-	if err == nil {
-		return nil
-	}
-	return &x509TokenExchangeError{err: err}
-}
 
 // NewX509WorkloadIdentityAuth creates the HTTP authentication state for an
 // X.509 workload identity. Token exchange remains lazy until GetToken is called.
@@ -102,7 +87,7 @@ func (s x509CredentialSource) exchange(
 		ServiceAccountID:   serviceAccountID,
 	})
 	if err != nil {
-		return exchangedToken{}, noRetryX509TokenExchangeError(fmt.Errorf("failed to marshal token exchange request: %w", err))
+		return exchangedToken{}, internal.WithNoRetryError(fmt.Errorf("failed to marshal token exchange request: %w", err))
 	}
 	httpClient = withoutRedirects(httpClient)
 	for retry := 0; ; retry++ {
@@ -113,23 +98,23 @@ func (s x509CredentialSource) exchange(
 			if readErr == nil {
 				token, parseErr := parseX509TokenExchangeResponse(resp.StatusCode, responseBody)
 				if parseErr == nil || !shouldRetryTokenExchange(resp, nil) || retry >= tokenExchangeMaxRetries {
-					return token, noRetryX509TokenExchangeError(parseErr)
+					return token, internal.WithNoRetryError(parseErr)
 				}
 			} else {
 				if resp.StatusCode != http.StatusOK && !shouldRetryTokenExchange(resp, nil) {
 					_, statusErr := parseX509TokenExchangeResponse(resp.StatusCode, nil)
-					return exchangedToken{}, noRetryX509TokenExchangeError(statusErr)
+					return exchangedToken{}, internal.WithNoRetryError(statusErr)
 				}
 				if retry >= tokenExchangeMaxRetries {
-					return exchangedToken{}, noRetryX509TokenExchangeError(readErr)
+					return exchangedToken{}, internal.WithNoRetryError(readErr)
 				}
 			}
 		} else if retry >= tokenExchangeMaxRetries {
-			return exchangedToken{}, noRetryX509TokenExchangeError(exchangeErr)
+			return exchangedToken{}, internal.WithNoRetryError(exchangeErr)
 		}
 
 		if err := waitForTokenExchangeRetry(ctx, tokenExchangeRetryDelay(resp, retry)); err != nil {
-			return exchangedToken{}, noRetryX509TokenExchangeError(err)
+			return exchangedToken{}, internal.WithNoRetryError(err)
 		}
 	}
 }

--- a/auth/x509workloadidentity.go
+++ b/auth/x509workloadidentity.go
@@ -115,8 +115,14 @@ func (s x509CredentialSource) exchange(
 				if parseErr == nil || !shouldRetryTokenExchange(resp, nil) || retry >= tokenExchangeMaxRetries {
 					return token, noRetryX509TokenExchangeError(parseErr)
 				}
-			} else if retry >= tokenExchangeMaxRetries {
-				return exchangedToken{}, noRetryX509TokenExchangeError(readErr)
+			} else {
+				if resp.StatusCode != http.StatusOK && !shouldRetryTokenExchange(resp, nil) {
+					_, statusErr := parseX509TokenExchangeResponse(resp.StatusCode, nil)
+					return exchangedToken{}, noRetryX509TokenExchangeError(statusErr)
+				}
+				if retry >= tokenExchangeMaxRetries {
+					return exchangedToken{}, noRetryX509TokenExchangeError(readErr)
+				}
 			}
 		} else if retry >= tokenExchangeMaxRetries {
 			return exchangedToken{}, noRetryX509TokenExchangeError(exchangeErr)

--- a/auth/x509workloadidentity.go
+++ b/auth/x509workloadidentity.go
@@ -29,6 +29,23 @@ type x509CredentialSource struct {
 	refreshBefore time.Duration
 }
 
+// x509TokenExchangeError prevents the generic API request loop from repeating
+// an exchange that has already exhausted the X.509 exchange retry policy.
+type x509TokenExchangeError struct {
+	err error
+}
+
+func (e *x509TokenExchangeError) Error() string { return e.err.Error() }
+func (e *x509TokenExchangeError) Unwrap() error { return e.err }
+func (e *x509TokenExchangeError) NoRetry()      {}
+
+func noRetryX509TokenExchangeError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &x509TokenExchangeError{err: err}
+}
+
 // NewX509WorkloadIdentityAuth creates the HTTP authentication state for an
 // X.509 workload identity. Token exchange remains lazy until GetToken is called.
 func NewX509WorkloadIdentityAuth(config X509WorkloadIdentity) (*WorkloadIdentityAuth, error) {
@@ -58,7 +75,7 @@ func (s x509CredentialSource) exchange(
 		ServiceAccountID:   serviceAccountID,
 	})
 	if err != nil {
-		return exchangedToken{}, fmt.Errorf("failed to marshal token exchange request: %w", err)
+		return exchangedToken{}, noRetryX509TokenExchangeError(fmt.Errorf("failed to marshal token exchange request: %w", err))
 	}
 	resp, err := exchangeToken(
 		ctx,
@@ -68,14 +85,15 @@ func (s x509CredentialSource) exchange(
 		tokenExchangeMaxRetries,
 	)
 	if err != nil {
-		return exchangedToken{}, err
+		return exchangedToken{}, noRetryX509TokenExchangeError(err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	responseBody, err := readTokenExchangeResponse(resp.Body, tokenExchangeResponseBodySize)
 	if err != nil {
-		return exchangedToken{}, err
+		return exchangedToken{}, noRetryX509TokenExchangeError(err)
 	}
-	return parseX509TokenExchangeResponse(resp.StatusCode, responseBody)
+	token, err := parseX509TokenExchangeResponse(resp.StatusCode, responseBody)
+	return token, noRetryX509TokenExchangeError(err)
 }
 
 func (s x509CredentialSource) refreshBuffer(expiresIn time.Duration) time.Duration {

--- a/auth/x509workloadidentity.go
+++ b/auth/x509workloadidentity.go
@@ -48,6 +48,8 @@ func noRetryX509TokenExchangeError(err error) error {
 
 // NewX509WorkloadIdentityAuth creates the HTTP authentication state for an
 // X.509 workload identity. Token exchange remains lazy until GetToken is called.
+// The state binds to the first comparable HTTPDoer used and rejects later doer
+// changes so cached tokens cannot cross certificate-backed transports.
 func NewX509WorkloadIdentityAuth(config X509WorkloadIdentity) (*WorkloadIdentityAuth, error) {
 	if err := validateWorkloadIdentity("X509WorkloadIdentity", config.IdentityProviderID, config.ServiceAccountID); err != nil {
 		return nil, err
@@ -102,6 +104,10 @@ func (s x509CredentialSource) refreshBuffer(expiresIn time.Duration) time.Durati
 		refreshBefore = DefaultRefreshBuffer
 	}
 	return min(refreshBefore, expiresIn/2)
+}
+
+func (x509CredentialSource) kind() workloadIdentityCredentialSourceKind {
+	return workloadIdentityCredentialSourceX509
 }
 
 func parseX509TokenExchangeResponse(statusCode int, body []byte) (exchangedToken, error) {

--- a/auth/x509workloadidentity.go
+++ b/auth/x509workloadidentity.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -35,6 +36,8 @@ type x509CredentialSource struct {
 	refreshBefore time.Duration
 }
 
+var errX509NativeHTTPTransport = errors.New("X.509 workload identity requires an *http.Client with a native *http.Transport so its client identity can be verified")
+
 // x509TokenExchangeError prevents the generic API request loop from repeating
 // an exchange that has already exhausted the X.509 exchange retry policy.
 type x509TokenExchangeError struct {
@@ -54,10 +57,11 @@ func noRetryX509TokenExchangeError(err error) error {
 
 // NewX509WorkloadIdentityAuth creates the HTTP authentication state for an
 // X.509 workload identity. Token exchange remains lazy until GetToken is called.
-// The state binds to the first comparable HTTPDoer used and rejects later doer
-// changes so cached tokens cannot cross certificate-backed transports. A native
-// *http.Transport must use exactly one static client certificate; replace the
-// transport rather than mutating it when rotating the identity.
+// The state binds to the first *http.Client used and rejects later client or
+// transport changes so cached tokens cannot cross certificate-backed
+// transports. Its native *http.Transport must use exactly one static client
+// certificate with client session resumption disabled; replace the transport
+// rather than mutating it when rotating the identity.
 func NewX509WorkloadIdentityAuth(config X509WorkloadIdentity) (*WorkloadIdentityAuth, error) {
 	if err := validateWorkloadIdentity("X509WorkloadIdentity", config.IdentityProviderID, config.ServiceAccountID); err != nil {
 		return nil, err
@@ -72,20 +76,17 @@ func NewX509WorkloadIdentityAuth(config X509WorkloadIdentity) (*WorkloadIdentity
 	), nil
 }
 
-func validateX509HTTPTransportIdentity(roundTripper http.RoundTripper) error {
-	transport, ok := roundTripper.(*http.Transport)
-	if !ok {
-		return nil
-	}
+func x509HTTPTransportIdentity(transport *http.Transport) ([sha256.Size]byte, error) {
 	legacyTLSDialConfigured := transport.DialTLS != nil //nolint:staticcheck // Reject a legacy hook that can select another client identity.
 	tlsConfig := transport.TLSClientConfig
 	if tlsConfig != nil && len(tlsConfig.Certificates) == 1 &&
 		len(tlsConfig.Certificates[0].Certificate) != 0 &&
 		tlsConfig.GetClientCertificate == nil &&
+		tlsConfig.ClientSessionCache == nil &&
 		!legacyTLSDialConfigured && transport.DialTLSContext == nil {
-		return nil
+		return sha256.Sum256(tlsConfig.Certificates[0].Certificate[0]), nil
 	}
-	return errors.New("X.509 workload identity requires one immutable client identity per native HTTP transport; configure exactly one static TLS certificate without TLS dial or certificate-selection hooks, and replace the transport to rotate identities")
+	return [sha256.Size]byte{}, errors.New("X.509 workload identity requires one immutable client identity per native HTTP transport; configure exactly one static TLS certificate without TLS dial hooks, certificate-selection hooks, or client session caching, and replace the transport to rotate identities")
 }
 
 func (s x509CredentialSource) exchange(
@@ -103,23 +104,28 @@ func (s x509CredentialSource) exchange(
 	if err != nil {
 		return exchangedToken{}, noRetryX509TokenExchangeError(fmt.Errorf("failed to marshal token exchange request: %w", err))
 	}
-	resp, err := exchangeToken(
-		ctx,
-		withoutRedirects(httpClient),
-		x509TokenExchangeURL,
-		body,
-		tokenExchangeMaxRetries,
-	)
-	if err != nil {
-		return exchangedToken{}, noRetryX509TokenExchangeError(err)
+	httpClient = withoutRedirects(httpClient)
+	for retry := 0; ; retry++ {
+		resp, exchangeErr := exchangeToken(ctx, httpClient, x509TokenExchangeURL, body, 0)
+		if exchangeErr == nil {
+			responseBody, readErr := readTokenExchangeResponse(resp.Body, tokenExchangeResponseBodySize)
+			_ = resp.Body.Close()
+			if readErr == nil {
+				token, parseErr := parseX509TokenExchangeResponse(resp.StatusCode, responseBody)
+				if parseErr == nil || !shouldRetryTokenExchange(resp, nil) || retry >= tokenExchangeMaxRetries {
+					return token, noRetryX509TokenExchangeError(parseErr)
+				}
+			} else if retry >= tokenExchangeMaxRetries {
+				return exchangedToken{}, noRetryX509TokenExchangeError(readErr)
+			}
+		} else if retry >= tokenExchangeMaxRetries {
+			return exchangedToken{}, noRetryX509TokenExchangeError(exchangeErr)
+		}
+
+		if err := waitForTokenExchangeRetry(ctx, tokenExchangeRetryDelay(resp, retry)); err != nil {
+			return exchangedToken{}, noRetryX509TokenExchangeError(err)
+		}
 	}
-	defer func() { _ = resp.Body.Close() }()
-	responseBody, err := readTokenExchangeResponse(resp.Body, tokenExchangeResponseBodySize)
-	if err != nil {
-		return exchangedToken{}, noRetryX509TokenExchangeError(err)
-	}
-	token, err := parseX509TokenExchangeResponse(resp.StatusCode, responseBody)
-	return token, noRetryX509TokenExchangeError(err)
 }
 
 func (s x509CredentialSource) refreshBuffer(expiresIn time.Duration) time.Duration {

--- a/auth/x509workloadidentity.go
+++ b/auth/x509workloadidentity.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -129,8 +130,9 @@ func parseX509TokenExchangeResponse(statusCode int, body []byte) (exchangedToken
 	}
 
 	var tokenResp struct {
-		AccessToken string   `json:"access_token"`
-		ExpiresIn   *float64 `json:"expires_in"`
+		AccessToken string          `json:"access_token"`
+		ExpiresIn   *float64        `json:"expires_in"`
+		TokenType   json.RawMessage `json:"token_type"`
 	}
 	if err := json.Unmarshal(body, &tokenResp); err != nil {
 		return exchangedToken{}, fmt.Errorf("failed to decode token exchange response: %w", err)
@@ -147,10 +149,42 @@ func parseX509TokenExchangeResponse(statusCode int, body []byte) (exchangedToken
 	if expiresIn <= 0 {
 		return exchangedToken{}, fmt.Errorf("token exchange response requires a positive numeric 'expires_in' field")
 	}
-	if tokenResp.AccessToken == "" {
-		return exchangedToken{}, fmt.Errorf("token exchange response missing 'access_token' field")
+	if len(tokenResp.TokenType) != 0 {
+		var tokenType string
+		if tokenResp.TokenType[0] != '"' || json.Unmarshal(tokenResp.TokenType, &tokenType) != nil ||
+			!strings.EqualFold(tokenType, "Bearer") {
+			return exchangedToken{}, fmt.Errorf("token exchange response has invalid 'token_type' field")
+		}
+	}
+	if !validBearerAccessToken(tokenResp.AccessToken) {
+		return exchangedToken{}, fmt.Errorf("token exchange response has invalid 'access_token' field")
 	}
 	return exchangedToken{accessToken: tokenResp.AccessToken, expiresIn: expiresIn}, nil
+}
+
+func validBearerAccessToken(token string) bool {
+	if token == "" {
+		return false
+	}
+	padding := false
+	for i := range len(token) {
+		character := token[i]
+		switch {
+		case character == '=':
+			padding = true
+		case character >= 'a' && character <= 'z',
+			character >= 'A' && character <= 'Z',
+			character >= '0' && character <= '9',
+			character == '-', character == '.', character == '_', character == '~',
+			character == '+', character == '/':
+			if padding {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return token[0] != '='
 }
 
 func withoutRedirects(httpClient HTTPDoer) HTTPDoer {
@@ -159,6 +193,7 @@ func withoutRedirects(httpClient HTTPDoer) HTTPDoer {
 		return httpClient
 	}
 	clone := *client
+	clone.Jar = nil
 	clone.CheckRedirect = func(*http.Request, []*http.Request) error {
 		return http.ErrUseLastResponse
 	}

--- a/auth/x509workloadidentity.go
+++ b/auth/x509workloadidentity.go
@@ -2,7 +2,6 @@ package auth
 
 import (
 	"context"
-	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -34,11 +33,6 @@ type x509TokenExchangeRequest struct {
 
 type x509CredentialSource struct {
 	refreshBefore time.Duration
-}
-
-type x509HTTPTransportIdentity struct {
-	native            bool
-	certificateSHA256 [sha256.Size]byte
 }
 
 // x509TokenExchangeError prevents the generic API request loop from repeating
@@ -78,10 +72,10 @@ func NewX509WorkloadIdentityAuth(config X509WorkloadIdentity) (*WorkloadIdentity
 	), nil
 }
 
-func x509HTTPTransportIdentityFor(roundTripper http.RoundTripper) (x509HTTPTransportIdentity, error) {
+func validateX509HTTPTransportIdentity(roundTripper http.RoundTripper) error {
 	transport, ok := roundTripper.(*http.Transport)
 	if !ok {
-		return x509HTTPTransportIdentity{}, nil
+		return nil
 	}
 	legacyTLSDialConfigured := transport.DialTLS != nil //nolint:staticcheck // Reject a legacy hook that can select another client identity.
 	tlsConfig := transport.TLSClientConfig
@@ -89,12 +83,9 @@ func x509HTTPTransportIdentityFor(roundTripper http.RoundTripper) (x509HTTPTrans
 		len(tlsConfig.Certificates[0].Certificate) != 0 &&
 		tlsConfig.GetClientCertificate == nil &&
 		!legacyTLSDialConfigured && transport.DialTLSContext == nil {
-		return x509HTTPTransportIdentity{
-			native:            true,
-			certificateSHA256: sha256.Sum256(tlsConfig.Certificates[0].Certificate[0]),
-		}, nil
+		return nil
 	}
-	return x509HTTPTransportIdentity{}, errors.New("X.509 workload identity requires one immutable client identity per native HTTP transport; configure exactly one static TLS certificate without TLS dial or certificate-selection hooks, and replace the transport to rotate identities")
+	return errors.New("X.509 workload identity requires one immutable client identity per native HTTP transport; configure exactly one static TLS certificate without TLS dial or certificate-selection hooks, and replace the transport to rotate identities")
 }
 
 func (s x509CredentialSource) exchange(

--- a/auth/x509workloadidentity.go
+++ b/auth/x509workloadidentity.go
@@ -14,6 +14,10 @@ const (
 	x509TokenExchangeURL          = "https://mtls.auth.openai.com/oauth/token"
 	tokenExchangeMaxRetries       = 2
 	tokenExchangeResponseBodySize = 1 << 20
+	// Allow every accepted Retry-After delay plus a bounded aggregate budget
+	// for the initial request and retries.
+	x509TokenExchangeRequestBudget     = 30 * time.Second
+	x509WorkloadIdentityRefreshTimeout = tokenExchangeMaxRetryDelay*tokenExchangeMaxRetries + x509TokenExchangeRequestBudget
 )
 
 // x509TokenExchangeRequest deliberately has no SubjectToken or ClientID field.
@@ -104,6 +108,10 @@ func (s x509CredentialSource) refreshBuffer(expiresIn time.Duration) time.Durati
 		refreshBefore = DefaultRefreshBuffer
 	}
 	return min(refreshBefore, expiresIn/2)
+}
+
+func (x509CredentialSource) refreshTimeout() time.Duration {
+	return x509WorkloadIdentityRefreshTimeout
 }
 
 func (x509CredentialSource) kind() workloadIdentityCredentialSourceKind {

--- a/auth/x509workloadidentity.go
+++ b/auth/x509workloadidentity.go
@@ -1,0 +1,134 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"time"
+)
+
+const (
+	x509SubjectTokenType          = "urn:openai:params:oauth:token-type:x509"
+	x509TokenExchangeURL          = "https://mtls.auth.openai.com/oauth/token"
+	tokenExchangeMaxRetries       = 2
+	tokenExchangeResponseBodySize = 1 << 20
+)
+
+// x509TokenExchangeRequest deliberately has no SubjectToken or ClientID field.
+// The mutually authenticated TLS connection is the subject credential.
+type x509TokenExchangeRequest struct {
+	GrantType          string `json:"grant_type"`
+	SubjectTokenType   string `json:"subject_token_type"`
+	IdentityProviderID string `json:"identity_provider_id"`
+	ServiceAccountID   string `json:"service_account_id"`
+}
+
+type x509CredentialSource struct {
+	refreshBefore time.Duration
+}
+
+// NewX509WorkloadIdentityAuth creates the HTTP authentication state for an
+// X.509 workload identity. Token exchange remains lazy until GetToken is called.
+func NewX509WorkloadIdentityAuth(config X509WorkloadIdentity) (*WorkloadIdentityAuth, error) {
+	if err := validateWorkloadIdentity("X509WorkloadIdentity", config.IdentityProviderID, config.ServiceAccountID); err != nil {
+		return nil, err
+	}
+	if config.RefreshBuffer < 0 {
+		return nil, fmt.Errorf("X509WorkloadIdentity: RefreshBuffer must be non-negative")
+	}
+	return newWorkloadIdentityAuth(
+		config.IdentityProviderID,
+		config.ServiceAccountID,
+		x509CredentialSource{refreshBefore: config.RefreshBuffer},
+	), nil
+}
+
+func (s x509CredentialSource) exchange(
+	ctx context.Context,
+	httpClient HTTPDoer,
+	identityProviderID string,
+	serviceAccountID string,
+) (exchangedToken, error) {
+	body, err := json.Marshal(x509TokenExchangeRequest{
+		GrantType:          TokenExchangeGrantType,
+		SubjectTokenType:   x509SubjectTokenType,
+		IdentityProviderID: identityProviderID,
+		ServiceAccountID:   serviceAccountID,
+	})
+	if err != nil {
+		return exchangedToken{}, fmt.Errorf("failed to marshal token exchange request: %w", err)
+	}
+	resp, err := exchangeToken(
+		ctx,
+		withoutRedirects(httpClient),
+		x509TokenExchangeURL,
+		body,
+		tokenExchangeMaxRetries,
+	)
+	if err != nil {
+		return exchangedToken{}, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	responseBody, err := readTokenExchangeResponse(resp.Body, tokenExchangeResponseBodySize)
+	if err != nil {
+		return exchangedToken{}, err
+	}
+	return parseX509TokenExchangeResponse(resp.StatusCode, responseBody)
+}
+
+func (s x509CredentialSource) refreshBuffer(expiresIn time.Duration) time.Duration {
+	refreshBefore := s.refreshBefore
+	if refreshBefore == 0 {
+		refreshBefore = DefaultRefreshBuffer
+	}
+	return min(refreshBefore, expiresIn/2)
+}
+
+func parseX509TokenExchangeResponse(statusCode int, body []byte) (exchangedToken, error) {
+	if statusCode == http.StatusBadRequest || statusCode == http.StatusUnauthorized || statusCode == http.StatusForbidden {
+		// Preserve the typed OAuth status without retaining or surfacing an
+		// untrusted response body that could contain credential material.
+		return exchangedToken{}, &OAuthError{StatusCode: statusCode}
+	}
+	if statusCode != http.StatusOK {
+		return exchangedToken{}, fmt.Errorf("token exchange failed with status %d", statusCode)
+	}
+
+	var tokenResp struct {
+		AccessToken string   `json:"access_token"`
+		ExpiresIn   *float64 `json:"expires_in"`
+	}
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return exchangedToken{}, fmt.Errorf("failed to decode token exchange response: %w", err)
+	}
+	if tokenResp.ExpiresIn == nil {
+		return exchangedToken{}, fmt.Errorf("token exchange response requires a positive numeric 'expires_in' field")
+	}
+	seconds := *tokenResp.ExpiresIn
+	if math.IsNaN(seconds) || math.IsInf(seconds, 0) ||
+		seconds > float64(math.MaxInt64)/float64(time.Second) {
+		return exchangedToken{}, fmt.Errorf("token exchange response has invalid 'expires_in' field")
+	}
+	expiresIn := time.Duration(seconds * float64(time.Second))
+	if expiresIn <= 0 {
+		return exchangedToken{}, fmt.Errorf("token exchange response requires a positive numeric 'expires_in' field")
+	}
+	if tokenResp.AccessToken == "" {
+		return exchangedToken{}, fmt.Errorf("token exchange response missing 'access_token' field")
+	}
+	return exchangedToken{accessToken: tokenResp.AccessToken, expiresIn: expiresIn}, nil
+}
+
+func withoutRedirects(httpClient HTTPDoer) HTTPDoer {
+	client, ok := httpClient.(*http.Client)
+	if !ok {
+		return httpClient
+	}
+	clone := *client
+	clone.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	return &clone
+}

--- a/auth/x509workloadidentity_retry_internal_test.go
+++ b/auth/x509workloadidentity_retry_internal_test.go
@@ -71,3 +71,32 @@ func TestX509TokenExchangeResponseReadRetriesAreBounded(t *testing.T) {
 		t.Fatalf("exchange calls = %d, want %d", got, want)
 	}
 }
+
+func TestX509TokenExchangeDoesNotRetryDefinitiveStatusReadFailure(t *testing.T) {
+	for _, statusCode := range []int{
+		http.StatusBadRequest,
+		http.StatusUnauthorized,
+		http.StatusForbidden,
+	} {
+		t.Run(http.StatusText(statusCode), func(t *testing.T) {
+			var calls atomic.Int32
+			doer := &internalHTTPDoer{do: func(*http.Request) (*http.Response, error) {
+				calls.Add(1)
+				return &http.Response{
+					StatusCode: statusCode,
+					Header:     http.Header{"Retry-After": []string{"0"}},
+					Body:       &failingTokenResponseBody{},
+				}, nil
+			}}
+
+			_, err := (x509CredentialSource{}).exchange(t.Context(), doer, "idp-test", "svc-test")
+			var oauthErr *OAuthError
+			if !errors.As(err, &oauthErr) || oauthErr.StatusCode != statusCode {
+				t.Fatalf("exchange() error = %v, want OAuthError status %d", err, statusCode)
+			}
+			if got, want := calls.Load(), int32(1); got != want {
+				t.Fatalf("exchange calls = %d, want %d", got, want)
+			}
+		})
+	}
+}

--- a/auth/x509workloadidentity_retry_internal_test.go
+++ b/auth/x509workloadidentity_retry_internal_test.go
@@ -1,0 +1,73 @@
+package auth
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+type failingTokenResponseBody struct {
+	read bool
+}
+
+func (b *failingTokenResponseBody) Read(p []byte) (int, error) {
+	if b.read {
+		return 0, io.ErrUnexpectedEOF
+	}
+	b.read = true
+	return copy(p, `{"access_token":`), nil
+}
+
+func (*failingTokenResponseBody) Close() error { return nil }
+
+func TestX509TokenExchangeRetriesTransientResponseReadFailure(t *testing.T) {
+	var calls atomic.Int32
+	doer := &internalHTTPDoer{do: func(*http.Request) (*http.Response, error) {
+		if calls.Add(1) == 1 {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Retry-After": []string{"0"}},
+				Body:       &failingTokenResponseBody{},
+			}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"access_token":"retry-token","expires_in":60}`)),
+		}, nil
+	}}
+
+	token, err := (x509CredentialSource{}).exchange(t.Context(), doer, "idp-test", "svc-test")
+	if err != nil {
+		t.Fatalf("exchange() error = %v", err)
+	}
+	if token.accessToken != "retry-token" {
+		t.Fatalf("exchange() token = %q, want retry-token", token.accessToken)
+	}
+	if got, want := calls.Load(), int32(2); got != want {
+		t.Fatalf("exchange calls = %d, want %d", got, want)
+	}
+}
+
+func TestX509TokenExchangeResponseReadRetriesAreBounded(t *testing.T) {
+	var calls atomic.Int32
+	doer := &internalHTTPDoer{do: func(*http.Request) (*http.Response, error) {
+		calls.Add(1)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Retry-After": []string{"0"}},
+			Body:       &failingTokenResponseBody{},
+		}, nil
+	}}
+
+	_, err := (x509CredentialSource{}).exchange(t.Context(), doer, "idp-test", "svc-test")
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatalf("exchange() error = %v, want io.ErrUnexpectedEOF", err)
+	}
+	if got, want := calls.Load(), int32(tokenExchangeMaxRetries+1); got != want {
+		t.Fatalf("exchange calls = %d, want %d", got, want)
+	}
+}

--- a/auth/x509workloadidentity_test.go
+++ b/auth/x509workloadidentity_test.go
@@ -634,6 +634,16 @@ func TestX509Concurrent401InvalidationKeepsNewToken(t *testing.T) {
 }
 
 func TestX509WorkloadIdentity401ClosesReplayBodyWhenMiddlewareFails(t *testing.T) {
+	testX509ReplayBodyClose(t, false)
+}
+
+func TestX509WorkloadIdentity401DoesNotDoubleCloseReplayBodyOnDownstreamError(t *testing.T) {
+	testX509ReplayBodyClose(t, true)
+}
+
+func testX509ReplayBodyClose(t *testing.T, downstreamClosesBody bool) {
+	t.Helper()
+
 	var exchangeCalls atomic.Int32
 	exchangeClient := &http.Client{Transport: &closureTransport{fn: func(*http.Request) (*http.Response, error) {
 		call := exchangeCalls.Add(1)
@@ -671,7 +681,7 @@ func TestX509WorkloadIdentity401ClosesReplayBodyWhenMiddlewareFails(t *testing.T
 
 	middlewareErr := errors.New("middleware rejected replay")
 	var calls int
-	next := func(*http.Request) (*http.Response, error) {
+	next := func(replayReq *http.Request) (*http.Response, error) {
 		calls++
 		if calls == 1 {
 			return &http.Response{
@@ -679,6 +689,9 @@ func TestX509WorkloadIdentity401ClosesReplayBodyWhenMiddlewareFails(t *testing.T
 				Body:       http.NoBody,
 				Header:     make(http.Header),
 			}, nil
+		}
+		if downstreamClosesBody {
+			_ = replayReq.Body.Close()
 		}
 		return nil, middlewareErr
 	}

--- a/auth/x509workloadidentity_test.go
+++ b/auth/x509workloadidentity_test.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/cookiejar"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"reflect"
 	"strings"
@@ -268,6 +270,95 @@ func TestX509TokenExchangeRequiresPositiveExpiresIn(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestX509TokenExchangeValidatesBearerTokenTypeAndGrammar(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		for _, body := range []string{
+			`{"access_token":"abc-._~+/==","expires_in":60}`,
+			`{"access_token":"abc-._~+/==","expires_in":60,"token_type":"Bearer"}`,
+			`{"access_token":"abc-._~+/==","expires_in":60,"token_type":"bearer"}`,
+		} {
+			wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
+			if err != nil {
+				t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
+			}
+			if _, err := wia.GetToken(t.Context(), mockOAuthServer(body, http.StatusOK)); err != nil {
+				t.Errorf("GetToken() body %s error = %v", body, err)
+			}
+		}
+	})
+
+	t.Run("invalid token type", func(t *testing.T) {
+		for _, tokenType := range []string{`"Basic"`, `"MAC"`, `"DPoP"`, `null`, `123`} {
+			body := fmt.Sprintf(`{"access_token":"must-not-leak","expires_in":60,"token_type":%s}`, tokenType)
+			wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
+			if err != nil {
+				t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
+			}
+			_, err = wia.GetToken(t.Context(), mockOAuthServer(body, http.StatusOK))
+			if err == nil {
+				t.Errorf("GetToken() token_type %s error = nil", tokenType)
+			} else if strings.Contains(err.Error(), "must-not-leak") {
+				t.Errorf("GetToken() error contains access token: %v", err)
+			}
+		}
+	})
+
+	t.Run("invalid access token", func(t *testing.T) {
+		invalidTokens := []string{
+			" leading", "trailing ", "two words", "line\r\nbreak", "line\nbreak",
+			"nul\x00byte", "tab\tbyte", "nonascii-\u00e9", "bad!punctuation", "=padding-only", "abc=more",
+		}
+		for _, accessToken := range invalidTokens {
+			body, err := json.Marshal(map[string]any{
+				"access_token": accessToken,
+				"expires_in":   60,
+				"token_type":   "Bearer",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
+			if err != nil {
+				t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
+			}
+			_, err = wia.GetToken(t.Context(), mockOAuthServer(string(body), http.StatusOK))
+			if err == nil {
+				t.Errorf("GetToken() token %q error = nil", accessToken)
+			} else if strings.Contains(err.Error(), accessToken) {
+				t.Errorf("GetToken() error contains access token: %v", err)
+			}
+		}
+	})
+
+	t.Run("invalid token is not cached", func(t *testing.T) {
+		var calls atomic.Int32
+		httpClient := &http.Client{Transport: &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+			if calls.Add(1) == 1 {
+				return tokenResponse("line\r\nbreak", 60), nil
+			}
+			return tokenResponse("safe-token", 60), nil
+		}}}
+		wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
+		if err != nil {
+			t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
+		}
+		_, err = wia.GetToken(t.Context(), httpClient)
+		if err == nil {
+			t.Fatal("first GetToken() error = nil")
+		}
+		token, err := wia.GetToken(t.Context(), httpClient)
+		if err != nil {
+			t.Fatalf("second GetToken() error = %v", err)
+		}
+		if got, want := token, "safe-token"; got != want {
+			t.Fatalf("second GetToken() = %q, want %q", got, want)
+		}
+		if got, want := calls.Load(), int32(2); got != want {
+			t.Fatalf("token exchange calls = %d, want %d", got, want)
+		}
+	})
 }
 
 func TestIDTokenWorkloadIdentityRegression(t *testing.T) {
@@ -658,6 +749,74 @@ func TestX509Concurrent401InvalidationKeepsNewToken(t *testing.T) {
 	}
 	if got, want := exchangeCalls.Load(), int32(2); got != want {
 		t.Errorf("token exchange calls = %d, want %d", got, want)
+	}
+}
+
+func TestX509Second401InvalidatesReplayToken(t *testing.T) {
+	var exchangeCalls atomic.Int32
+	exchangeClient := &http.Client{Transport: &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+		call := exchangeCalls.Add(1)
+		return tokenResponse(fmt.Sprintf("token-%d", call), 60), nil
+	}}}
+	wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
+	if err != nil {
+		t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
+	}
+	var authorizations []string
+	next := func(req *http.Request) (*http.Response, error) {
+		authorizations = append(authorizations, req.Header.Get("Authorization"))
+		return &http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Header:     make(http.Header),
+			Body:       http.NoBody,
+		}, nil
+	}
+
+	for range 2 {
+		req, reqErr := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://mtls.api.openai.com/v1/models", nil)
+		if reqErr != nil {
+			t.Fatal(reqErr)
+		}
+		resp, middlewareErr := auth.WorkloadIdentityMiddleware(wia, exchangeClient, req, next)
+		if middlewareErr != nil {
+			t.Fatalf("WorkloadIdentityMiddleware() error = %v", middlewareErr)
+		}
+		_ = resp.Body.Close()
+	}
+
+	if got, want := strings.Join(authorizations, ","), "Bearer token-1,Bearer token-2,Bearer token-3,Bearer token-4"; got != want {
+		t.Fatalf("Authorization sequence = %q, want %q", got, want)
+	}
+}
+
+func TestX509TokenExchangeDoesNotInheritHTTPClientCookies(t *testing.T) {
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	authURL, err := url.Parse("https://mtls.auth.openai.com/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	jar.SetCookies(authURL, []*http.Cookie{{Name: "api-session", Value: "secret", Path: "/"}})
+	var exchangeCookie string
+	httpClient := &http.Client{
+		Jar: jar,
+		Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+			exchangeCookie = req.Header.Get("Cookie")
+			return tokenResponse("x509-token", 60), nil
+		}},
+	}
+	wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
+	if err != nil {
+		t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
+	}
+
+	if _, err := wia.GetToken(t.Context(), httpClient); err != nil {
+		t.Fatalf("GetToken() error = %v", err)
+	}
+	if exchangeCookie != "" {
+		t.Fatalf("token exchange Cookie = %q, want empty", exchangeCookie)
 	}
 }
 

--- a/auth/x509workloadidentity_test.go
+++ b/auth/x509workloadidentity_test.go
@@ -29,6 +29,15 @@ func (b *closeTrackingReadCloser) Close() error {
 	return b.ReadCloser.Close()
 }
 
+type dynamicallyNonComparableHTTPDoer struct {
+	state any
+	doer  auth.HTTPDoer
+}
+
+func (d dynamicallyNonComparableHTTPDoer) Do(req *http.Request) (*http.Response, error) {
+	return d.doer.Do(req)
+}
+
 func testX509WorkloadIdentity() auth.X509WorkloadIdentity {
 	return auth.X509WorkloadIdentity{
 		IdentityProviderID: "idp-test",
@@ -125,6 +134,25 @@ func TestX509WorkloadIdentityAuthRejectsHTTPDoerChange(t *testing.T) {
 	}
 	if got := callsB.Load(); got != 0 {
 		t.Errorf("HTTP client B exchange calls = %d, want 0", got)
+	}
+}
+
+func TestX509WorkloadIdentityAuthRejectsDynamicallyNonComparableHTTPDoer(t *testing.T) {
+	httpDoer := dynamicallyNonComparableHTTPDoer{
+		state: []string{"not-comparable"},
+		doer: &http.Client{Transport: &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+			t.Fatal("dynamically non-comparable HTTP doer was called")
+			return nil, nil
+		}}},
+	}
+	wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
+	if err != nil {
+		t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
+	}
+
+	_, err = wia.GetToken(t.Context(), httpDoer)
+	if err == nil || !strings.Contains(err.Error(), "requires a comparable HTTP client") {
+		t.Fatalf("GetToken() error = %v, want comparable HTTP client error", err)
 	}
 }
 

--- a/auth/x509workloadidentity_test.go
+++ b/auth/x509workloadidentity_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
 	"strings"
 	"sync"
@@ -17,6 +18,16 @@ import (
 
 	"github.com/openai/openai-go/v3/auth"
 )
+
+type closeTrackingReadCloser struct {
+	io.ReadCloser
+	closes atomic.Int32
+}
+
+func (b *closeTrackingReadCloser) Close() error {
+	b.closes.Add(1)
+	return b.ReadCloser.Close()
+}
 
 func testX509WorkloadIdentity() auth.X509WorkloadIdentity {
 	return auth.X509WorkloadIdentity{
@@ -619,5 +630,82 @@ func TestX509Concurrent401InvalidationKeepsNewToken(t *testing.T) {
 	}
 	if got, want := exchangeCalls.Load(), int32(2); got != want {
 		t.Errorf("token exchange calls = %d, want %d", got, want)
+	}
+}
+
+func TestX509WorkloadIdentity401ClosesReplayBodyWhenMiddlewareFails(t *testing.T) {
+	var exchangeCalls atomic.Int32
+	exchangeClient := &http.Client{Transport: &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+		call := exchangeCalls.Add(1)
+		return tokenResponse(fmt.Sprintf("token-%d", call), 60), nil
+	}}}
+	wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
+	if err != nil {
+		t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
+	}
+
+	bodyPath := t.TempDir() + "/body"
+	if writeErr := os.WriteFile(bodyPath, []byte("request body"), 0o600); writeErr != nil {
+		t.Fatal(writeErr)
+	}
+	req, err := http.NewRequestWithContext(
+		t.Context(),
+		http.MethodPost,
+		"https://mtls.api.openai.com/v1/custom",
+		strings.NewReader("request body"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = req.Body.Close() }()
+
+	var replayBody *closeTrackingReadCloser
+	req.GetBody = func() (io.ReadCloser, error) {
+		body, openErr := os.Open(bodyPath)
+		if openErr != nil {
+			return nil, openErr
+		}
+		replayBody = &closeTrackingReadCloser{ReadCloser: body}
+		return replayBody, nil
+	}
+
+	middlewareErr := errors.New("middleware rejected replay")
+	var calls int
+	next := func(*http.Request) (*http.Response, error) {
+		calls++
+		if calls == 1 {
+			return &http.Response{
+				StatusCode: http.StatusUnauthorized,
+				Body:       http.NoBody,
+				Header:     make(http.Header),
+			}, nil
+		}
+		return nil, middlewareErr
+	}
+
+	resp, err := auth.WorkloadIdentityMiddleware(wia, exchangeClient, req, next)
+	if !errors.Is(err, middlewareErr) {
+		t.Fatalf("WorkloadIdentityMiddleware() error = %v, want %v", err, middlewareErr)
+	}
+	if resp != nil {
+		if resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+		t.Errorf("WorkloadIdentityMiddleware() response = %#v, want nil", resp)
+	}
+	if got, want := calls, 2; got != want {
+		t.Errorf("middleware calls = %d, want %d", got, want)
+	}
+	if got, want := exchangeCalls.Load(), int32(2); got != want {
+		t.Errorf("token exchange calls = %d, want %d", got, want)
+	}
+	if replayBody == nil {
+		t.Fatal("GetBody was not called")
+	}
+	if got, want := replayBody.closes.Load(), int32(1); got != want {
+		t.Errorf("replay body closes = %d, want %d", got, want)
+	}
+	if _, err := replayBody.Read(make([]byte, 1)); err == nil {
+		t.Error("replay body remains readable after middleware error")
 	}
 }

--- a/auth/x509workloadidentity_test.go
+++ b/auth/x509workloadidentity_test.go
@@ -141,14 +141,14 @@ func TestX509WorkloadIdentityMiddlewareRequiresRequestPolicyBeforeExchange(t *te
 func TestX509WorkloadIdentityAuthRejectsHTTPDoerChange(t *testing.T) {
 	var callsA atomic.Int32
 	var callsB atomic.Int32
-	httpClientA := &http.Client{Transport: &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+	httpClientA := nativeX509HTTPClient(t, func(*http.Request) (*http.Response, error) {
 		callsA.Add(1)
 		return tokenResponse("token-a", 60), nil
-	}}}
-	httpClientB := &http.Client{Transport: &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+	})
+	httpClientB := nativeX509HTTPClient(t, func(*http.Request) (*http.Response, error) {
 		callsB.Add(1)
 		return tokenResponse("token-b", 60), nil
-	}}}
+	})
 	wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
 	if err != nil {
 		t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
@@ -194,14 +194,14 @@ func TestX509WorkloadIdentityAuthRejectsDynamicallyNonComparableHTTPDoer(t *test
 	}
 
 	_, err = wia.GetToken(t.Context(), httpDoer)
-	if err == nil || !strings.Contains(err.Error(), "requires a comparable HTTP client") {
-		t.Fatalf("GetToken() error = %v, want comparable HTTP client error", err)
+	if err == nil || !strings.Contains(err.Error(), "native *http.Transport") {
+		t.Fatalf("GetToken() error = %v, want native HTTP transport error", err)
 	}
 }
 
 func TestX509TokenExchangeRequest(t *testing.T) {
 	var requestBody map[string]any
-	httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+	httpClient := nativeX509HTTPClient(t, func(req *http.Request) (*http.Response, error) {
 		if got, want := req.Method, http.MethodPost; got != want {
 			t.Errorf("request method = %q, want %q", got, want)
 		}
@@ -219,7 +219,7 @@ func TestX509TokenExchangeRequest(t *testing.T) {
 			return nil, err
 		}
 		return tokenResponse("x509-token", 3600), nil
-	}}}
+	})
 
 	wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
 	if err != nil {
@@ -254,7 +254,7 @@ func TestX509TokenExchangeDoesNotRetryOAuthErrors(t *testing.T) {
 	for _, statusCode := range []int{http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden} {
 		t.Run(http.StatusText(statusCode), func(t *testing.T) {
 			var calls atomic.Int32
-			httpClient := &http.Client{Transport: &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+			httpClient := nativeX509HTTPClient(t, func(*http.Request) (*http.Response, error) {
 				calls.Add(1)
 				return &http.Response{
 					StatusCode: statusCode,
@@ -263,7 +263,7 @@ func TestX509TokenExchangeDoesNotRetryOAuthErrors(t *testing.T) {
 						`{"error":"invalid_grant","error_description":"generic exchange failure"}`,
 					)),
 				}, nil
-			}}}
+			})
 			wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
 			if err != nil {
 				t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
@@ -303,7 +303,7 @@ func TestX509TokenExchangeRequiresPositiveExpiresIn(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
 			}
-			httpClient := mockOAuthServer(testCase.body, http.StatusOK)
+			httpClient := mockOAuthServer(t, testCase.body, http.StatusOK)
 			if _, err := wia.GetToken(t.Context(), httpClient); err == nil {
 				t.Fatal("GetToken() error = nil")
 			} else if strings.Contains(err.Error(), "secret-token") {
@@ -324,7 +324,7 @@ func TestX509TokenExchangeValidatesBearerTokenTypeAndGrammar(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
 			}
-			if _, err := wia.GetToken(t.Context(), mockOAuthServer(body, http.StatusOK)); err != nil {
+			if _, err := wia.GetToken(t.Context(), mockOAuthServer(t, body, http.StatusOK)); err != nil {
 				t.Errorf("GetToken() body %s error = %v", body, err)
 			}
 		}
@@ -337,7 +337,7 @@ func TestX509TokenExchangeValidatesBearerTokenTypeAndGrammar(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
 			}
-			_, err = wia.GetToken(t.Context(), mockOAuthServer(body, http.StatusOK))
+			_, err = wia.GetToken(t.Context(), mockOAuthServer(t, body, http.StatusOK))
 			if err == nil {
 				t.Errorf("GetToken() token_type %s error = nil", tokenType)
 			} else if strings.Contains(err.Error(), "must-not-leak") {
@@ -364,7 +364,7 @@ func TestX509TokenExchangeValidatesBearerTokenTypeAndGrammar(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
 			}
-			_, err = wia.GetToken(t.Context(), mockOAuthServer(string(body), http.StatusOK))
+			_, err = wia.GetToken(t.Context(), mockOAuthServer(t, string(body), http.StatusOK))
 			if err == nil {
 				t.Errorf("GetToken() token %q error = nil", accessToken)
 			} else if strings.Contains(err.Error(), accessToken) {
@@ -375,12 +375,12 @@ func TestX509TokenExchangeValidatesBearerTokenTypeAndGrammar(t *testing.T) {
 
 	t.Run("invalid token is not cached", func(t *testing.T) {
 		var calls atomic.Int32
-		httpClient := &http.Client{Transport: &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+		httpClient := nativeX509HTTPClient(t, func(*http.Request) (*http.Response, error) {
 			if calls.Add(1) == 1 {
 				return tokenResponse("line\r\nbreak", 60), nil
 			}
 			return tokenResponse("safe-token", 60), nil
-		}}}
+		})
 		wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
 		if err != nil {
 			t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
@@ -441,7 +441,7 @@ func TestIDTokenWorkloadIdentityRegression(t *testing.T) {
 
 func TestX509TokenExchangeRetriesTransientFailures(t *testing.T) {
 	var calls atomic.Int32
-	httpClient := &http.Client{Transport: &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+	httpClient := nativeX509HTTPClient(t, func(*http.Request) (*http.Response, error) {
 		switch calls.Add(1) {
 		case 1:
 			return nil, errors.New("temporary connection failure")
@@ -454,7 +454,7 @@ func TestX509TokenExchangeRetriesTransientFailures(t *testing.T) {
 		default:
 			return tokenResponse("retried-token", 60), nil
 		}
-	}}}
+	})
 
 	wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
 	if err != nil {
@@ -470,14 +470,14 @@ func TestX509TokenExchangeRetriesTransientFailures(t *testing.T) {
 
 func TestX509TokenExchangeRetriesAreBounded(t *testing.T) {
 	var calls atomic.Int32
-	httpClient := &http.Client{Transport: &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+	httpClient := nativeX509HTTPClient(t, func(*http.Request) (*http.Response, error) {
 		calls.Add(1)
 		return &http.Response{
 			StatusCode: http.StatusServiceUnavailable,
 			Header:     http.Header{"Retry-After": []string{"0"}},
 			Body:       io.NopCloser(strings.NewReader(`{"access_token":"must-not-leak"}`)),
 		}, nil
-	}}}
+	})
 
 	wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
 	if err != nil {
@@ -498,14 +498,14 @@ func TestX509TokenExchangeRetriesAreBounded(t *testing.T) {
 func TestX509TokenExchangeRetryWaitHonorsContext(t *testing.T) {
 	requestStarted := make(chan struct{})
 	var once sync.Once
-	httpClient := &http.Client{Transport: &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+	httpClient := nativeX509HTTPClient(t, func(*http.Request) (*http.Response, error) {
 		once.Do(func() { close(requestStarted) })
 		return &http.Response{
 			StatusCode: http.StatusTooManyRequests,
 			Header:     http.Header{"Retry-After": []string{"60"}},
 			Body:       io.NopCloser(strings.NewReader(`{"error":"rate_limit"}`)),
 		}, nil
-	}}}
+	})
 
 	wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
 	if err != nil {
@@ -531,19 +531,17 @@ func TestX509TokenExchangeRefusesRedirects(t *testing.T) {
 	}))
 	t.Cleanup(redirectTarget.Close)
 
-	httpClient := &http.Client{
-		Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
-			if req.URL.Host == "mtls.auth.openai.com" {
-				return &http.Response{
-					StatusCode: http.StatusFound,
-					Header:     http.Header{"Location": []string{redirectTarget.URL}},
-					Body:       io.NopCloser(strings.NewReader("redirect")),
-				}, nil
-			}
-			return http.DefaultTransport.RoundTrip(req)
-		}},
-		CheckRedirect: func(*http.Request, []*http.Request) error { return nil },
-	}
+	httpClient := nativeX509HTTPClient(t, func(req *http.Request) (*http.Response, error) {
+		if req.URL.Host == "mtls.auth.openai.com" {
+			return &http.Response{
+				StatusCode: http.StatusFound,
+				Header:     http.Header{"Location": []string{redirectTarget.URL}},
+				Body:       io.NopCloser(strings.NewReader("redirect")),
+			}, nil
+		}
+		return http.DefaultTransport.RoundTrip(req)
+	})
+	httpClient.CheckRedirect = func(*http.Request, []*http.Request) error { return nil }
 
 	wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
 	if err != nil {
@@ -560,11 +558,11 @@ func TestX509TokenExchangeRefusesRedirects(t *testing.T) {
 func TestX509CanceledWaiterDoesNotCancelRefresh(t *testing.T) {
 	exchangeStarted := make(chan struct{})
 	releaseExchange := make(chan struct{})
-	httpClient := &http.Client{Transport: &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+	httpClient := nativeX509HTTPClient(t, func(*http.Request) (*http.Response, error) {
 		close(exchangeStarted)
 		<-releaseExchange
 		return tokenResponse("shared-token", 60), nil
-	}}}
+	})
 
 	wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
 	if err != nil {
@@ -594,48 +592,17 @@ func TestX509CanceledWaiterDoesNotCancelRefresh(t *testing.T) {
 	}
 }
 
-func TestX509CanceledOnlyWaiterCancelsSharedRefresh(t *testing.T) {
-	exchangeStarted := make(chan struct{})
-	exchangeCanceled := make(chan struct{})
-	httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
-		close(exchangeStarted)
-		<-req.Context().Done()
-		close(exchangeCanceled)
-		return nil, req.Context().Err()
-	}}}
-	wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
-	if err != nil {
-		t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
-	}
-	ctx, cancel := context.WithCancel(t.Context())
-	done := make(chan error, 1)
-	go func() {
-		_, getTokenErr := wia.GetToken(ctx, httpClient)
-		done <- getTokenErr
-	}()
-	<-exchangeStarted
-	cancel()
-	if err := <-done; !errors.Is(err, context.Canceled) {
-		t.Errorf("GetToken() error = %v, want context.Canceled", err)
-	}
-	select {
-	case <-exchangeCanceled:
-	case <-time.After(time.Second):
-		t.Fatal("shared exchange context was not canceled")
-	}
-}
-
 func TestX509InitialRefreshIsSingleFlight(t *testing.T) {
 	exchangeStarted := make(chan struct{})
 	releaseExchange := make(chan struct{})
 	var calls atomic.Int32
 	var startOnce sync.Once
-	httpClient := &http.Client{Transport: &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+	httpClient := nativeX509HTTPClient(t, func(*http.Request) (*http.Response, error) {
 		calls.Add(1)
 		startOnce.Do(func() { close(exchangeStarted) })
 		<-releaseExchange
 		return tokenResponse("shared-token", 60), nil
-	}}}
+	})
 	wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
 	if err != nil {
 		t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
@@ -669,10 +636,10 @@ func TestX509InitialRefreshIsSingleFlight(t *testing.T) {
 
 func TestX509ExpiredTokenRefreshesSynchronously(t *testing.T) {
 	var calls atomic.Int32
-	httpClient := &http.Client{Transport: &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+	httpClient := nativeX509HTTPClient(t, func(*http.Request) (*http.Response, error) {
 		call := calls.Add(1)
 		return tokenResponse(fmt.Sprintf("token-%d", call), 0.1), nil
-	}}}
+	})
 	config := testX509WorkloadIdentity()
 	config.RefreshBuffer = time.Nanosecond
 	wia, err := auth.NewX509WorkloadIdentityAuth(config)
@@ -695,13 +662,13 @@ func TestX509ExpiredTokenRefreshesSynchronously(t *testing.T) {
 func TestX509RefreshBufferClampedToHalfTTL(t *testing.T) {
 	var calls atomic.Int32
 	secondExchange := make(chan struct{})
-	httpClient := &http.Client{Transport: &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+	httpClient := nativeX509HTTPClient(t, func(*http.Request) (*http.Response, error) {
 		call := calls.Add(1)
 		if call == 2 {
 			close(secondExchange)
 		}
 		return tokenResponse(fmt.Sprintf("token-%d", call), 1), nil
-	}}}
+	})
 	config := testX509WorkloadIdentity()
 	config.RefreshBuffer = 10 * time.Second
 	wia, err := auth.NewX509WorkloadIdentityAuth(config)
@@ -732,10 +699,10 @@ func TestX509RefreshBufferClampedToHalfTTL(t *testing.T) {
 
 func TestX509Concurrent401InvalidationKeepsNewToken(t *testing.T) {
 	var exchangeCalls atomic.Int32
-	exchangeClient := &http.Client{Transport: &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+	exchangeClient := nativeX509HTTPClient(t, func(*http.Request) (*http.Response, error) {
 		call := exchangeCalls.Add(1)
 		return tokenResponse(fmt.Sprintf("token-%d", call), 60), nil
-	}}}
+	})
 	wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
 	if err != nil {
 		t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
@@ -795,10 +762,10 @@ func TestX509Concurrent401InvalidationKeepsNewToken(t *testing.T) {
 
 func TestX509Second401InvalidatesReplayToken(t *testing.T) {
 	var exchangeCalls atomic.Int32
-	exchangeClient := &http.Client{Transport: &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+	exchangeClient := nativeX509HTTPClient(t, func(*http.Request) (*http.Response, error) {
 		call := exchangeCalls.Add(1)
 		return tokenResponse(fmt.Sprintf("token-%d", call), 60), nil
-	}}}
+	})
 	wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
 	if err != nil {
 		t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
@@ -841,13 +808,11 @@ func TestX509TokenExchangeDoesNotInheritHTTPClientCookies(t *testing.T) {
 	}
 	jar.SetCookies(authURL, []*http.Cookie{{Name: "api-session", Value: "secret", Path: "/"}})
 	var exchangeCookie string
-	httpClient := &http.Client{
-		Jar: jar,
-		Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
-			exchangeCookie = req.Header.Get("Cookie")
-			return tokenResponse("x509-token", 60), nil
-		}},
-	}
+	httpClient := nativeX509HTTPClient(t, func(req *http.Request) (*http.Response, error) {
+		exchangeCookie = req.Header.Get("Cookie")
+		return tokenResponse("x509-token", 60), nil
+	})
+	httpClient.Jar = jar
 	wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
 	if err != nil {
 		t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
@@ -873,10 +838,10 @@ func testX509ReplayBodyClose(t *testing.T, downstreamClosesBody bool) {
 	t.Helper()
 
 	var exchangeCalls atomic.Int32
-	exchangeClient := &http.Client{Transport: &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+	exchangeClient := nativeX509HTTPClient(t, func(*http.Request) (*http.Response, error) {
 		call := exchangeCalls.Add(1)
 		return tokenResponse(fmt.Sprintf("token-%d", call), 60), nil
-	}}}
+	})
 	wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
 	if err != nil {
 		t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)

--- a/auth/x509workloadidentity_test.go
+++ b/auth/x509workloadidentity_test.go
@@ -75,6 +75,48 @@ func TestX509WorkloadIdentityDoesNotOwnCertificateMaterial(t *testing.T) {
 	}
 }
 
+func TestX509WorkloadIdentityAuthRejectsHTTPDoerChange(t *testing.T) {
+	var callsA atomic.Int32
+	var callsB atomic.Int32
+	httpClientA := &http.Client{Transport: &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+		callsA.Add(1)
+		return tokenResponse("token-a", 60), nil
+	}}}
+	httpClientB := &http.Client{Transport: &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+		callsB.Add(1)
+		return tokenResponse("token-b", 60), nil
+	}}}
+	wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
+	if err != nil {
+		t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
+	}
+
+	token, err := wia.GetToken(t.Context(), httpClientA)
+	if err != nil {
+		t.Fatalf("first GetToken() error = %v", err)
+	}
+	if token != "token-a" {
+		t.Fatalf("first GetToken() = %q, want token-a", token)
+	}
+	_, err = wia.GetToken(t.Context(), httpClientB)
+	if err == nil {
+		t.Fatal("GetToken() with different HTTP client error = nil")
+	}
+	token, err = wia.GetToken(t.Context(), httpClientA)
+	if err != nil {
+		t.Fatalf("cached GetToken() error = %v", err)
+	}
+	if token != "token-a" {
+		t.Errorf("cached GetToken() = %q, want token-a", token)
+	}
+	if got, want := callsA.Load(), int32(1); got != want {
+		t.Errorf("HTTP client A exchange calls = %d, want %d", got, want)
+	}
+	if got := callsB.Load(); got != 0 {
+		t.Errorf("HTTP client B exchange calls = %d, want 0", got)
+	}
+}
+
 func TestX509TokenExchangeRequest(t *testing.T) {
 	var requestBody map[string]any
 	httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
@@ -378,6 +420,37 @@ func TestX509CanceledWaiterDoesNotCancelRefresh(t *testing.T) {
 	close(releaseExchange)
 	if err := <-leaderDone; err != nil {
 		t.Fatalf("leader GetToken() error = %v", err)
+	}
+}
+
+func TestX509CanceledOnlyWaiterCancelsSharedRefresh(t *testing.T) {
+	exchangeStarted := make(chan struct{})
+	exchangeCanceled := make(chan struct{})
+	httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+		close(exchangeStarted)
+		<-req.Context().Done()
+		close(exchangeCanceled)
+		return nil, req.Context().Err()
+	}}}
+	wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
+	if err != nil {
+		t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() {
+		_, getTokenErr := wia.GetToken(ctx, httpClient)
+		done <- getTokenErr
+	}()
+	<-exchangeStarted
+	cancel()
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Errorf("GetToken() error = %v, want context.Canceled", err)
+	}
+	select {
+	case <-exchangeCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("shared exchange context was not canceled")
 	}
 }
 

--- a/auth/x509workloadidentity_test.go
+++ b/auth/x509workloadidentity_test.go
@@ -1,0 +1,550 @@
+package auth_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/openai/openai-go/v3/auth"
+)
+
+func testX509WorkloadIdentity() auth.X509WorkloadIdentity {
+	return auth.X509WorkloadIdentity{
+		IdentityProviderID: "idp-test",
+		ServiceAccountID:   "svc-test",
+	}
+}
+
+func tokenResponse(token string, expiresIn any) *http.Response {
+	body, err := json.Marshal(map[string]any{
+		"access_token": token,
+		"expires_in":   expiresIn,
+	})
+	if err != nil {
+		panic(err)
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(string(body))),
+	}
+}
+
+func TestX509WorkloadIdentityValidation(t *testing.T) {
+	testCases := []struct {
+		name   string
+		config auth.X509WorkloadIdentity
+	}{
+		{name: "missing identity provider", config: auth.X509WorkloadIdentity{ServiceAccountID: "svc-test"}},
+		{name: "missing service account", config: auth.X509WorkloadIdentity{IdentityProviderID: "idp-test"}},
+		{name: "negative refresh buffer", config: auth.X509WorkloadIdentity{
+			IdentityProviderID: "idp-test",
+			ServiceAccountID:   "svc-test",
+			RefreshBuffer:      -time.Second,
+		}},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if _, err := auth.NewX509WorkloadIdentityAuth(testCase.config); err == nil {
+				t.Fatal("NewX509WorkloadIdentityAuth() error = nil")
+			}
+		})
+	}
+}
+
+func TestX509WorkloadIdentityDoesNotOwnCertificateMaterial(t *testing.T) {
+	typeOfConfig := reflect.TypeFor[auth.X509WorkloadIdentity]()
+	gotFields := make([]string, 0, typeOfConfig.NumField())
+	for i := range typeOfConfig.NumField() {
+		gotFields = append(gotFields, typeOfConfig.Field(i).Name)
+	}
+	wantFields := []string{"IdentityProviderID", "ServiceAccountID", "RefreshBuffer"}
+	if !reflect.DeepEqual(gotFields, wantFields) {
+		t.Errorf("X509WorkloadIdentity fields = %v, want %v", gotFields, wantFields)
+	}
+}
+
+func TestX509TokenExchangeRequest(t *testing.T) {
+	var requestBody map[string]any
+	httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+		if got, want := req.Method, http.MethodPost; got != want {
+			t.Errorf("request method = %q, want %q", got, want)
+		}
+		if got, want := req.URL.String(), "https://mtls.auth.openai.com/oauth/token"; got != want {
+			t.Errorf("request URL = %q, want %q", got, want)
+		}
+		if got, want := req.Header.Get("Content-Type"), "application/json"; got != want {
+			t.Errorf("Content-Type = %q, want %q", got, want)
+		}
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		if err := json.Unmarshal(body, &requestBody); err != nil {
+			return nil, err
+		}
+		return tokenResponse("x509-token", 3600), nil
+	}}}
+
+	wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
+	if err != nil {
+		t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
+	}
+	token, err := wia.GetToken(t.Context(), httpClient)
+	if err != nil {
+		t.Fatalf("GetToken() error = %v", err)
+	}
+	if got, want := token, "x509-token"; got != want {
+		t.Errorf("GetToken() = %q, want %q", got, want)
+	}
+
+	wantBody := map[string]any{
+		"grant_type":           "urn:ietf:params:oauth:grant-type:token-exchange",
+		"subject_token_type":   "urn:openai:params:oauth:token-type:x509",
+		"identity_provider_id": "idp-test",
+		"service_account_id":   "svc-test",
+	}
+	if !reflect.DeepEqual(requestBody, wantBody) {
+		t.Errorf("request body = %#v, want %#v", requestBody, wantBody)
+	}
+	if _, ok := requestBody["subject_token"]; ok {
+		t.Error("request body contains subject_token")
+	}
+	if _, ok := requestBody["client_id"]; ok {
+		t.Error("request body contains client_id")
+	}
+}
+
+func TestX509TokenExchangeDoesNotRetryOAuthErrors(t *testing.T) {
+	for _, statusCode := range []int{http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden} {
+		t.Run(http.StatusText(statusCode), func(t *testing.T) {
+			var calls atomic.Int32
+			httpClient := &http.Client{Transport: &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+				calls.Add(1)
+				return &http.Response{
+					StatusCode: statusCode,
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+					Body: io.NopCloser(strings.NewReader(
+						`{"error":"invalid_grant","error_description":"generic exchange failure"}`,
+					)),
+				}, nil
+			}}}
+			wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
+			if err != nil {
+				t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
+			}
+			_, err = wia.GetToken(t.Context(), httpClient)
+			var oauthErr *auth.OAuthError
+			if !errors.As(err, &oauthErr) {
+				t.Fatalf("GetToken() error = %v, want *auth.OAuthError", err)
+			}
+			if got, want := oauthErr.StatusCode, statusCode; got != want {
+				t.Errorf("OAuthError.StatusCode = %d, want %d", got, want)
+			}
+			if strings.Contains(err.Error(), "generic exchange failure") {
+				t.Errorf("GetToken() error contains response body: %v", err)
+			}
+			if got, want := calls.Load(), int32(1); got != want {
+				t.Errorf("token exchange calls = %d, want %d", got, want)
+			}
+		})
+	}
+}
+
+func TestX509TokenExchangeRequiresPositiveExpiresIn(t *testing.T) {
+	testCases := []struct {
+		name string
+		body string
+	}{
+		{name: "missing", body: `{"access_token":"secret-token"}`},
+		{name: "zero", body: `{"access_token":"secret-token","expires_in":0}`},
+		{name: "negative", body: `{"access_token":"secret-token","expires_in":-1}`},
+		{name: "not numeric", body: `{"access_token":"secret-token","expires_in":"3600"}`},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
+			if err != nil {
+				t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
+			}
+			httpClient := mockOAuthServer(testCase.body, http.StatusOK)
+			if _, err := wia.GetToken(t.Context(), httpClient); err == nil {
+				t.Fatal("GetToken() error = nil")
+			} else if strings.Contains(err.Error(), "secret-token") {
+				t.Errorf("GetToken() error contains access token: %v", err)
+			}
+		})
+	}
+}
+
+func TestIDTokenWorkloadIdentityRegression(t *testing.T) {
+	provider := &mockProvider{token: "id-subject-token", tokenType: auth.SubjectTokenTypeID}
+	var requestURL string
+	var requestBody map[string]any
+	httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+		requestURL = req.URL.String()
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		if err := json.Unmarshal(body, &requestBody); err != nil {
+			return nil, err
+		}
+		return tokenResponse("id-token-exchange", 3600), nil
+	}}}
+	wia, err := auth.NewWorkloadIdentityAuth(auth.WorkloadIdentity{
+		IdentityProviderID: "idp-test",
+		ServiceAccountID:   "svc-test",
+		Provider:           provider,
+	})
+	if err != nil {
+		t.Fatalf("NewWorkloadIdentityAuth() error = %v", err)
+	}
+	if _, err := wia.GetToken(t.Context(), httpClient); err != nil {
+		t.Fatalf("GetToken() error = %v", err)
+	}
+	if got, want := requestURL, "https://auth.openai.com/oauth/token"; got != want {
+		t.Errorf("request URL = %q, want %q", got, want)
+	}
+	if got, want := requestBody["subject_token"], "id-subject-token"; got != want {
+		t.Errorf("subject_token = %v, want %q", got, want)
+	}
+	if got, want := requestBody["subject_token_type"], "urn:ietf:params:oauth:token-type:id_token"; got != want {
+		t.Errorf("subject_token_type = %v, want %q", got, want)
+	}
+}
+
+func TestX509TokenExchangeRetriesTransientFailures(t *testing.T) {
+	var calls atomic.Int32
+	httpClient := &http.Client{Transport: &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+		switch calls.Add(1) {
+		case 1:
+			return nil, errors.New("temporary connection failure")
+		case 2:
+			return &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Header:     http.Header{"Retry-After": []string{"0"}},
+				Body:       io.NopCloser(strings.NewReader(`{"error":"rate_limit"}`)),
+			}, nil
+		default:
+			return tokenResponse("retried-token", 60), nil
+		}
+	}}}
+
+	wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
+	if err != nil {
+		t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
+	}
+	if _, err := wia.GetToken(t.Context(), httpClient); err != nil {
+		t.Fatalf("GetToken() error = %v", err)
+	}
+	if got, want := calls.Load(), int32(3); got != want {
+		t.Errorf("token exchange calls = %d, want %d", got, want)
+	}
+}
+
+func TestX509TokenExchangeRetriesAreBounded(t *testing.T) {
+	var calls atomic.Int32
+	httpClient := &http.Client{Transport: &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+		calls.Add(1)
+		return &http.Response{
+			StatusCode: http.StatusServiceUnavailable,
+			Header:     http.Header{"Retry-After": []string{"0"}},
+			Body:       io.NopCloser(strings.NewReader(`{"access_token":"must-not-leak"}`)),
+		}, nil
+	}}}
+
+	wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
+	if err != nil {
+		t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
+	}
+	_, err = wia.GetToken(t.Context(), httpClient)
+	if err == nil {
+		t.Fatal("GetToken() error = nil")
+	}
+	if got, want := calls.Load(), int32(3); got != want {
+		t.Errorf("token exchange calls = %d, want %d", got, want)
+	}
+	if strings.Contains(err.Error(), "must-not-leak") {
+		t.Errorf("GetToken() error contains response body: %v", err)
+	}
+}
+
+func TestX509TokenExchangeRetryWaitHonorsContext(t *testing.T) {
+	requestStarted := make(chan struct{})
+	var once sync.Once
+	httpClient := &http.Client{Transport: &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+		once.Do(func() { close(requestStarted) })
+		return &http.Response{
+			StatusCode: http.StatusTooManyRequests,
+			Header:     http.Header{"Retry-After": []string{"60"}},
+			Body:       io.NopCloser(strings.NewReader(`{"error":"rate_limit"}`)),
+		}, nil
+	}}}
+
+	wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
+	if err != nil {
+		t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() {
+		_, getTokenErr := wia.GetToken(ctx, httpClient)
+		done <- getTokenErr
+	}()
+	<-requestStarted
+	cancel()
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Errorf("GetToken() error = %v, want context.Canceled", err)
+	}
+}
+
+func TestX509TokenExchangeRefusesRedirects(t *testing.T) {
+	var redirectedRequests atomic.Int32
+	redirectTarget := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		redirectedRequests.Add(1)
+	}))
+	t.Cleanup(redirectTarget.Close)
+
+	httpClient := &http.Client{
+		Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+			if req.URL.Host == "mtls.auth.openai.com" {
+				return &http.Response{
+					StatusCode: http.StatusFound,
+					Header:     http.Header{"Location": []string{redirectTarget.URL}},
+					Body:       io.NopCloser(strings.NewReader("redirect")),
+				}, nil
+			}
+			return http.DefaultTransport.RoundTrip(req)
+		}},
+		CheckRedirect: func(*http.Request, []*http.Request) error { return nil },
+	}
+
+	wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
+	if err != nil {
+		t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
+	}
+	if _, err := wia.GetToken(t.Context(), httpClient); err == nil {
+		t.Fatal("GetToken() error = nil")
+	}
+	if got := redirectedRequests.Load(); got != 0 {
+		t.Errorf("redirect target requests = %d, want 0", got)
+	}
+}
+
+func TestX509CanceledWaiterDoesNotCancelRefresh(t *testing.T) {
+	exchangeStarted := make(chan struct{})
+	releaseExchange := make(chan struct{})
+	httpClient := &http.Client{Transport: &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+		close(exchangeStarted)
+		<-releaseExchange
+		return tokenResponse("shared-token", 60), nil
+	}}}
+
+	wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
+	if err != nil {
+		t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
+	}
+	leaderDone := make(chan error, 1)
+	go func() {
+		_, getTokenErr := wia.GetToken(t.Context(), httpClient)
+		leaderDone <- getTokenErr
+	}()
+	<-exchangeStarted
+
+	waiterCtx, cancelWaiter := context.WithCancel(t.Context())
+	cancelWaiter()
+	if _, err := wia.GetToken(waiterCtx, httpClient); !errors.Is(err, context.Canceled) {
+		t.Errorf("waiter GetToken() error = %v, want context.Canceled", err)
+	}
+	select {
+	case err := <-leaderDone:
+		t.Fatalf("shared refresh completed before release with error %v", err)
+	default:
+	}
+
+	close(releaseExchange)
+	if err := <-leaderDone; err != nil {
+		t.Fatalf("leader GetToken() error = %v", err)
+	}
+}
+
+func TestX509InitialRefreshIsSingleFlight(t *testing.T) {
+	exchangeStarted := make(chan struct{})
+	releaseExchange := make(chan struct{})
+	var calls atomic.Int32
+	var startOnce sync.Once
+	httpClient := &http.Client{Transport: &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+		calls.Add(1)
+		startOnce.Do(func() { close(exchangeStarted) })
+		<-releaseExchange
+		return tokenResponse("shared-token", 60), nil
+	}}}
+	wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
+	if err != nil {
+		t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
+	}
+
+	const goroutines = 16
+	start := make(chan struct{})
+	results := make(chan error, goroutines)
+	for range goroutines {
+		go func() {
+			<-start
+			token, getTokenErr := wia.GetToken(t.Context(), httpClient)
+			if getTokenErr == nil && token != "shared-token" {
+				getTokenErr = fmt.Errorf("GetToken() = %q, want shared-token", token)
+			}
+			results <- getTokenErr
+		}()
+	}
+	close(start)
+	<-exchangeStarted
+	close(releaseExchange)
+	for range goroutines {
+		if err := <-results; err != nil {
+			t.Error(err)
+		}
+	}
+	if got, want := calls.Load(), int32(1); got != want {
+		t.Errorf("token exchange calls = %d, want %d", got, want)
+	}
+}
+
+func TestX509ExpiredTokenRefreshesSynchronously(t *testing.T) {
+	var calls atomic.Int32
+	httpClient := &http.Client{Transport: &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+		call := calls.Add(1)
+		return tokenResponse(fmt.Sprintf("token-%d", call), 0.1), nil
+	}}}
+	config := testX509WorkloadIdentity()
+	config.RefreshBuffer = time.Nanosecond
+	wia, err := auth.NewX509WorkloadIdentityAuth(config)
+	if err != nil {
+		t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
+	}
+
+	if token, err := wia.GetToken(t.Context(), httpClient); err != nil || token != "token-1" {
+		t.Fatalf("first GetToken() = %q, %v; want token-1, nil", token, err)
+	}
+	time.Sleep(150 * time.Millisecond)
+	if token, err := wia.GetToken(t.Context(), httpClient); err != nil || token != "token-2" {
+		t.Fatalf("second GetToken() = %q, %v; want token-2, nil", token, err)
+	}
+	if got, want := calls.Load(), int32(2); got != want {
+		t.Errorf("token exchange calls = %d, want %d", got, want)
+	}
+}
+
+func TestX509RefreshBufferClampedToHalfTTL(t *testing.T) {
+	var calls atomic.Int32
+	secondExchange := make(chan struct{})
+	httpClient := &http.Client{Transport: &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+		call := calls.Add(1)
+		if call == 2 {
+			close(secondExchange)
+		}
+		return tokenResponse(fmt.Sprintf("token-%d", call), 1), nil
+	}}}
+	config := testX509WorkloadIdentity()
+	config.RefreshBuffer = 10 * time.Second
+	wia, err := auth.NewX509WorkloadIdentityAuth(config)
+	if err != nil {
+		t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
+	}
+
+	if _, err := wia.GetToken(t.Context(), httpClient); err != nil {
+		t.Fatalf("first GetToken() error = %v", err)
+	}
+	if _, err := wia.GetToken(t.Context(), httpClient); err != nil {
+		t.Fatalf("second GetToken() error = %v", err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("immediate token exchange calls = %d, want 1", got)
+	}
+
+	time.Sleep(600 * time.Millisecond)
+	if _, err := wia.GetToken(t.Context(), httpClient); err != nil {
+		t.Fatalf("proactive GetToken() error = %v", err)
+	}
+	select {
+	case <-secondExchange:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for proactive refresh")
+	}
+}
+
+func TestX509Concurrent401InvalidationKeepsNewToken(t *testing.T) {
+	var exchangeCalls atomic.Int32
+	exchangeClient := &http.Client{Transport: &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+		call := exchangeCalls.Add(1)
+		return tokenResponse(fmt.Sprintf("token-%d", call), 60), nil
+	}}}
+	wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
+	if err != nil {
+		t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
+	}
+	if _, err := wia.GetToken(t.Context(), exchangeClient); err != nil {
+		t.Fatalf("initial GetToken() error = %v", err)
+	}
+
+	bothOldRequestsStarted := make(chan struct{})
+	newTokenUsed := make(chan struct{})
+	var oldTokenCalls atomic.Int32
+	var bothOnce sync.Once
+	var newOnce sync.Once
+	next := func(req *http.Request) (*http.Response, error) {
+		switch req.Header.Get("Authorization") {
+		case "Bearer token-1":
+			call := oldTokenCalls.Add(1)
+			if call == 2 {
+				bothOnce.Do(func() { close(bothOldRequestsStarted) })
+				<-newTokenUsed
+			} else {
+				<-bothOldRequestsStarted
+			}
+			return &http.Response{StatusCode: http.StatusUnauthorized, Body: http.NoBody, Header: make(http.Header)}, nil
+		case "Bearer token-2":
+			newOnce.Do(func() { close(newTokenUsed) })
+			return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Header: make(http.Header)}, nil
+		default:
+			return nil, fmt.Errorf("unexpected authorization header %q", req.Header.Get("Authorization"))
+		}
+	}
+
+	results := make(chan error, 2)
+	for range 2 {
+		go func() {
+			req, reqErr := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://mtls.api.openai.com/v1/models", nil)
+			if reqErr != nil {
+				results <- reqErr
+				return
+			}
+			resp, middlewareErr := auth.WorkloadIdentityMiddleware(wia, exchangeClient, req, next)
+			if resp != nil && resp.Body != nil {
+				_ = resp.Body.Close()
+			}
+			results <- middlewareErr
+		}()
+	}
+	for range 2 {
+		if err := <-results; err != nil {
+			t.Errorf("WorkloadIdentityMiddleware() error = %v", err)
+		}
+	}
+	if got, want := exchangeCalls.Load(), int32(2); got != want {
+		t.Errorf("token exchange calls = %d, want %d", got, want)
+	}
+}

--- a/auth/x509workloadidentity_test.go
+++ b/auth/x509workloadidentity_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/openai/openai-go/v3/auth"
+	"github.com/openai/openai-go/v3/internal"
 )
 
 type closeTrackingReadCloser struct {
@@ -94,6 +95,46 @@ func TestX509WorkloadIdentityDoesNotOwnCertificateMaterial(t *testing.T) {
 	wantFields := []string{"IdentityProviderID", "ServiceAccountID", "RefreshBuffer"}
 	if !reflect.DeepEqual(gotFields, wantFields) {
 		t.Errorf("X509WorkloadIdentity fields = %v, want %v", gotFields, wantFields)
+	}
+}
+
+func TestX509WorkloadIdentityMiddlewareRequiresRequestPolicyBeforeExchange(t *testing.T) {
+	var exchangeCalls atomic.Int32
+	var nextCalls atomic.Int32
+	exchangeClient := &http.Client{Transport: &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+		exchangeCalls.Add(1)
+		return tokenResponse("x509-token", 60), nil
+	}}}
+	wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
+	if err != nil {
+		t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
+	}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://attacker.invalid/collect", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := auth.WorkloadIdentityMiddleware(wia, exchangeClient, req, func(*http.Request) (*http.Response, error) {
+		nextCalls.Add(1)
+		return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+	})
+	if err == nil {
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+		t.Fatal("WorkloadIdentityMiddleware() error = nil")
+	}
+	if resp != nil {
+		if resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+		t.Errorf("WorkloadIdentityMiddleware() response = %#v, want nil", resp)
+	}
+	if got := exchangeCalls.Load(); got != 0 {
+		t.Errorf("token exchange calls = %d, want 0", got)
+	}
+	if got := nextCalls.Load(); got != 0 {
+		t.Errorf("next calls = %d, want 0", got)
 	}
 }
 
@@ -735,7 +776,7 @@ func TestX509Concurrent401InvalidationKeepsNewToken(t *testing.T) {
 				results <- reqErr
 				return
 			}
-			resp, middlewareErr := auth.WorkloadIdentityMiddleware(wia, exchangeClient, req, next)
+			resp, middlewareErr := auth.WorkloadIdentityMiddleware(wia, exchangeClient, internal.WithX509RequestPolicy(req), next)
 			if resp != nil && resp.Body != nil {
 				_ = resp.Body.Close()
 			}
@@ -777,7 +818,7 @@ func TestX509Second401InvalidatesReplayToken(t *testing.T) {
 		if reqErr != nil {
 			t.Fatal(reqErr)
 		}
-		resp, middlewareErr := auth.WorkloadIdentityMiddleware(wia, exchangeClient, req, next)
+		resp, middlewareErr := auth.WorkloadIdentityMiddleware(wia, exchangeClient, internal.WithX509RequestPolicy(req), next)
 		if middlewareErr != nil {
 			t.Fatalf("WorkloadIdentityMiddleware() error = %v", middlewareErr)
 		}
@@ -883,7 +924,7 @@ func testX509ReplayBodyClose(t *testing.T, downstreamClosesBody bool) {
 		return nil, middlewareErr
 	}
 
-	resp, err := auth.WorkloadIdentityMiddleware(wia, exchangeClient, req, next)
+	resp, err := auth.WorkloadIdentityMiddleware(wia, exchangeClient, internal.WithX509RequestPolicy(req), next)
 	if !errors.Is(err, middlewareErr) {
 		t.Fatalf("WorkloadIdentityMiddleware() error = %v, want %v", err, middlewareErr)
 	}

--- a/auth/x509workloadidentity_transport_test.go
+++ b/auth/x509workloadidentity_transport_test.go
@@ -1,6 +1,10 @@
 package auth_test
 
 import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"net"
 	"net/http"
 	"sync/atomic"
 	"testing"
@@ -99,4 +103,59 @@ func TestX509WorkloadIdentityAuthRejectsHTTPTransportChange(t *testing.T) {
 			t.Errorf("default HTTP transport B exchange calls = %d, want 0", got)
 		}
 	})
+}
+
+func TestX509WorkloadIdentityAuthRequiresImmutableNativeTransportIdentity(t *testing.T) {
+	staticCertificate := []tls.Certificate{{Certificate: [][]byte{{1}}, PrivateKey: struct{}{}}}
+	testCases := []struct {
+		name      string
+		transport *http.Transport
+	}{
+		{name: "missing static certificate", transport: &http.Transport{}},
+		{
+			name: "certificate selection hook",
+			transport: &http.Transport{TLSClientConfig: &tls.Config{
+				Certificates: staticCertificate,
+				GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+					return &staticCertificate[0], nil
+				},
+			}},
+		},
+		{
+			name: "multiple static certificates",
+			transport: &http.Transport{TLSClientConfig: &tls.Config{
+				Certificates: append(staticCertificate, tls.Certificate{}),
+			}},
+		},
+		{
+			name: "legacy TLS dial hook",
+			transport: &http.Transport{
+				TLSClientConfig: &tls.Config{Certificates: staticCertificate},
+				DialTLS: func(string, string) (net.Conn, error) {
+					return nil, errors.New("must not be called")
+				},
+			},
+		},
+		{
+			name: "context TLS dial hook",
+			transport: &http.Transport{
+				TLSClientConfig: &tls.Config{Certificates: staticCertificate},
+				DialTLSContext: func(context.Context, string, string) (net.Conn, error) {
+					return nil, errors.New("must not be called")
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
+			if err != nil {
+				t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
+			}
+			if _, err := wia.GetToken(t.Context(), &http.Client{Transport: testCase.transport}); err == nil {
+				t.Fatal("GetToken() error = nil")
+			}
+		})
+	}
 }

--- a/auth/x509workloadidentity_transport_test.go
+++ b/auth/x509workloadidentity_transport_test.go
@@ -1,0 +1,102 @@
+package auth_test
+
+import (
+	"net/http"
+	"sync/atomic"
+	"testing"
+
+	"github.com/openai/openai-go/v3/auth"
+)
+
+func TestX509WorkloadIdentityAuthRejectsHTTPTransportChange(t *testing.T) {
+	t.Run("explicit transport", func(t *testing.T) {
+		var callsA atomic.Int32
+		var callsB atomic.Int32
+		transportA := &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+			callsA.Add(1)
+			return tokenResponse("token-a", 60), nil
+		}}
+		transportB := &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+			callsB.Add(1)
+			return tokenResponse("token-b", 60), nil
+		}}
+		httpClient := &http.Client{Transport: transportA}
+		wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
+		if err != nil {
+			t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
+		}
+
+		token, err := wia.GetToken(t.Context(), httpClient)
+		if err != nil {
+			t.Fatalf("first GetToken() error = %v", err)
+		}
+		if token != "token-a" {
+			t.Fatalf("first GetToken() = %q, want token-a", token)
+		}
+		token, err = wia.GetToken(t.Context(), httpClient)
+		if err != nil {
+			t.Fatalf("cached GetToken() error = %v", err)
+		}
+		if token != "token-a" {
+			t.Fatalf("cached GetToken() = %q, want token-a", token)
+		}
+
+		httpClient.Transport = transportB
+		ctx := t.Context()
+		const callers = 16
+		errs := make(chan error, callers)
+		for range callers {
+			go func() {
+				_, getErr := wia.GetToken(ctx, httpClient)
+				errs <- getErr
+			}()
+		}
+		for range callers {
+			if getErr := <-errs; getErr == nil {
+				t.Error("GetToken() after HTTP transport change error = nil")
+			}
+		}
+		if got, want := callsA.Load(), int32(1); got != want {
+			t.Errorf("HTTP transport A exchange calls = %d, want %d", got, want)
+		}
+		if got := callsB.Load(); got != 0 {
+			t.Errorf("HTTP transport B exchange calls = %d, want 0", got)
+		}
+	})
+
+	t.Run("default transport", func(t *testing.T) {
+		originalDefaultTransport := http.DefaultTransport
+		t.Cleanup(func() {
+			http.DefaultTransport = originalDefaultTransport
+		})
+
+		var callsA atomic.Int32
+		var callsB atomic.Int32
+		http.DefaultTransport = &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+			callsA.Add(1)
+			return tokenResponse("token-a", 60), nil
+		}}
+		httpClient := &http.Client{}
+		wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
+		if err != nil {
+			t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
+		}
+		if _, err := wia.GetToken(t.Context(), httpClient); err != nil {
+			t.Fatalf("first GetToken() error = %v", err)
+		}
+
+		http.DefaultTransport = &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+			callsB.Add(1)
+			return tokenResponse("token-b", 60), nil
+		}}
+		if _, err := wia.GetToken(t.Context(), httpClient); err == nil {
+			t.Fatal("GetToken() after default HTTP transport change error = nil")
+		}
+		if got, want := callsA.Load(), int32(1); got != want {
+			t.Errorf("default HTTP transport A exchange calls = %d, want %d", got, want)
+		}
+		if got := callsB.Load(); got != 0 {
+			t.Errorf("default HTTP transport B exchange calls = %d, want 0", got)
+		}
+	})
+}

--- a/auth/x509workloadidentity_transport_test.go
+++ b/auth/x509workloadidentity_transport_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -16,15 +17,15 @@ func TestX509WorkloadIdentityAuthRejectsHTTPTransportChange(t *testing.T) {
 	t.Run("explicit transport", func(t *testing.T) {
 		var callsA atomic.Int32
 		var callsB atomic.Int32
-		transportA := &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+		clientA := nativeX509HTTPClient(t, func(*http.Request) (*http.Response, error) {
 			callsA.Add(1)
 			return tokenResponse("token-a", 60), nil
-		}}
-		transportB := &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+		})
+		clientB := nativeX509HTTPClient(t, func(*http.Request) (*http.Response, error) {
 			callsB.Add(1)
 			return tokenResponse("token-b", 60), nil
-		}}
-		httpClient := &http.Client{Transport: transportA}
+		})
+		httpClient := &http.Client{Transport: clientA.Transport}
 		wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
 		if err != nil {
 			t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
@@ -45,7 +46,7 @@ func TestX509WorkloadIdentityAuthRejectsHTTPTransportChange(t *testing.T) {
 			t.Fatalf("cached GetToken() = %q, want token-a", token)
 		}
 
-		httpClient.Transport = transportB
+		httpClient.Transport = clientB.Transport
 		ctx := t.Context()
 		const callers = 16
 		errs := make(chan error, callers)
@@ -76,10 +77,11 @@ func TestX509WorkloadIdentityAuthRejectsHTTPTransportChange(t *testing.T) {
 
 		var callsA atomic.Int32
 		var callsB atomic.Int32
-		http.DefaultTransport = &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+		clientA := nativeX509HTTPClient(t, func(*http.Request) (*http.Response, error) {
 			callsA.Add(1)
 			return tokenResponse("token-a", 60), nil
-		}}
+		})
+		http.DefaultTransport = clientA.Transport
 		httpClient := &http.Client{}
 		wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
 		if err != nil {
@@ -89,10 +91,11 @@ func TestX509WorkloadIdentityAuthRejectsHTTPTransportChange(t *testing.T) {
 			t.Fatalf("first GetToken() error = %v", err)
 		}
 
-		http.DefaultTransport = &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+		clientB := nativeX509HTTPClient(t, func(*http.Request) (*http.Response, error) {
 			callsB.Add(1)
 			return tokenResponse("token-b", 60), nil
-		}}
+		})
+		http.DefaultTransport = clientB.Transport
 		if _, err := wia.GetToken(t.Context(), httpClient); err == nil {
 			t.Fatal("GetToken() after default HTTP transport change error = nil")
 		}
@@ -157,5 +160,73 @@ func TestX509WorkloadIdentityAuthRequiresImmutableNativeTransportIdentity(t *tes
 				t.Fatal("GetToken() error = nil")
 			}
 		})
+	}
+}
+
+func TestX509WorkloadIdentityAuthRejectsClientSessionCacheBeforeExchange(t *testing.T) {
+	var dialCalls atomic.Int32
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			Certificates:       []tls.Certificate{{Certificate: [][]byte{{1}}}},
+			ClientSessionCache: tls.NewLRUClientSessionCache(1),
+		},
+		DialContext: func(context.Context, string, string) (net.Conn, error) {
+			dialCalls.Add(1)
+			return nil, errors.New("must not dial")
+		},
+	}
+	wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
+	if err != nil {
+		t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
+	}
+
+	if _, err := wia.GetToken(t.Context(), &http.Client{Transport: transport}); err == nil || !strings.Contains(err.Error(), "session caching") {
+		t.Fatalf("GetToken() error = %v, want client session cache rejection", err)
+	}
+	if got := dialCalls.Load(); got != 0 {
+		t.Fatalf("dial calls = %d, want 0", got)
+	}
+}
+
+func TestX509WorkloadIdentityAuthRejectsStaticCertificateMutation(t *testing.T) {
+	var calls atomic.Int32
+	httpClient := nativeX509HTTPClient(t, func(*http.Request) (*http.Response, error) {
+		calls.Add(1)
+		return tokenResponse("token-a", 60), nil
+	})
+	wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
+	if err != nil {
+		t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
+	}
+	if _, err := wia.GetToken(t.Context(), httpClient); err != nil {
+		t.Fatalf("first GetToken() error = %v", err)
+	}
+
+	transport := httpClient.Transport.(*http.Transport)
+	transport.TLSClientConfig.Certificates[0].Certificate[0] = []byte{2}
+	if _, err := wia.GetToken(t.Context(), httpClient); err == nil || !strings.Contains(err.Error(), "cannot change client certificates") {
+		t.Fatalf("GetToken() after certificate mutation error = %v, want identity rejection", err)
+	}
+	if got, want := calls.Load(), int32(1); got != want {
+		t.Fatalf("token exchange calls = %d, want %d", got, want)
+	}
+}
+
+func TestX509WorkloadIdentityAuthRejectsOpaqueRoundTripperBeforeExchange(t *testing.T) {
+	var calls atomic.Int32
+	httpClient := &http.Client{Transport: &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+		calls.Add(1)
+		return tokenResponse("must-not-be-used", 60), nil
+	}}}
+	wia, err := auth.NewX509WorkloadIdentityAuth(testX509WorkloadIdentity())
+	if err != nil {
+		t.Fatalf("NewX509WorkloadIdentityAuth() error = %v", err)
+	}
+
+	if _, err := wia.GetToken(t.Context(), httpClient); err == nil || !strings.Contains(err.Error(), "native *http.Transport") {
+		t.Fatalf("GetToken() error = %v, want opaque transport rejection", err)
+	}
+	if got := calls.Load(); got != 0 {
+		t.Fatalf("token exchange calls = %d, want 0", got)
 	}
 }

--- a/auth_test.go
+++ b/auth_test.go
@@ -23,6 +23,19 @@ type mockSubjectTokenProvider struct {
 	mu        sync.Mutex
 }
 
+type observingSubjectTokenProvider struct {
+	httpDoer auth.HTTPDoer
+}
+
+func (*observingSubjectTokenProvider) TokenType() auth.SubjectTokenType {
+	return auth.SubjectTokenTypeJWT
+}
+
+func (p *observingSubjectTokenProvider) GetToken(_ context.Context, httpDoer auth.HTTPDoer) (string, error) {
+	p.httpDoer = httpDoer
+	return "test-subject-token", nil
+}
+
 func (m *mockSubjectTokenProvider) TokenType() auth.SubjectTokenType {
 	return m.tokenType
 }
@@ -45,6 +58,32 @@ func testWorkloadIdentity(provider auth.SubjectTokenProvider) auth.WorkloadIdent
 		IdentityProviderID: "test-idp-id",
 		ServiceAccountID:   "test-sa-id",
 		Provider:           provider,
+	}
+}
+
+func TestClientWorkloadIdentityPreservesNonComparableHTTPDoerForProvider(t *testing.T) {
+	provider := &observingSubjectTokenProvider{}
+	httpDoer := nonComparableHTTPDoer{do: func(req *http.Request) (*http.Response, error) {
+		if req.URL.Host == "auth.openai.com" {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"access_token":"exchanged-token","expires_in":3600}`)),
+			}, nil
+		}
+		return modelsListResponse(), nil
+	}}
+	client := openai.NewClient(
+		option.WithWorkloadIdentity(testWorkloadIdentity(provider)),
+		option.WithHTTPClient(httpDoer),
+		option.WithMaxRetries(0),
+	)
+
+	if _, err := client.Models.List(t.Context()); err != nil {
+		t.Fatalf("Models.List() error = %v", err)
+	}
+	if _, ok := provider.httpDoer.(nonComparableHTTPDoer); !ok {
+		t.Fatalf("provider HTTP doer type = %T, want nonComparableHTTPDoer", provider.httpDoer)
 	}
 }
 

--- a/azure/azure.go
+++ b/azure/azure.go
@@ -113,6 +113,7 @@ func WithTokenCredentialScopes(scopes []string) func(*tokenCredentialConfig) err
 // [Azure Identity]: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity
 func WithTokenCredential(tokenCredential azcore.TokenCredential, options ...TokenCredentialOption) option.RequestOption {
 	return requestconfig.RequestOptionFunc(func(rc *requestconfig.RequestConfig) error {
+		rc.SetProviderAuthentication(requestconfig.ProviderAuthenticationAzure)
 		tc := &tokenCredentialConfig{
 			Scopes: []string{"https://cognitiveservices.azure.com/.default"},
 		}
@@ -155,6 +156,7 @@ func WithAPIKey(apiKey string) option.RequestOption {
 	// Api-Key instead. Deleting Authorization also prevents request security from
 	// automatically injecting environment-derived client credentials.
 	return requestconfig.RequestOptionFunc(func(rc *requestconfig.RequestConfig) error {
+		rc.SetProviderAuthentication(requestconfig.ProviderAuthenticationAzure)
 		return rc.Apply(
 			option.WithHeaderDel("Authorization"),
 			option.WithHeader("Api-Key", apiKey),

--- a/azure/azure.go
+++ b/azure/azure.go
@@ -35,7 +35,8 @@ import (
 	"github.com/openai/openai-go/v3/option"
 )
 
-// WithEndpoint configures this client to connect to an Azure OpenAI endpoint.
+// WithEndpoint configures this client to connect to an Azure OpenAI endpoint
+// and marks requests as Azure provider traffic.
 //
 //   - endpoint - the Azure OpenAI endpoint to connect to. Ex: https://<azure-openai-resource>.openai.azure.com
 //   - apiVersion - the Azure OpenAI API version to target (ex: 2024-06-01). See [Azure OpenAI apiversions] for current API versions. This value cannot be empty.
@@ -74,6 +75,7 @@ func WithEndpoint(endpoint string, apiVersion string) option.RequestOption {
 		if apiVersion == "" {
 			return errors.New("apiVersion is an empty string, but needs to be set. See https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#rest-api-versioning for details.")
 		}
+		rc.SetProviderAuthentication(requestconfig.ProviderAuthenticationAzure)
 
 		if err := withQueryAdd.Apply(rc); err != nil {
 			return err

--- a/bedrock/auth.go
+++ b/bedrock/auth.go
@@ -80,6 +80,9 @@ func newClientOptions(
 	}
 	opts = append(opts, userOpts...)
 	opts = append(opts, requestconfig.WithRequestFinalizer(func(rc *requestconfig.RequestConfig) error {
+		if resolved.mode != authModeSkip {
+			rc.SetProviderAuthentication(requestconfig.ProviderAuthenticationBedrock)
+		}
 		if resolved.mode != authModeSkip && (rc.APIKey != "" || rc.AdminAPIKey != "") {
 			return errors.New("bedrock: provider authentication cannot be combined with an OpenAI API key; configure authentication in `bedrock.Config`")
 		}

--- a/bedrock/auth.go
+++ b/bedrock/auth.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/openai/openai-go/v3/internal"
 	"github.com/openai/openai-go/v3/internal/requestconfig"
 	"github.com/openai/openai-go/v3/option"
 )
@@ -467,10 +468,10 @@ func verifyAWSCredentials(ctx context.Context, awsCfg aws.Config, explicitAWS bo
 func bearerMiddleware(baseURL *url.URL, provider TokenProvider) option.Middleware {
 	return func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
 		if err := validateProviderRequest(req, baseURL); err != nil {
-			return nil, requestconfig.WithNoRetryError(err)
+			return nil, internal.WithNoRetryError(err)
 		}
 		if req.Header.Get("Authorization") != "" {
-			return nil, requestconfig.WithNoRetryError(errors.New("bedrock: provider authentication cannot be combined with a custom `Authorization` header"))
+			return nil, internal.WithNoRetryError(errors.New("bedrock: provider authentication cannot be combined with a custom `Authorization` header"))
 		}
 
 		token, err := provider(req.Context())
@@ -479,7 +480,7 @@ func bearerMiddleware(baseURL *url.URL, provider TokenProvider) option.Middlewar
 		}
 		token = strings.TrimSpace(token)
 		if token == "" {
-			return nil, requestconfig.WithNoRetryError(errors.New("bedrock: bearer credential provider must return a non-empty string"))
+			return nil, internal.WithNoRetryError(errors.New("bedrock: bearer credential provider must return a non-empty string"))
 		}
 		req.Header.Set("Authorization", "Bearer "+token)
 		return next(req)
@@ -501,25 +502,25 @@ func endpointSigV4Middleware(baseURL *url.URL, cfg aws.Config, signer httpSigner
 	}
 	return func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
 		if err := validateProviderRequest(req, baseURL); err != nil {
-			return nil, requestconfig.WithNoRetryError(err)
+			return nil, internal.WithNoRetryError(err)
 		}
 		if req.Header.Get("Authorization") != "" {
-			return nil, requestconfig.WithNoRetryError(errors.New("bedrock: provider authentication cannot be combined with a custom `Authorization` header"))
+			return nil, internal.WithNoRetryError(errors.New("bedrock: provider authentication cannot be combined with a custom `Authorization` header"))
 		}
 		if _, err := reconcileEndpointRegion(req.URL, cfg.Region); err != nil {
-			return nil, requestconfig.WithNoRetryError(err)
+			return nil, internal.WithNoRetryError(err)
 		}
 
 		body, err := materializeReplayableBody(req)
 		if err != nil {
-			return nil, requestconfig.WithNoRetryError(err)
+			return nil, internal.WithNoRetryError(err)
 		}
 		credentials, err := cfg.Credentials.Retrieve(req.Context())
 		if err != nil {
 			return nil, &safeError{message: credentialResolutionMessage, cause: err}
 		}
 		if strings.TrimSpace(credentials.AccessKeyID) == "" || strings.TrimSpace(credentials.SecretAccessKey) == "" {
-			return nil, requestconfig.WithNoRetryError(errors.New(credentialResolutionMessage))
+			return nil, internal.WithNoRetryError(errors.New(credentialResolutionMessage))
 		}
 
 		req.Method = strings.ToUpper(req.Method)

--- a/bedrock/auth.go
+++ b/bedrock/auth.go
@@ -80,9 +80,7 @@ func newClientOptions(
 	}
 	opts = append(opts, userOpts...)
 	opts = append(opts, requestconfig.WithRequestFinalizer(func(rc *requestconfig.RequestConfig) error {
-		if resolved.mode != authModeSkip {
-			rc.SetProviderAuthentication(requestconfig.ProviderAuthenticationBedrock)
-		}
+		rc.SetProviderAuthentication(requestconfig.ProviderAuthenticationBedrock)
 		if resolved.mode != authModeSkip && (rc.APIKey != "" || rc.AdminAPIKey != "") {
 			return errors.New("bedrock: provider authentication cannot be combined with an OpenAI API key; configure authentication in `bedrock.Config`")
 		}

--- a/bedrock/auth_additional_test.go
+++ b/bedrock/auth_additional_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	"github.com/openai/openai-go/v3/auth"
 	"github.com/openai/openai-go/v3/option"
 )
 
@@ -145,6 +146,35 @@ func TestSkipAuthAllowsExplicitGatewayCredentials(t *testing.T) {
 				t.Fatalf("Authorization = %q, want %q", got, test.authorization)
 			}
 		})
+	}
+}
+
+func TestSkipAuthRejectsX509WorkloadIdentityBeforeExchange(t *testing.T) {
+	var transportCalls int
+	client, err := NewClient(context.Background(), Config{
+		SkipAuth: true,
+		BaseURL:  "https://private-bedrock-gateway.example/openai/v1",
+	},
+		option.WithX509WorkloadIdentity(auth.X509WorkloadIdentity{
+			IdentityProviderID: "idp-test",
+			ServiceAccountID:   "svc-test",
+		}),
+		option.WithHTTPClient(httpDoerFunc(func(req *http.Request) (*http.Response, error) {
+			transportCalls++
+			return successfulResponse(req), nil
+		})),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var response *http.Response
+	err = client.Get(context.Background(), "/models", nil, &response)
+	if err == nil || !strings.Contains(err.Error(), "Bedrock provider authentication") {
+		t.Fatalf("error = %v, want Bedrock/X.509 incompatibility", err)
+	}
+	if transportCalls != 0 {
+		t.Fatalf("transport calls = %d, want 0", transportCalls)
 	}
 }
 

--- a/bedrock/auth_test.go
+++ b/bedrock/auth_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/auth"
 	"github.com/openai/openai-go/v3/option"
 )
 
@@ -34,6 +35,35 @@ func successfulResponse(req *http.Request) *http.Response {
 		Header:     http.Header{"Content-Type": {"application/json"}},
 		Body:       io.NopCloser(strings.NewReader(`{}`)),
 		Request:    req,
+	}
+}
+
+func TestProviderAuthenticationRejectsX509BeforeExchange(t *testing.T) {
+	var calls atomic.Int32
+	httpClient := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls.Add(1)
+		return nil, errors.New("HTTP request must not be attempted")
+	})}
+	client, err := NewClient(t.Context(), Config{
+		APIKey:    "bedrock-key",
+		AWSRegion: "us-east-1",
+		BaseURL:   "https://bedrock.example/openai/v1",
+	},
+		option.WithX509WorkloadIdentity(auth.X509WorkloadIdentity{
+			IdentityProviderID: "idp-test",
+			ServiceAccountID:   "svc-test",
+		}),
+		option.WithHTTPClient(httpClient),
+	)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	if _, err := client.Models.List(t.Context()); err == nil {
+		t.Fatal("Models.List() error = nil")
+	}
+	if got := calls.Load(); got != 0 {
+		t.Fatalf("HTTP calls = %d, want 0", got)
 	}
 }
 

--- a/examples/x509-workload-identity/main.go
+++ b/examples/x509-workload-identity/main.go
@@ -100,9 +100,6 @@ func newX509HTTPClient(certificateChainPath string, privateKeyPath string) (*htt
 	transport.TLSClientConfig = &tls.Config{
 		Certificates: []tls.Certificate{certificate},
 		MinVersion:   tls.VersionTLS12,
-		GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
-			return &certificate, nil
-		},
 	}
 
 	return &http.Client{

--- a/examples/x509-workload-identity/main.go
+++ b/examples/x509-workload-identity/main.go
@@ -1,0 +1,114 @@
+// The x509-workload-identity command demonstrates an application-owned rollout
+// toggle between API-key authentication and X.509 workload identity federation.
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/auth"
+	"github.com/openai/openai-go/v3/option"
+)
+
+const responseHeaderTimeout = 10 * time.Minute
+
+func main() {
+	if err := run(context.Background()); err != nil {
+		slog.Error("OpenAI request failed", "err", err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context) error {
+	var client openai.Client
+	switch mode := os.Getenv("OPENAI_AUTH_MODE"); mode {
+	case "", "api_key":
+		client = openai.NewClient()
+	case "x509":
+		certificateChainPath, err := requiredEnvironmentVariable("OPENAI_MTLS_CERTIFICATE_CHAIN")
+		if err != nil {
+			return err
+		}
+		privateKeyPath, err := requiredEnvironmentVariable("OPENAI_MTLS_PRIVATE_KEY")
+		if err != nil {
+			return err
+		}
+		identityProviderID, err := requiredEnvironmentVariable("OPENAI_IDENTITY_PROVIDER_ID")
+		if err != nil {
+			return err
+		}
+		serviceAccountID, err := requiredEnvironmentVariable("OPENAI_SERVICE_ACCOUNT_ID")
+		if err != nil {
+			return err
+		}
+
+		httpClient, err := newX509HTTPClient(certificateChainPath, privateKeyPath)
+		if err != nil {
+			return err
+		}
+		defer httpClient.CloseIdleConnections()
+
+		client = openai.NewClient(
+			option.WithHTTPClient(httpClient),
+			option.WithX509WorkloadIdentity(auth.X509WorkloadIdentity{
+				IdentityProviderID: identityProviderID,
+				ServiceAccountID:   serviceAccountID,
+			}),
+		)
+	default:
+		return fmt.Errorf("unsupported OPENAI_AUTH_MODE %q (want api_key or x509)", mode)
+	}
+
+	models, err := client.Models.List(ctx)
+	if err != nil {
+		return fmt.Errorf("list models: %w", err)
+	}
+	slog.Info("OpenAI request succeeded", "models", len(models.Data))
+	return nil
+}
+
+func requiredEnvironmentVariable(name string) (string, error) {
+	value := os.Getenv(name)
+	if value == "" {
+		return "", fmt.Errorf("%s is required", name)
+	}
+	return value, nil
+}
+
+func newX509HTTPClient(certificateChainPath string, privateKeyPath string) (*http.Client, error) {
+	certificate, err := tls.LoadX509KeyPair(certificateChainPath, privateKeyPath)
+	if err != nil {
+		return nil, fmt.Errorf("load X.509 client certificate: %w", err)
+	}
+
+	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return nil, errors.New("http.DefaultTransport is not an *http.Transport")
+	}
+	transport := defaultTransport.Clone()
+	transport.Proxy = nil
+	transport.DialTLS = nil //nolint:staticcheck // Clear an inherited legacy hook so TLSClientConfig remains authoritative.
+	transport.DialTLSContext = nil
+	transport.ResponseHeaderTimeout = responseHeaderTimeout
+	transport.TLSClientConfig = &tls.Config{
+		Certificates: []tls.Certificate{certificate},
+		MinVersion:   tls.VersionTLS12,
+		GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			return &certificate, nil
+		},
+	}
+
+	return &http.Client{
+		Transport: transport,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}, nil
+}

--- a/examples/x509-workload-identity/main_test.go
+++ b/examples/x509-workload-identity/main_test.go
@@ -62,15 +62,8 @@ func TestNewX509HTTPClientOwnsTransportConfiguration(t *testing.T) {
 	if transport.TLSClientConfig.Certificates[0].PrivateKey == nil {
 		t.Error("transport-owned certificate has no private key")
 	}
-	if transport.TLSClientConfig.GetClientCertificate == nil {
-		t.Fatal("GetClientCertificate is nil")
-	}
-	certificate, err := transport.TLSClientConfig.GetClientCertificate(&tls.CertificateRequestInfo{})
-	if err != nil {
-		t.Fatalf("GetClientCertificate() error = %v", err)
-	}
-	if certificate.PrivateKey != transport.TLSClientConfig.Certificates[0].PrivateKey {
-		t.Error("GetClientCertificate() returned a different private key")
+	if transport.TLSClientConfig.GetClientCertificate != nil {
+		t.Fatal("GetClientCertificate is non-nil")
 	}
 	if err := httpClient.CheckRedirect(nil, nil); !errors.Is(err, http.ErrUseLastResponse) {
 		t.Errorf("CheckRedirect() error = %v, want http.ErrUseLastResponse", err)

--- a/examples/x509-workload-identity/main_test.go
+++ b/examples/x509-workload-identity/main_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestNewX509HTTPClientOwnsTransportConfiguration(t *testing.T) {
+	certificatePath, privateKeyPath := writeTestKeyPair(t)
+
+	originalDefaultTransport := http.DefaultTransport
+	baseTransport, ok := originalDefaultTransport.(*http.Transport)
+	if !ok {
+		t.Skip("http.DefaultTransport is not an *http.Transport")
+	}
+	defaultTransport := baseTransport.Clone()
+	defaultTransport.Proxy = http.ProxyFromEnvironment
+	defaultTransport.ResponseHeaderTimeout = time.Second
+	defaultTransport.TLSClientConfig = &tls.Config{ServerName: "inherited.invalid"}
+	http.DefaultTransport = defaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalDefaultTransport })
+
+	httpClient, err := newX509HTTPClient(certificatePath, privateKeyPath)
+	if err != nil {
+		t.Fatalf("newX509HTTPClient() error = %v", err)
+	}
+	t.Cleanup(httpClient.CloseIdleConnections)
+
+	transport, ok := httpClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("newX509HTTPClient().Transport type = %T, want *http.Transport", httpClient.Transport)
+	}
+	if transport == defaultTransport {
+		t.Fatal("newX509HTTPClient() reused http.DefaultTransport")
+	}
+	if transport.Proxy != nil {
+		t.Error("newX509HTTPClient().Transport.Proxy is non-nil")
+	}
+	if got, want := transport.ResponseHeaderTimeout, responseHeaderTimeout; got != want {
+		t.Errorf("ResponseHeaderTimeout = %v, want %v", got, want)
+	}
+	if got, want := transport.TLSClientConfig.MinVersion, uint16(tls.VersionTLS12); got != want {
+		t.Errorf("TLS MinVersion = %d, want %d", got, want)
+	}
+	if got := transport.TLSClientConfig.ServerName; got != "" {
+		t.Errorf("TLS ServerName = %q, want empty", got)
+	}
+	if got, want := len(transport.TLSClientConfig.Certificates), 1; got != want {
+		t.Fatalf("TLS certificate count = %d, want %d", got, want)
+	}
+	if transport.TLSClientConfig.Certificates[0].PrivateKey == nil {
+		t.Error("transport-owned certificate has no private key")
+	}
+	if transport.TLSClientConfig.GetClientCertificate == nil {
+		t.Fatal("GetClientCertificate is nil")
+	}
+	certificate, err := transport.TLSClientConfig.GetClientCertificate(&tls.CertificateRequestInfo{})
+	if err != nil {
+		t.Fatalf("GetClientCertificate() error = %v", err)
+	}
+	if certificate.PrivateKey != transport.TLSClientConfig.Certificates[0].PrivateKey {
+		t.Error("GetClientCertificate() returned a different private key")
+	}
+	if err := httpClient.CheckRedirect(nil, nil); !errors.Is(err, http.ErrUseLastResponse) {
+		t.Errorf("CheckRedirect() error = %v, want http.ErrUseLastResponse", err)
+	}
+
+	if defaultTransport.Proxy == nil {
+		t.Error("newX509HTTPClient() mutated http.DefaultTransport.Proxy")
+	}
+	if got, want := defaultTransport.ResponseHeaderTimeout, time.Second; got != want {
+		t.Errorf("default ResponseHeaderTimeout = %v, want %v", got, want)
+	}
+	if got, want := defaultTransport.TLSClientConfig.ServerName, "inherited.invalid"; got != want {
+		t.Errorf("default TLS ServerName = %q, want %q", got, want)
+	}
+	if got := len(defaultTransport.TLSClientConfig.Certificates); got != 0 {
+		t.Errorf("default TLS certificate count = %d, want 0", got)
+	}
+}
+
+func writeTestKeyPair(t *testing.T) (string, string) {
+	t.Helper()
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ecdsa.GenerateKey() error = %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+	certificateDER, err := x509.CreateCertificate(rand.Reader, template, template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		t.Fatalf("x509.CreateCertificate() error = %v", err)
+	}
+	privateKeyDER, err := x509.MarshalECPrivateKey(privateKey)
+	if err != nil {
+		t.Fatalf("x509.MarshalECPrivateKey() error = %v", err)
+	}
+
+	tempDir := t.TempDir()
+	certificatePath := filepath.Join(tempDir, "client.pem")
+	privateKeyPath := filepath.Join(tempDir, "client.key")
+	certificatePEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certificateDER})
+	privateKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: privateKeyDER})
+	if err := os.WriteFile(certificatePath, certificatePEM, 0o600); err != nil {
+		t.Fatalf("os.WriteFile(%q) error = %v", certificatePath, err)
+	}
+	if err := os.WriteFile(privateKeyPath, privateKeyPEM, 0o600); err != nil {
+		t.Fatalf("os.WriteFile(%q) error = %v", privateKeyPath, err)
+	}
+	return certificatePath, privateKeyPath
+}

--- a/internal/closeonce.go
+++ b/internal/closeonce.go
@@ -1,0 +1,25 @@
+package internal
+
+import (
+	"io"
+	"sync"
+)
+
+// NewCloseOnceReadCloser lets callers clean up a body after a downstream
+// error without double-closing it when the downstream consumer already did.
+func NewCloseOnceReadCloser(body io.ReadCloser) io.ReadCloser {
+	return &closeOnceReadCloser{ReadCloser: body}
+}
+
+type closeOnceReadCloser struct {
+	io.ReadCloser
+	once sync.Once
+	err  error
+}
+
+func (b *closeOnceReadCloser) Close() error {
+	b.once.Do(func() {
+		b.err = b.ReadCloser.Close()
+	})
+	return b.err
+}

--- a/internal/httptransport.go
+++ b/internal/httptransport.go
@@ -1,0 +1,16 @@
+package internal
+
+import "net/http"
+
+// NativeHTTPTransport returns the effective RoundTripper for a native
+// *http.Client. Opaque HTTP doers do not expose a transport identity.
+func NativeHTTPTransport(httpDoer any) http.RoundTripper {
+	client, ok := httpDoer.(*http.Client)
+	if !ok {
+		return nil
+	}
+	if client.Transport == nil {
+		return http.DefaultTransport
+	}
+	return client.Transport
+}

--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -748,6 +748,7 @@ func (cfg *RequestConfig) Clone(ctx context.Context) *RequestConfig {
 		Context:            ctx,
 		Request:            req,
 		BaseURL:            cfg.BaseURL,
+		CustomHTTPDoer:     cfg.CustomHTTPDoer,
 		HTTPClient:         cfg.HTTPClient,
 		Middlewares:        cfg.Middlewares,
 		APIKey:             cfg.APIKey,

--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -15,7 +15,6 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/openai/openai-go/v3/internal"
@@ -501,22 +500,6 @@ func (b *bodyWithTimeout) Close() error {
 	return err
 }
 
-// closeOnceReadCloser lets Execute clean up bodies when middleware returns an
-// error before reaching the transport, without double-closing bodies that a
-// transport has already closed.
-type closeOnceReadCloser struct {
-	io.ReadCloser
-	once sync.Once
-	err  error
-}
-
-func (b *closeOnceReadCloser) Close() error {
-	b.once.Do(func() {
-		b.err = b.ReadCloser.Close()
-	})
-	return b.err
-}
-
 func retryDelay(res *http.Response, retryCount int) time.Duration {
 	// If the backend tells us to wait a certain amount of time, use that value
 	if retryAfterDelay, ok := parseRetryAfterHeader(res); ok {
@@ -598,7 +581,7 @@ func (cfg *RequestConfig) Execute() (err error) {
 
 		req := cfg.Request.Clone(ctx)
 		if req.Body != nil {
-			req.Body = &closeOnceReadCloser{ReadCloser: req.Body}
+			req.Body = internal.NewCloseOnceReadCloser(req.Body)
 		}
 		if shouldSendRetryCount {
 			req.Header.Set("X-Stainless-Retry-Count", strconv.Itoa(retryCount))

--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -926,27 +926,37 @@ func WithBearerAuthPreference() RequestOption {
 	})
 }
 
+func (r RequestConfig) preferredAuthentication(hasBearerCredential bool) authCredentialPreference {
+	if r.authPreference == authCredentialPreferenceBearer && r.Security.BearerAuth && hasBearerCredential {
+		return authCredentialPreferenceBearer
+	}
+	if r.authPreference == authCredentialPreferenceAdmin && r.Security.AdminAPIKeyAuth && r.AdminAPIKey != "" {
+		return authCredentialPreferenceAdmin
+	}
+	if r.Security.AdminAPIKeyAuth && r.AdminAPIKey != "" {
+		return authCredentialPreferenceAdmin
+	}
+	if r.Security.BearerAuth && hasBearerCredential {
+		return authCredentialPreferenceBearer
+	}
+	return authCredentialPreferenceNone
+}
+
+// BearerAuthenticationPreferred reports whether bearer authentication is the
+// effective scheme when workload identity supplies the bearer credential.
+func (r RequestConfig) BearerAuthenticationPreferred() bool {
+	return r.preferredAuthentication(true) == authCredentialPreferenceBearer
+}
+
 func ApplySecurity(r RequestConfig) {
 	if r.authHeaderOverride {
 		return
 	}
 
-	if r.authPreference == authCredentialPreferenceBearer && r.Security.BearerAuth && r.APIKey != "" {
+	switch r.preferredAuthentication(r.APIKey != "") {
+	case authCredentialPreferenceBearer:
 		r.Request.Header.Set("authorization", fmt.Sprintf("Bearer %s", r.APIKey))
-		return
-	}
-
-	if r.authPreference == authCredentialPreferenceAdmin && r.Security.AdminAPIKeyAuth && r.AdminAPIKey != "" {
+	case authCredentialPreferenceAdmin:
 		r.Request.Header.Set("authorization", fmt.Sprintf("Bearer %s", r.AdminAPIKey))
-		return
-	}
-
-	if r.Security.AdminAPIKeyAuth && r.AdminAPIKey != "" {
-		r.Request.Header.Set("authorization", fmt.Sprintf("Bearer %s", r.AdminAPIKey))
-		return
-	}
-
-	if r.Security.BearerAuth && r.APIKey != "" {
-		r.Request.Header.Set("authorization", fmt.Sprintf("Bearer %s", r.APIKey))
 	}
 }

--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -343,6 +343,7 @@ type RequestConfig struct {
 	authHeaderOverride bool
 	authPreference     authCredentialPreference
 	workloadIdentity   WorkloadIdentityCredentialSource
+	providerAuth       ProviderAuthentication
 	// Configure which security scheme(s) should be enabled for this request
 	Security Security
 	// If ResponseBodyInto not nil, then we will attempt to deserialize into
@@ -362,6 +363,14 @@ type WorkloadIdentityCredentialSource uint8
 const (
 	WorkloadIdentityCredentialSourceSubjectToken WorkloadIdentityCredentialSource = iota + 1
 	WorkloadIdentityCredentialSourceX509
+)
+
+// ProviderAuthentication identifies a provider-owned credential mode.
+type ProviderAuthentication string
+
+const (
+	ProviderAuthenticationAzure   ProviderAuthentication = "Azure"
+	ProviderAuthenticationBedrock ProviderAuthentication = "Bedrock"
 )
 
 // middleware is exactly the same type as the Middleware type found in the [option] package,
@@ -750,6 +759,7 @@ func (cfg *RequestConfig) Clone(ctx context.Context) *RequestConfig {
 		authHeaderOverride: cfg.authHeaderOverride,
 		authPreference:     cfg.authPreference,
 		workloadIdentity:   cfg.workloadIdentity,
+		providerAuth:       cfg.providerAuth,
 	}
 
 	return new
@@ -805,6 +815,19 @@ func (cfg *RequestConfig) UseWorkloadIdentityCredential(source WorkloadIdentityC
 // This function is internal API and may change without notice.
 func (cfg *RequestConfig) SetWorkloadIdentityFinalizer(finalize func(*RequestConfig) error) {
 	cfg.wifFinalizer = finalize
+}
+
+// SetProviderAuthentication records a provider-owned credential mode so it
+// cannot be combined with an incompatible OpenAI credential at finalization.
+// This function is internal API and may change without notice.
+func (cfg *RequestConfig) SetProviderAuthentication(provider ProviderAuthentication) {
+	cfg.providerAuth = provider
+}
+
+// ProviderAuthentication returns the selected provider-owned credential mode.
+// This function is internal API and may change without notice.
+func (cfg *RequestConfig) ProviderAuthentication() ProviderAuthentication {
+	return cfg.providerAuth
 }
 
 func (cfg *RequestConfig) Apply(opts ...RequestOption) error {

--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -127,7 +127,7 @@ type noRetryError struct {
 
 func (e *noRetryError) Error() string { return e.err.Error() }
 func (e *noRetryError) Unwrap() error { return e.err }
-func (e *noRetryError) noRetry()      {}
+func (e *noRetryError) NoRetry()      {}
 
 // WithNoRetryError marks err as deterministic for the generic request retry
 // loop while preserving its message and unwrap chain. This function is
@@ -379,7 +379,7 @@ func shouldRetry(req *http.Request, res *http.Response, err error) bool {
 		return false
 	}
 
-	var deterministic interface{ noRetry() }
+	var deterministic interface{ NoRetry() }
 	if errors.As(err, &deterministic) {
 		return false
 	}

--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -337,6 +337,7 @@ type RequestConfig struct {
 	finalizers         []requestFinalizer
 	authHeaderOverride bool
 	authPreference     authCredentialPreference
+	workloadIdentity   WorkloadIdentityCredentialSource
 	// Configure which security scheme(s) should be enabled for this request
 	Security Security
 	// If ResponseBodyInto not nil, then we will attempt to deserialize into
@@ -348,6 +349,15 @@ type RequestConfig struct {
 	ResponseInto **http.Response
 	Body         io.Reader
 }
+
+// WorkloadIdentityCredentialSource identifies the selected workload identity
+// branch. It is internal API used to reject incompatible authentication options.
+type WorkloadIdentityCredentialSource uint8
+
+const (
+	WorkloadIdentityCredentialSourceSubjectToken WorkloadIdentityCredentialSource = iota + 1
+	WorkloadIdentityCredentialSourceX509
+)
 
 // middleware is exactly the same type as the Middleware type found in the [option] package,
 // but it is redeclared here for circular dependency issues.
@@ -748,6 +758,7 @@ func (cfg *RequestConfig) Clone(ctx context.Context) *RequestConfig {
 		finalizers:         append([]requestFinalizer(nil), cfg.finalizers...),
 		authHeaderOverride: cfg.authHeaderOverride,
 		authPreference:     cfg.authPreference,
+		workloadIdentity:   cfg.workloadIdentity,
 	}
 
 	return new
@@ -784,6 +795,17 @@ func (cfg *RequestConfig) SetAdminAPIKey(value string) {
 	cfg.AdminAPIKey = value
 	cfg.authHeaderOverride = false
 	cfg.authPreference = authCredentialPreferenceAdmin
+}
+
+// UseWorkloadIdentityCredential selects one workload identity credential
+// branch and rejects configurations that combine subject-token and X.509 WIF.
+// This function is internal API and may change without notice.
+func (cfg *RequestConfig) UseWorkloadIdentityCredential(source WorkloadIdentityCredentialSource) error {
+	if cfg.workloadIdentity != 0 && cfg.workloadIdentity != source {
+		return fmt.Errorf("requestconfig: workload identity credential options are mutually exclusive")
+	}
+	cfg.workloadIdentity = source
+	return nil
 }
 
 func (cfg *RequestConfig) Apply(opts ...RequestOption) error {

--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -114,28 +113,6 @@ type requestFinalizer func(*RequestConfig) error
 
 type requestFinalizerOption struct {
 	finalize func(*RequestConfig) error
-}
-
-// noRetryError marks deterministic request setup or policy failures that
-// cannot be fixed by replaying the same request. It deliberately remains an
-// internal implementation detail so public error strings and wrapping stay
-// unchanged.
-type noRetryError struct {
-	err error
-}
-
-func (e *noRetryError) Error() string { return e.err.Error() }
-func (e *noRetryError) Unwrap() error { return e.err }
-func (e *noRetryError) NoRetry()      {}
-
-// WithNoRetryError marks err as deterministic for the generic request retry
-// loop while preserving its message and unwrap chain. This function is
-// internal API and may change without notice.
-func WithNoRetryError(err error) error {
-	if err == nil {
-		return nil
-	}
-	return &noRetryError{err: err}
 }
 
 func (o requestFinalizerOption) Apply(cfg *RequestConfig) error {
@@ -393,8 +370,7 @@ func shouldRetry(req *http.Request, res *http.Response, err error) bool {
 		return false
 	}
 
-	var deterministic interface{ NoRetry() }
-	if errors.As(err, &deterministic) {
+	if internal.IsNoRetryError(err) {
 		return false
 	}
 
@@ -927,6 +903,9 @@ func WithBearerAuthPreference() RequestOption {
 }
 
 func (r RequestConfig) preferredAuthentication(hasBearerCredential bool) authCredentialPreference {
+	if r.authHeaderOverride {
+		return authCredentialPreferenceNone
+	}
 	if r.authPreference == authCredentialPreferenceBearer && r.Security.BearerAuth && hasBearerCredential {
 		return authCredentialPreferenceBearer
 	}
@@ -949,10 +928,6 @@ func (r RequestConfig) BearerAuthenticationPreferred() bool {
 }
 
 func ApplySecurity(r RequestConfig) {
-	if r.authHeaderOverride {
-		return
-	}
-
 	switch r.preferredAuthentication(r.APIKey != "") {
 	case authCredentialPreferenceBearer:
 		r.Request.Header.Set("authorization", fmt.Sprintf("Bearer %s", r.APIKey))

--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -289,6 +289,11 @@ func NewRequestConfig(ctx context.Context, method string, u string, body any, ds
 			return nil, err
 		}
 	}
+	if cfg.wifFinalizer != nil {
+		if err := cfg.wifFinalizer(&cfg); err != nil {
+			return nil, err
+		}
+	}
 
 	// This must run after `cfg.Apply(...)` above so we know which specific security scheme to add
 	ApplySecurity(cfg)
@@ -335,6 +340,7 @@ type RequestConfig struct {
 	Project            string
 	WebhookSecret      string
 	finalizers         []requestFinalizer
+	wifFinalizer       requestFinalizer
 	authHeaderOverride bool
 	authPreference     authCredentialPreference
 	workloadIdentity   WorkloadIdentityCredentialSource
@@ -757,6 +763,7 @@ func (cfg *RequestConfig) Clone(ctx context.Context) *RequestConfig {
 		Project:            cfg.Project,
 		WebhookSecret:      cfg.WebhookSecret,
 		finalizers:         append([]requestFinalizer(nil), cfg.finalizers...),
+		wifFinalizer:       cfg.wifFinalizer,
 		authHeaderOverride: cfg.authHeaderOverride,
 		authPreference:     cfg.authPreference,
 		workloadIdentity:   cfg.workloadIdentity,
@@ -807,6 +814,14 @@ func (cfg *RequestConfig) UseWorkloadIdentityCredential(source WorkloadIdentityC
 	}
 	cfg.workloadIdentity = source
 	return nil
+}
+
+// SetWorkloadIdentityFinalizer installs the finalizer for the selected
+// workload identity branch. A later credential option replaces the earlier
+// finalizer instead of stacking authentication middleware.
+// This function is internal API and may change without notice.
+func (cfg *RequestConfig) SetWorkloadIdentityFinalizer(finalize func(*RequestConfig) error) {
+	cfg.wifFinalizer = finalize
 }
 
 func (cfg *RequestConfig) Apply(opts ...RequestOption) error {

--- a/internal/requestconfig/requestconfig_test.go
+++ b/internal/requestconfig/requestconfig_test.go
@@ -157,6 +157,42 @@ func TestRequestFinalizerComposesThroughApply(t *testing.T) {
 	}
 }
 
+func TestWorkloadIdentityFinalizerReplacesEarlierCredential(t *testing.T) {
+	var finalized []string
+	first := RequestOptionFunc(func(cfg *RequestConfig) error {
+		cfg.SetWorkloadIdentityFinalizer(func(*RequestConfig) error {
+			finalized = append(finalized, "first")
+			return nil
+		})
+		return nil
+	})
+	second := RequestOptionFunc(func(cfg *RequestConfig) error {
+		cfg.SetWorkloadIdentityFinalizer(func(*RequestConfig) error {
+			finalized = append(finalized, "second")
+			return nil
+		})
+		return nil
+	})
+
+	if _, err := NewRequestConfig(
+		context.Background(),
+		http.MethodGet,
+		"/models",
+		nil,
+		nil,
+		first,
+		second,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := len(finalized), 1; got != want {
+		t.Fatalf("finalizer calls = %d, want %d", got, want)
+	}
+	if got, want := finalized[0], "second"; got != want {
+		t.Errorf("finalizer = %q, want %q", got, want)
+	}
+}
+
 func TestRequestConfigClonePreservesCustomHTTPDoer(t *testing.T) {
 	calls := 0
 	cfg, err := NewRequestConfig(context.Background(), http.MethodGet, "/models", nil, nil)
@@ -175,7 +211,6 @@ func TestRequestConfigClonePreservesCustomHTTPDoer(t *testing.T) {
 			Body:       http.NoBody,
 		}, nil
 	})
-
 	clone := cfg.Clone(t.Context())
 	if clone == nil {
 		t.Fatal("Clone() = nil")

--- a/internal/requestconfig/requestconfig_test.go
+++ b/internal/requestconfig/requestconfig_test.go
@@ -157,6 +157,40 @@ func TestRequestFinalizerComposesThroughApply(t *testing.T) {
 	}
 }
 
+func TestRequestConfigClonePreservesCustomHTTPDoer(t *testing.T) {
+	calls := 0
+	cfg, err := NewRequestConfig(context.Background(), http.MethodGet, "/models", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.BaseURL, err = url.Parse("https://example.com/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.CustomHTTPDoer = httpDoerFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		return &http.Response{
+			StatusCode: http.StatusNoContent,
+			Header:     make(http.Header),
+			Body:       http.NoBody,
+		}, nil
+	})
+
+	clone := cfg.Clone(t.Context())
+	if clone == nil {
+		t.Fatal("Clone() = nil")
+	}
+	if clone.CustomHTTPDoer == nil {
+		t.Fatal("Clone() did not preserve CustomHTTPDoer")
+	}
+	if err := clone.Execute(); err != nil {
+		t.Fatalf("cloned Execute() error = %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("custom HTTP doer calls = %d, want 1", calls)
+	}
+}
+
 func TestExecuteClosesAttemptBodyOnHandlerError(t *testing.T) {
 	t.Run("no retry", func(t *testing.T) {
 		body := newTrackedFileBody(t)

--- a/internal/requestconfig/requestconfig_test.go
+++ b/internal/requestconfig/requestconfig_test.go
@@ -8,6 +8,8 @@ import (
 	"net/url"
 	"os"
 	"testing"
+
+	"github.com/openai/openai-go/v3/internal"
 )
 
 type closeTrackingReadCloser struct {
@@ -25,6 +27,11 @@ type httpDoerFunc func(*http.Request) (*http.Response, error)
 func (f httpDoerFunc) Do(req *http.Request) (*http.Response, error) {
 	return f(req)
 }
+
+type callerNoRetryError struct{}
+
+func (callerNoRetryError) Error() string { return "caller error" }
+func (callerNoRetryError) NoRetry()      {}
 
 func newTrackedFileBody(t *testing.T) *closeTrackingReadCloser {
 	t.Helper()
@@ -238,7 +245,7 @@ func TestExecuteClosesAttemptBodyOnHandlerError(t *testing.T) {
 		attempts := 0
 		cfg.Middlewares = []middleware{func(*http.Request, middlewareNext) (*http.Response, error) {
 			attempts++
-			return nil, WithNoRetryError(errors.New("blocked"))
+			return nil, internal.WithNoRetryError(errors.New("blocked"))
 		}}
 
 		err := cfg.Execute()
@@ -312,4 +319,27 @@ func TestExecuteClosesAttemptBodyOnHandlerError(t *testing.T) {
 			t.Fatalf("body closes = %d, want 1", body.closes)
 		}
 	})
+}
+
+func TestExecuteRetriesCallerErrorWithUnrelatedNoRetryMethod(t *testing.T) {
+	cfg := newBodyCloseRequestConfig(t, nil)
+	cfg.MaxRetries = 1
+	attempts := 0
+	cfg.Middlewares = []middleware{func(*http.Request, middlewareNext) (*http.Response, error) {
+		attempts++
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Header:     http.Header{"Retry-After-Ms": {"0"}},
+			Body:       http.NoBody,
+		}, callerNoRetryError{}
+	}}
+
+	err := cfg.Execute()
+	var callerErr callerNoRetryError
+	if !errors.As(err, &callerErr) {
+		t.Fatalf("Execute() error = %v, want callerNoRetryError", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts)
+	}
 }

--- a/internal/retry.go
+++ b/internal/retry.go
@@ -1,0 +1,27 @@
+package internal
+
+import "errors"
+
+// noRetryError marks deterministic request setup or policy failures that
+// cannot be fixed by replaying the same request.
+type noRetryError struct {
+	err error
+}
+
+func (e *noRetryError) Error() string { return e.err.Error() }
+func (e *noRetryError) Unwrap() error { return e.err }
+
+// WithNoRetryError marks err as deterministic for the generic request retry
+// loop while preserving its message and unwrap chain.
+func WithNoRetryError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &noRetryError{err: err}
+}
+
+// IsNoRetryError reports whether err contains the SDK's private retry marker.
+func IsNoRetryError(err error) bool {
+	var marker *noRetryError
+	return errors.As(err, &marker)
+}

--- a/internal/testutil/x509.go
+++ b/internal/testutil/x509.go
@@ -1,0 +1,67 @@
+package testutil
+
+import (
+	"context"
+	"crypto/tls"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// NewNativeX509HTTPClient routes HTTPS requests through a hermetic TLS server
+// while retaining a real native transport with one static client identity.
+func NewNativeX509HTTPClient(
+	t testing.TB,
+	roundTrip func(*http.Request) (*http.Response, error),
+) *http.Client {
+	t.Helper()
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(writer http.ResponseWriter, incoming *http.Request) {
+		request := incoming.Clone(incoming.Context())
+		request.URL.Scheme = "https"
+		request.URL.Host = incoming.Host
+		response, err := roundTrip(request)
+		if err != nil {
+			connection, _, hijackErr := writer.(http.Hijacker).Hijack()
+			if hijackErr == nil {
+				_ = connection.Close()
+			}
+			return
+		}
+		if response == nil {
+			writer.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		if response.Body != nil {
+			defer func() { _ = response.Body.Close() }()
+		}
+		for name, values := range response.Header {
+			for _, value := range values {
+				writer.Header().Add(name, value)
+			}
+		}
+		statusCode := response.StatusCode
+		if statusCode == 0 {
+			statusCode = http.StatusOK
+		}
+		writer.WriteHeader(statusCode)
+		if response.Body != nil {
+			_, _ = io.Copy(writer, response.Body)
+		}
+	}))
+	server.StartTLS()
+	t.Cleanup(server.Close)
+
+	serverTransport := server.Client().Transport.(*http.Transport)
+	transport := serverTransport.Clone()
+	transport.TLSClientConfig = serverTransport.TLSClientConfig.Clone()
+	transport.TLSClientConfig.ServerName = "example.com"
+	transport.TLSClientConfig.Certificates = []tls.Certificate{{Certificate: [][]byte{{1}}}}
+	transport.TLSClientConfig.ClientSessionCache = nil
+	dialer := &net.Dialer{}
+	transport.DialContext = func(ctx context.Context, _, _ string) (net.Conn, error) {
+		return dialer.DialContext(ctx, "tcp", server.Listener.Addr().String())
+	}
+	return &http.Client{Transport: transport}
+}

--- a/internal/workloadidentity.go
+++ b/internal/workloadidentity.go
@@ -6,6 +6,21 @@ import (
 )
 
 type expectedAuthorizationContextKey struct{}
+type x509RequestPolicyContextKey struct{}
+
+// WithX509RequestPolicy marks a request whose X.509 destination and credential
+// policy has been validated by the high-level client option.
+func WithX509RequestPolicy(req *http.Request) *http.Request {
+	ctx := context.WithValue(req.Context(), x509RequestPolicyContextKey{}, true)
+	return req.WithContext(ctx)
+}
+
+// HasX509RequestPolicy reports whether the high-level X.509 request policy is
+// bound to this request attempt.
+func HasX509RequestPolicy(req *http.Request) bool {
+	policyBound, _ := req.Context().Value(x509RequestPolicyContextKey{}).(bool)
+	return policyBound
+}
 
 // WithExpectedAuthorization binds the SDK-selected Authorization value to one
 // request attempt without exposing it through mutable middleware state.

--- a/internal/workloadidentity.go
+++ b/internal/workloadidentity.go
@@ -1,0 +1,22 @@
+package internal
+
+import (
+	"context"
+	"net/http"
+)
+
+type expectedAuthorizationContextKey struct{}
+
+// WithExpectedAuthorization binds the SDK-selected Authorization value to one
+// request attempt without exposing it through mutable middleware state.
+func WithExpectedAuthorization(req *http.Request, authorization string) *http.Request {
+	ctx := context.WithValue(req.Context(), expectedAuthorizationContextKey{}, authorization)
+	return req.WithContext(ctx)
+}
+
+// ExpectedAuthorization returns the SDK-selected Authorization value bound to
+// the current request attempt. An empty value is valid for headerless requests.
+func ExpectedAuthorization(req *http.Request) (string, bool) {
+	authorization, ok := req.Context().Value(expectedAuthorizationContextKey{}).(string)
+	return authorization, ok
+}

--- a/option/requestoption.go
+++ b/option/requestoption.go
@@ -2,7 +2,6 @@ package option
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -16,13 +15,6 @@ import (
 	"github.com/openai/openai-go/v3/internal/requestconfig"
 	"github.com/tidwall/sjson"
 )
-
-const x509APIBaseURL = "https://mtls.api.openai.com/v1/"
-
-// Keep enough transport-scoped auth states for a primary client plus a small
-// set of method-level overrides without retaining every transport ever used by
-// a long-lived client.
-const x509WorkloadIdentityAuthCacheCapacity = 8
 
 // RequestOption is an option for the requests made by the openai API Client
 // which can be supplied to clients, services, and methods. You can read more about this functional
@@ -334,66 +326,6 @@ func WithWorkloadIdentity(config auth.WorkloadIdentity) RequestOption {
 	})
 }
 
-// WithX509WorkloadIdentity returns a RequestOption that configures X.509
-// workload identity authentication. The configured HTTP client must present
-// the client certificate for token exchange and API requests. Custom HTTPClient
-// implementations are responsible for refusing redirects internally.
-//
-// When no base URL is configured explicitly or through OPENAI_BASE_URL, X.509
-// workload identity clients use https://mtls.api.openai.com/v1.
-func WithX509WorkloadIdentity(config auth.X509WorkloadIdentity) RequestOption {
-	cache := x509WorkloadIdentityAuthCache{}
-	return requestconfig.RequestOptionFunc(func(r *requestconfig.RequestConfig) error {
-		if err := r.UseWorkloadIdentityCredential(requestconfig.WorkloadIdentityCredentialSourceX509); err != nil {
-			return err
-		}
-		r.SetAPIKey("")
-		r.SetWorkloadIdentityFinalizer(func(r *requestconfig.RequestConfig) error {
-			return configureX509Request(r, &cache, config)
-		})
-		return nil
-	})
-}
-
-type x509WorkloadIdentityAuthCache struct {
-	mu      sync.Mutex
-	entries []x509WorkloadIdentityAuthCacheEntry
-}
-
-type x509WorkloadIdentityAuthCacheEntry struct {
-	httpDoer auth.HTTPDoer
-	auth     *auth.WorkloadIdentityAuth
-}
-
-func (c *x509WorkloadIdentityAuthCache) get(
-	httpDoer auth.HTTPDoer,
-	config auth.X509WorkloadIdentity,
-) (*auth.WorkloadIdentityAuth, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	for i := range c.entries {
-		if c.entries[i].httpDoer != httpDoer {
-			continue
-		}
-		entry := c.entries[i]
-		copy(c.entries[i:], c.entries[i+1:])
-		c.entries[len(c.entries)-1] = entry
-		return entry.auth, nil
-	}
-	wia, err := auth.NewX509WorkloadIdentityAuth(config)
-	if err != nil {
-		return nil, err
-	}
-	entry := x509WorkloadIdentityAuthCacheEntry{httpDoer: httpDoer, auth: wia}
-	if len(c.entries) == x509WorkloadIdentityAuthCacheCapacity {
-		copy(c.entries, c.entries[1:])
-		c.entries[len(c.entries)-1] = entry
-	} else {
-		c.entries = append(c.entries, entry)
-	}
-	return wia, nil
-}
-
 func withWorkloadIdentityAuth(
 	credentialSource requestconfig.WorkloadIdentityCredentialSource,
 	newAuth func() (*auth.WorkloadIdentityAuth, error),
@@ -433,42 +365,4 @@ func withWorkloadIdentityAuth(
 		})
 		return nil
 	})
-}
-
-func configureX509Request(
-	r *requestconfig.RequestConfig,
-	cache *x509WorkloadIdentityAuthCache,
-	config auth.X509WorkloadIdentity,
-) error {
-	if r.BaseURL == nil {
-		if err := r.Apply(requestconfig.WithDefaultBaseURL(x509APIBaseURL)); err != nil {
-			return err
-		}
-	}
-
-	var configuredHTTPDoer auth.HTTPDoer = r.HTTPClient
-	if r.CustomHTTPDoer != nil {
-		configuredHTTPDoer = r.CustomHTTPDoer
-	}
-	if configuredHTTPDoer == nil {
-		return errors.New("X.509 workload identity requires an HTTP client")
-	}
-	wia, err := cache.get(configuredHTTPDoer, config)
-	if err != nil {
-		return err
-	}
-
-	if r.CustomHTTPDoer == nil && r.HTTPClient != nil {
-		clone := *r.HTTPClient
-		clone.CheckRedirect = func(*http.Request, []*http.Request) error {
-			return errors.New("X.509 workload identity API redirects are disabled")
-		}
-		r.HTTPClient = &clone
-	}
-
-	authMiddleware := Middleware(func(req *http.Request, next func(*http.Request) (*http.Response, error)) (*http.Response, error) {
-		return auth.WorkloadIdentityMiddleware(wia, configuredHTTPDoer, req, next)
-	})
-	r.Middlewares = append([]Middleware{authMiddleware}, r.Middlewares...)
-	return nil
 }

--- a/option/requestoption.go
+++ b/option/requestoption.go
@@ -18,6 +18,11 @@ import (
 
 const x509APIBaseURL = "https://mtls.api.openai.com/v1/"
 
+// Keep enough transport-scoped auth states for a primary client plus a small
+// set of method-level overrides without retaining every transport ever used by
+// a long-lived client.
+const x509WorkloadIdentityAuthCacheCapacity = 8
+
 // RequestOption is an option for the requests made by the openai API Client
 // which can be supplied to clients, services, and methods. You can read more about this functional
 // options pattern in our [README].
@@ -347,8 +352,13 @@ func WithX509WorkloadIdentity(config auth.X509WorkloadIdentity) RequestOption {
 }
 
 type x509WorkloadIdentityAuthCache struct {
-	mu         sync.Mutex
-	byHTTPDoer map[auth.HTTPDoer]*auth.WorkloadIdentityAuth
+	mu      sync.Mutex
+	entries []x509WorkloadIdentityAuthCacheEntry
+}
+
+type x509WorkloadIdentityAuthCacheEntry struct {
+	httpDoer auth.HTTPDoer
+	auth     *auth.WorkloadIdentityAuth
 }
 
 func (c *x509WorkloadIdentityAuthCache) get(
@@ -357,17 +367,26 @@ func (c *x509WorkloadIdentityAuthCache) get(
 ) (*auth.WorkloadIdentityAuth, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if wia := c.byHTTPDoer[httpDoer]; wia != nil {
-		return wia, nil
+	for i := range c.entries {
+		if c.entries[i].httpDoer != httpDoer {
+			continue
+		}
+		entry := c.entries[i]
+		copy(c.entries[i:], c.entries[i+1:])
+		c.entries[len(c.entries)-1] = entry
+		return entry.auth, nil
 	}
 	wia, err := auth.NewX509WorkloadIdentityAuth(config)
 	if err != nil {
 		return nil, err
 	}
-	if c.byHTTPDoer == nil {
-		c.byHTTPDoer = make(map[auth.HTTPDoer]*auth.WorkloadIdentityAuth)
+	entry := x509WorkloadIdentityAuthCacheEntry{httpDoer: httpDoer, auth: wia}
+	if len(c.entries) == x509WorkloadIdentityAuthCacheCapacity {
+		copy(c.entries, c.entries[1:])
+		c.entries[len(c.entries)-1] = entry
+	} else {
+		c.entries = append(c.entries, entry)
 	}
-	c.byHTTPDoer[httpDoer] = wia
 	return wia, nil
 }
 
@@ -438,8 +457,9 @@ func configureX509Request(
 		r.HTTPClient = &clone
 	}
 
-	r.Middlewares = append(r.Middlewares, func(req *http.Request, next func(*http.Request) (*http.Response, error)) (*http.Response, error) {
+	authMiddleware := Middleware(func(req *http.Request, next func(*http.Request) (*http.Response, error)) (*http.Response, error) {
 		return auth.WorkloadIdentityMiddleware(wia, configuredHTTPDoer, req, next)
 	})
+	r.Middlewares = append([]Middleware{authMiddleware}, r.Middlewares...)
 	return nil
 }

--- a/option/requestoption.go
+++ b/option/requestoption.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -54,12 +53,19 @@ type HTTPClient interface {
 	Do(*http.Request) (*http.Response, error)
 }
 
+// comparableHTTPClient preserves a stable identity for custom HTTPClient
+// values that cannot themselves be used as map keys.
+type comparableHTTPClient struct {
+	HTTPClient
+}
+
 // WithHTTPClient returns a RequestOption that changes the underlying http client used to make this
 // request, which by default is [http.DefaultClient].
 //
 // For custom uses cases, it is recommended to provide an [*http.Client] with a custom
 // [http.RoundTripper] as its transport, rather than directly implementing [HTTPClient].
 func WithHTTPClient(client HTTPClient) RequestOption {
+	customHTTPClient := &comparableHTTPClient{HTTPClient: client}
 	return requestconfig.RequestOptionFunc(func(r *requestconfig.RequestConfig) error {
 		if client == nil {
 			return fmt.Errorf("requestoption: custom http client cannot be nil")
@@ -70,7 +76,7 @@ func WithHTTPClient(client HTTPClient) RequestOption {
 			r.HTTPClient = c
 			r.CustomHTTPDoer = nil
 		} else {
-			r.CustomHTTPDoer = client
+			r.CustomHTTPDoer = customHTTPClient
 		}
 
 		return nil
@@ -333,9 +339,10 @@ func WithX509WorkloadIdentity(config auth.X509WorkloadIdentity) RequestOption {
 			return err
 		}
 		r.SetAPIKey("")
-		return r.Apply(requestconfig.WithRequestFinalizer(func(r *requestconfig.RequestConfig) error {
+		r.SetWorkloadIdentityFinalizer(func(r *requestconfig.RequestConfig) error {
 			return configureX509Request(r, &cache, config)
-		}))
+		})
+		return nil
 	})
 }
 
@@ -348,10 +355,6 @@ func (c *x509WorkloadIdentityAuthCache) get(
 	httpDoer auth.HTTPDoer,
 	config auth.X509WorkloadIdentity,
 ) (*auth.WorkloadIdentityAuth, error) {
-	if httpDoer == nil || !reflect.TypeOf(httpDoer).Comparable() {
-		return auth.NewX509WorkloadIdentityAuth(config)
-	}
-
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if wia := c.byHTTPDoer[httpDoer]; wia != nil {
@@ -419,6 +422,9 @@ func configureX509Request(
 	if r.CustomHTTPDoer != nil {
 		configuredHTTPDoer = r.CustomHTTPDoer
 	}
+	if configuredHTTPDoer == nil {
+		return errors.New("X.509 workload identity requires an HTTP client")
+	}
 	wia, err := cache.get(configuredHTTPDoer, config)
 	if err != nil {
 		return err
@@ -430,14 +436,11 @@ func configureX509Request(
 			return errors.New("X.509 workload identity API redirects are disabled")
 		}
 		r.HTTPClient = &clone
+		configuredHTTPDoer = &clone
 	}
 
-	var httpDoer auth.HTTPDoer = r.HTTPClient
-	if r.CustomHTTPDoer != nil {
-		httpDoer = r.CustomHTTPDoer
-	}
 	r.Middlewares = append(r.Middlewares, func(req *http.Request, next func(*http.Request) (*http.Response, error)) (*http.Response, error) {
-		return auth.WorkloadIdentityMiddleware(wia, httpDoer, req, next)
+		return auth.WorkloadIdentityMiddleware(wia, configuredHTTPDoer, req, next)
 	})
 	return nil
 }

--- a/option/requestoption.go
+++ b/option/requestoption.go
@@ -436,7 +436,6 @@ func configureX509Request(
 			return errors.New("X.509 workload identity API redirects are disabled")
 		}
 		r.HTTPClient = &clone
-		configuredHTTPDoer = &clone
 	}
 
 	r.Middlewares = append(r.Middlewares, func(req *http.Request, next func(*http.Request) (*http.Response, error)) (*http.Response, error) {

--- a/option/requestoption.go
+++ b/option/requestoption.go
@@ -15,6 +15,8 @@ import (
 	"github.com/tidwall/sjson"
 )
 
+const x509APIBaseURL = "https://mtls.api.openai.com/v1/"
+
 // RequestOption is an option for the requests made by the openai API Client
 // which can be supplied to clients, services, and methods. You can read more about this functional
 // options pattern in our [README].
@@ -310,16 +312,47 @@ func WithWebhookSecret(value string) requestconfig.PreRequestOptionFunc {
 // This enables the client to authenticate using short-lived tokens from cloud providers
 // (Kubernetes, Azure, GCP) instead of long-lived API keys.
 func WithWorkloadIdentity(config auth.WorkloadIdentity) RequestOption {
+	return withWorkloadIdentityAuth(requestconfig.WorkloadIdentityCredentialSourceSubjectToken, func() (*auth.WorkloadIdentityAuth, error) {
+		return auth.NewWorkloadIdentityAuth(config)
+	})
+}
+
+// WithX509WorkloadIdentity returns a RequestOption that configures X.509
+// workload identity authentication. The configured HTTP client must present
+// the client certificate for token exchange and API requests. Custom HTTPClient
+// implementations are responsible for refusing redirects internally.
+//
+// When no base URL is configured explicitly or through OPENAI_BASE_URL, X.509
+// workload identity clients use https://mtls.api.openai.com/v1.
+func WithX509WorkloadIdentity(config auth.X509WorkloadIdentity) RequestOption {
+	authOption := withWorkloadIdentityAuth(requestconfig.WorkloadIdentityCredentialSourceX509, func() (*auth.WorkloadIdentityAuth, error) {
+		return auth.NewX509WorkloadIdentityAuth(config)
+	})
+	return requestconfig.RequestOptionFunc(func(r *requestconfig.RequestConfig) error {
+		if err := authOption.Apply(r); err != nil {
+			return err
+		}
+		return r.Apply(requestconfig.WithRequestFinalizer(configureX509Request))
+	})
+}
+
+func withWorkloadIdentityAuth(
+	credentialSource requestconfig.WorkloadIdentityCredentialSource,
+	newAuth func() (*auth.WorkloadIdentityAuth, error),
+) RequestOption {
 	var wia *auth.WorkloadIdentityAuth
 	var initOnce sync.Once
 	var initErr error
 
 	return requestconfig.RequestOptionFunc(func(r *requestconfig.RequestConfig) error {
+		if err := r.UseWorkloadIdentityCredential(credentialSource); err != nil {
+			return err
+		}
 		r.SetAPIKey("")
 
 		r.Middlewares = append(r.Middlewares, func(req *http.Request, next func(*http.Request) (*http.Response, error)) (*http.Response, error) {
 			initOnce.Do(func() {
-				wia, initErr = auth.NewWorkloadIdentityAuth(config)
+				wia, initErr = newAuth()
 			})
 
 			if initErr != nil {
@@ -337,4 +370,21 @@ func WithWorkloadIdentity(config auth.WorkloadIdentity) RequestOption {
 		})
 		return nil
 	})
+}
+
+func configureX509Request(r *requestconfig.RequestConfig) error {
+	if r.BaseURL == nil {
+		if err := r.Apply(requestconfig.WithDefaultBaseURL(x509APIBaseURL)); err != nil {
+			return err
+		}
+	}
+	if r.CustomHTTPDoer != nil || r.HTTPClient == nil {
+		return nil
+	}
+	clone := *r.HTTPClient
+	clone.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	r.HTTPClient = &clone
+	return nil
 }

--- a/option/requestoption.go
+++ b/option/requestoption.go
@@ -72,7 +72,7 @@ type comparableHTTPClient struct {
 // [http.RoundTripper] as its transport, rather than directly implementing [HTTPClient].
 func WithHTTPClient(client HTTPClient) RequestOption {
 	customHTTPClient := client
-	if client != nil && !reflect.TypeOf(client).Comparable() {
+	if client != nil && !reflect.ValueOf(client).Comparable() {
 		customHTTPClient = &comparableHTTPClient{HTTPClient: client}
 	}
 	return requestconfig.RequestOptionFunc(func(r *requestconfig.RequestConfig) error {

--- a/option/requestoption.go
+++ b/option/requestoption.go
@@ -2,10 +2,12 @@ package option
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -325,15 +327,45 @@ func WithWorkloadIdentity(config auth.WorkloadIdentity) RequestOption {
 // When no base URL is configured explicitly or through OPENAI_BASE_URL, X.509
 // workload identity clients use https://mtls.api.openai.com/v1.
 func WithX509WorkloadIdentity(config auth.X509WorkloadIdentity) RequestOption {
-	authOption := withWorkloadIdentityAuth(requestconfig.WorkloadIdentityCredentialSourceX509, func() (*auth.WorkloadIdentityAuth, error) {
-		return auth.NewX509WorkloadIdentityAuth(config)
-	})
+	cache := x509WorkloadIdentityAuthCache{}
 	return requestconfig.RequestOptionFunc(func(r *requestconfig.RequestConfig) error {
-		if err := authOption.Apply(r); err != nil {
+		if err := r.UseWorkloadIdentityCredential(requestconfig.WorkloadIdentityCredentialSourceX509); err != nil {
 			return err
 		}
-		return r.Apply(requestconfig.WithRequestFinalizer(configureX509Request))
+		r.SetAPIKey("")
+		return r.Apply(requestconfig.WithRequestFinalizer(func(r *requestconfig.RequestConfig) error {
+			return configureX509Request(r, &cache, config)
+		}))
 	})
+}
+
+type x509WorkloadIdentityAuthCache struct {
+	mu         sync.Mutex
+	byHTTPDoer map[auth.HTTPDoer]*auth.WorkloadIdentityAuth
+}
+
+func (c *x509WorkloadIdentityAuthCache) get(
+	httpDoer auth.HTTPDoer,
+	config auth.X509WorkloadIdentity,
+) (*auth.WorkloadIdentityAuth, error) {
+	if httpDoer == nil || !reflect.TypeOf(httpDoer).Comparable() {
+		return auth.NewX509WorkloadIdentityAuth(config)
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if wia := c.byHTTPDoer[httpDoer]; wia != nil {
+		return wia, nil
+	}
+	wia, err := auth.NewX509WorkloadIdentityAuth(config)
+	if err != nil {
+		return nil, err
+	}
+	if c.byHTTPDoer == nil {
+		c.byHTTPDoer = make(map[auth.HTTPDoer]*auth.WorkloadIdentityAuth)
+	}
+	c.byHTTPDoer[httpDoer] = wia
+	return wia, nil
 }
 
 func withWorkloadIdentityAuth(
@@ -372,19 +404,40 @@ func withWorkloadIdentityAuth(
 	})
 }
 
-func configureX509Request(r *requestconfig.RequestConfig) error {
+func configureX509Request(
+	r *requestconfig.RequestConfig,
+	cache *x509WorkloadIdentityAuthCache,
+	config auth.X509WorkloadIdentity,
+) error {
 	if r.BaseURL == nil {
 		if err := r.Apply(requestconfig.WithDefaultBaseURL(x509APIBaseURL)); err != nil {
 			return err
 		}
 	}
-	if r.CustomHTTPDoer != nil || r.HTTPClient == nil {
-		return nil
+
+	var configuredHTTPDoer auth.HTTPDoer = r.HTTPClient
+	if r.CustomHTTPDoer != nil {
+		configuredHTTPDoer = r.CustomHTTPDoer
 	}
-	clone := *r.HTTPClient
-	clone.CheckRedirect = func(*http.Request, []*http.Request) error {
-		return http.ErrUseLastResponse
+	wia, err := cache.get(configuredHTTPDoer, config)
+	if err != nil {
+		return err
 	}
-	r.HTTPClient = &clone
+
+	if r.CustomHTTPDoer == nil && r.HTTPClient != nil {
+		clone := *r.HTTPClient
+		clone.CheckRedirect = func(*http.Request, []*http.Request) error {
+			return errors.New("X.509 workload identity API redirects are disabled")
+		}
+		r.HTTPClient = &clone
+	}
+
+	var httpDoer auth.HTTPDoer = r.HTTPClient
+	if r.CustomHTTPDoer != nil {
+		httpDoer = r.CustomHTTPDoer
+	}
+	r.Middlewares = append(r.Middlewares, func(req *http.Request, next func(*http.Request) (*http.Response, error)) (*http.Response, error) {
+		return auth.WorkloadIdentityMiddleware(wia, httpDoer, req, next)
+	})
 	return nil
 }

--- a/option/requestoption.go
+++ b/option/requestoption.go
@@ -423,6 +423,11 @@ func withWorkloadIdentityAuth(
 			} else {
 				httpDoer = r.HTTPClient
 			}
+			if credentialSource == requestconfig.WorkloadIdentityCredentialSourceSubjectToken {
+				if wrapped, ok := httpDoer.(*comparableHTTPClient); ok {
+					httpDoer = wrapped.HTTPClient
+				}
+			}
 
 			return auth.WorkloadIdentityMiddleware(wia, httpDoer, req, next)
 		})

--- a/option/requestoption.go
+++ b/option/requestoption.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -70,7 +71,10 @@ type comparableHTTPClient struct {
 // For custom uses cases, it is recommended to provide an [*http.Client] with a custom
 // [http.RoundTripper] as its transport, rather than directly implementing [HTTPClient].
 func WithHTTPClient(client HTTPClient) RequestOption {
-	customHTTPClient := &comparableHTTPClient{HTTPClient: client}
+	customHTTPClient := client
+	if client != nil && !reflect.TypeOf(client).Comparable() {
+		customHTTPClient = &comparableHTTPClient{HTTPClient: client}
+	}
 	return requestconfig.RequestOptionFunc(func(r *requestconfig.RequestConfig) error {
 		if client == nil {
 			return fmt.Errorf("requestoption: custom http client cannot be nil")

--- a/option/requestoption_test.go
+++ b/option/requestoption_test.go
@@ -5,7 +5,25 @@ import (
 	"testing"
 
 	"github.com/openai/openai-go/v3/auth"
+	"github.com/openai/openai-go/v3/internal"
 )
+
+func TestX509CredentialHeaderGuardPreservesTransportProxyAuthentication(t *testing.T) {
+	transport := &http.Transport{
+		ProxyConnectHeader: http.Header{"Proxy-Authorization": []string{"Basic proxy-secret"}},
+	}
+	client := &http.Client{Transport: transport}
+
+	if got := internal.NativeHTTPTransport(client); got != transport {
+		t.Fatal("X.509 transport identity did not preserve the configured transport")
+	}
+	if hasConflictingX509CredentialHeaders(make(http.Header)) {
+		t.Fatal("transport-level CONNECT credentials were treated as target request headers")
+	}
+	if got, want := transport.ProxyConnectHeader.Get("Proxy-Authorization"), "Basic proxy-secret"; got != want {
+		t.Fatalf("ProxyConnectHeader Authorization = %q, want %q", got, want)
+	}
+}
 
 func TestX509WorkloadIdentityAuthCacheIsBoundedAndLeastRecentlyUsed(t *testing.T) {
 	config := auth.X509WorkloadIdentity{

--- a/option/requestoption_test.go
+++ b/option/requestoption_test.go
@@ -1,0 +1,62 @@
+package option
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/openai/openai-go/v3/auth"
+)
+
+func TestX509WorkloadIdentityAuthCacheIsBoundedAndLeastRecentlyUsed(t *testing.T) {
+	config := auth.X509WorkloadIdentity{
+		IdentityProviderID: "idp-test",
+		ServiceAccountID:   "svc-test",
+	}
+	cache := x509WorkloadIdentityAuthCache{}
+	httpClients := make([]*http.Client, x509WorkloadIdentityAuthCacheCapacity+1)
+	authStates := make([]*auth.WorkloadIdentityAuth, x509WorkloadIdentityAuthCacheCapacity)
+	for i := range authStates {
+		httpClients[i] = &http.Client{}
+		var err error
+		authStates[i], err = cache.get(httpClients[i], config)
+		if err != nil {
+			t.Fatalf("cache.get(%d) error = %v", i, err)
+		}
+	}
+
+	// Refresh the first entry so the second becomes least recently used.
+	first, err := cache.get(httpClients[0], config)
+	if err != nil {
+		t.Fatalf("cache.get(first) error = %v", err)
+	}
+	if first != authStates[0] {
+		t.Fatal("cache.get(first) returned a new auth state")
+	}
+
+	httpClients[len(httpClients)-1] = &http.Client{}
+	_, err = cache.get(httpClients[len(httpClients)-1], config)
+	if err != nil {
+		t.Fatalf("cache.get(new) error = %v", err)
+	}
+	if got, want := len(cache.entries), x509WorkloadIdentityAuthCacheCapacity; got != want {
+		t.Fatalf("cache entry count = %d, want %d", got, want)
+	}
+
+	first, err = cache.get(httpClients[0], config)
+	if err != nil {
+		t.Fatalf("cache.get(first after eviction) error = %v", err)
+	}
+	if first != authStates[0] {
+		t.Fatal("recently used auth state was evicted")
+	}
+	second, err := cache.get(httpClients[1], config)
+	if err != nil {
+		t.Fatalf("cache.get(second after eviction) error = %v", err)
+	}
+	if second == authStates[1] {
+		t.Fatal("least recently used auth state was retained")
+	}
+	if got, want := len(cache.entries), x509WorkloadIdentityAuthCacheCapacity; got != want {
+		t.Fatalf("cache entry count after replacement = %d, want %d", got, want)
+	}
+}

--- a/option/x509workloadidentity.go
+++ b/option/x509workloadidentity.go
@@ -242,6 +242,9 @@ func isProviderOwnedX509Hostname(hostname string) bool {
 	}
 
 	parts := strings.Split(hostname, ".")
+	if isBedrockPrivateLinkX509Hostname(parts) {
+		return true
+	}
 	if len(parts) < 3 || parts[1] == "" {
 		return false
 	}
@@ -272,6 +275,19 @@ func isProviderOwnedX509Hostname(hostname string) bool {
 		}
 	}
 	return false
+}
+
+func isBedrockPrivateLinkX509Hostname(parts []string) bool {
+	if len(parts) != 6 || !strings.HasPrefix(parts[0], "vpce-") || parts[0] == "vpce-" || parts[2] == "" ||
+		strings.Join(parts[3:], ".") != "vpce.amazonaws.com" {
+		return false
+	}
+	switch parts[1] {
+	case "bedrock-mantle", "bedrock-runtime", "bedrock-runtime-fips":
+		return true
+	default:
+		return false
+	}
 }
 
 func (origin x509APIOrigin) validate(value *url.URL) error {

--- a/option/x509workloadidentity.go
+++ b/option/x509workloadidentity.go
@@ -159,7 +159,7 @@ func configureX509Request(
 			if err := apiOrigin.validateRequest(req); err != nil {
 				return nil, requestconfig.WithNoRetryError(err)
 			}
-			return auth.WorkloadIdentityMiddleware(wia, configuredHTTPDoer, req, next)
+			return auth.WorkloadIdentityMiddleware(wia, configuredHTTPDoer, internal.WithX509RequestPolicy(req), next)
 		}
 	} else {
 		expectedAuthorization := ""

--- a/option/x509workloadidentity.go
+++ b/option/x509workloadidentity.go
@@ -157,7 +157,7 @@ func configureX509Request(
 		}
 		authorizationMiddleware = func(req *http.Request, next MiddlewareNext) (*http.Response, error) {
 			if err := apiOrigin.validateRequest(req); err != nil {
-				return nil, requestconfig.WithNoRetryError(err)
+				return nil, internal.WithNoRetryError(err)
 			}
 			return auth.WorkloadIdentityMiddleware(wia, configuredHTTPDoer, internal.WithX509RequestPolicy(req), next)
 		}
@@ -168,10 +168,10 @@ func configureX509Request(
 		}
 		authorizationMiddleware = func(req *http.Request, next MiddlewareNext) (*http.Response, error) {
 			if err := apiOrigin.validateRequest(req); err != nil {
-				return nil, requestconfig.WithNoRetryError(err)
+				return nil, internal.WithNoRetryError(err)
 			}
 			if !hasExactX509Authorization(req.Header, expectedAuthorization) {
-				return nil, requestconfig.WithNoRetryError(errX509AuthorizationProvenance)
+				return nil, internal.WithNoRetryError(errX509AuthorizationProvenance)
 			}
 			return next(internal.WithExpectedAuthorization(req, expectedAuthorization))
 		}
@@ -179,17 +179,17 @@ func configureX509Request(
 	r.Middlewares = append([]Middleware{authorizationMiddleware}, r.Middlewares...)
 	r.Middlewares = append(r.Middlewares, func(req *http.Request, next MiddlewareNext) (*http.Response, error) {
 		if err := apiOrigin.validateRequest(req); err != nil {
-			return nil, requestconfig.WithNoRetryError(err)
+			return nil, internal.WithNoRetryError(err)
 		}
 		if hasConflictingX509CredentialHeaders(req.Header) {
-			return nil, requestconfig.WithNoRetryError(errX509RequestCredentialConflict)
+			return nil, internal.WithNoRetryError(errX509RequestCredentialConflict)
 		}
 		expectedAuthorization, ok := internal.ExpectedAuthorization(req)
 		if !ok {
-			return nil, requestconfig.WithNoRetryError(errors.New("X.509 workload identity authorization state is missing"))
+			return nil, internal.WithNoRetryError(errors.New("X.509 workload identity authorization state is missing"))
 		}
 		if !hasExactX509Authorization(req.Header, expectedAuthorization) {
-			return nil, requestconfig.WithNoRetryError(errX509AuthorizationProvenance)
+			return nil, internal.WithNoRetryError(errX509AuthorizationProvenance)
 		}
 		return next(req)
 	})

--- a/option/x509workloadidentity.go
+++ b/option/x509workloadidentity.go
@@ -150,7 +150,7 @@ func configureX509Request(
 	}
 
 	var authorizationMiddleware Middleware
-	if r.Security.BearerAuth {
+	if r.BearerAuthenticationPreferred() {
 		wia, err := cache.get(configuredHTTPDoer, config)
 		if err != nil {
 			return err
@@ -242,36 +242,50 @@ func isProviderOwnedX509Hostname(hostname string) bool {
 	}
 
 	parts := strings.Split(hostname, ".")
-	if isBedrockPrivateLinkX509Hostname(parts) {
+	if isBedrockPrivateLinkX509Hostname(parts) || isBedrockAgentCoreGatewayX509Hostname(parts) {
 		return true
 	}
 	if len(parts) < 3 || parts[1] == "" {
 		return false
 	}
-	switch parts[0] {
-	case "bedrock-mantle":
-		return strings.Join(parts[2:], ".") == "api.aws"
-	case "bedrock-runtime", "bedrock-runtime-fips":
-		suffix := strings.Join(parts[2:], ".")
-		for _, providerSuffix := range []string{
-			"amazonaws.com",
-			"api.aws",
-			"amazonaws.com.cn",
-			"api.amazonwebservices.com.cn",
-			"amazonaws.eu",
-			"api.amazonwebservices.eu",
-			"c2s.ic.gov",
-			"api.aws.ic.gov",
-			"sc2s.sgov.gov",
-			"api.aws.scloud",
-			"cloud.adc-e.uk",
-			"api.cloud-aws.adc-e.uk",
-			"csp.hci.ic.gov",
-			"api.aws.hci.ic.gov",
-		} {
-			if suffix == providerSuffix {
-				return true
-			}
+	return isBedrockServiceX509Label(parts[0]) && isBedrockProviderX509Suffix(strings.Join(parts[2:], "."))
+}
+
+func isBedrockServiceX509Label(label string) bool {
+	switch label {
+	case "bedrock", "bedrock-fips",
+		"bedrock-runtime", "bedrock-runtime-fips",
+		"bedrock-agent", "bedrock-agent-fips",
+		"bedrock-agent-runtime", "bedrock-agent-runtime-fips",
+		"bedrock-mantle",
+		"bedrock-data-automation", "bedrock-data-automation-fips",
+		"bedrock-data-automation-runtime", "bedrock-data-automation-runtime-fips",
+		"bedrock-agentcore", "bedrock-agentcore-control":
+		return true
+	default:
+		return false
+	}
+}
+
+func isBedrockProviderX509Suffix(suffix string) bool {
+	for _, providerSuffix := range []string{
+		"amazonaws.com",
+		"api.aws",
+		"amazonaws.com.cn",
+		"api.amazonwebservices.com.cn",
+		"amazonaws.eu",
+		"api.amazonwebservices.eu",
+		"c2s.ic.gov",
+		"api.aws.ic.gov",
+		"sc2s.sgov.gov",
+		"api.aws.scloud",
+		"cloud.adc-e.uk",
+		"api.cloud-aws.adc-e.uk",
+		"csp.hci.ic.gov",
+		"api.aws.hci.ic.gov",
+	} {
+		if suffix == providerSuffix {
+			return true
 		}
 	}
 	return false
@@ -282,12 +296,13 @@ func isBedrockPrivateLinkX509Hostname(parts []string) bool {
 		strings.Join(parts[3:], ".") != "vpce.amazonaws.com" {
 		return false
 	}
-	switch parts[1] {
-	case "bedrock-mantle", "bedrock-runtime", "bedrock-runtime-fips":
-		return true
-	default:
-		return false
-	}
+	return isBedrockServiceX509Label(parts[1])
+}
+
+func isBedrockAgentCoreGatewayX509Hostname(parts []string) bool {
+	return len(parts) >= 6 && parts[0] != "" && parts[1] == "gateway" &&
+		parts[2] == "bedrock-agentcore" && parts[3] != "" &&
+		isBedrockProviderX509Suffix(strings.Join(parts[4:], "."))
 }
 
 func (origin x509APIOrigin) validate(value *url.URL) error {

--- a/option/x509workloadidentity.go
+++ b/option/x509workloadidentity.go
@@ -1,0 +1,274 @@
+package option
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strings"
+	"sync"
+
+	"github.com/openai/openai-go/v3/auth"
+	"github.com/openai/openai-go/v3/internal"
+	"github.com/openai/openai-go/v3/internal/requestconfig"
+)
+
+const x509APIBaseURL = "https://mtls.api.openai.com/v1/"
+
+// Keep enough transport-scoped auth states for a primary client plus a small
+// set of method-level overrides without retaining every transport ever used by
+// a long-lived client.
+const x509WorkloadIdentityAuthCacheCapacity = 8
+
+var (
+	errX509RequestCredentialConflict = errors.New("X.509 workload identity cannot be combined with another request credential")
+	errX509AuthorizationProvenance   = errors.New("X.509 workload identity request Authorization does not match SDK-selected authentication")
+)
+
+// WithX509WorkloadIdentity returns a RequestOption that configures X.509
+// workload identity authentication. The configured HTTP client must present
+// the client certificate for token exchange and API requests. Custom HTTPClient
+// implementations are responsible for refusing redirects internally.
+//
+// When no base URL is configured explicitly or through OPENAI_BASE_URL, X.509
+// workload identity clients use https://mtls.api.openai.com/v1. Explicit API
+// bases must be absolute HTTPS URLs, and requests remain bound to that origin.
+// Provider authentication options such as Azure and Bedrock are incompatible.
+func WithX509WorkloadIdentity(config auth.X509WorkloadIdentity) RequestOption {
+	cache := x509WorkloadIdentityAuthCache{}
+	return requestconfig.RequestOptionFunc(func(r *requestconfig.RequestConfig) error {
+		if err := r.UseWorkloadIdentityCredential(requestconfig.WorkloadIdentityCredentialSourceX509); err != nil {
+			return err
+		}
+		r.SetAPIKey("")
+		r.SetWorkloadIdentityFinalizer(func(r *requestconfig.RequestConfig) error {
+			return configureX509Request(r, &cache, config)
+		})
+		return nil
+	})
+}
+
+type x509WorkloadIdentityAuthCache struct {
+	mu      sync.Mutex
+	entries []x509WorkloadIdentityAuthCacheEntry
+}
+
+type x509WorkloadIdentityAuthCacheEntry struct {
+	httpDoer      auth.HTTPDoer
+	httpTransport http.RoundTripper
+	auth          *auth.WorkloadIdentityAuth
+}
+
+func (c *x509WorkloadIdentityAuthCache) get(
+	httpDoer auth.HTTPDoer,
+	config auth.X509WorkloadIdentity,
+) (*auth.WorkloadIdentityAuth, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	httpTransport := internal.NativeHTTPTransport(httpDoer)
+	for i := range c.entries {
+		if !sameX509CacheIdentity(c.entries[i].httpDoer, httpDoer) ||
+			!sameX509CacheIdentity(c.entries[i].httpTransport, httpTransport) {
+			continue
+		}
+		entry := c.entries[i]
+		copy(c.entries[i:], c.entries[i+1:])
+		c.entries[len(c.entries)-1] = entry
+		return entry.auth, nil
+	}
+	wia, err := auth.NewX509WorkloadIdentityAuth(config)
+	if err != nil {
+		return nil, err
+	}
+	entry := x509WorkloadIdentityAuthCacheEntry{
+		httpDoer:      httpDoer,
+		httpTransport: httpTransport,
+		auth:          wia,
+	}
+	if len(c.entries) == x509WorkloadIdentityAuthCacheCapacity {
+		copy(c.entries, c.entries[1:])
+		c.entries[len(c.entries)-1] = entry
+	} else {
+		c.entries = append(c.entries, entry)
+	}
+	return wia, nil
+}
+
+func sameX509CacheIdentity(left any, right any) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	leftValue := reflect.ValueOf(left)
+	rightValue := reflect.ValueOf(right)
+	if leftValue.Type() != rightValue.Type() || !leftValue.Comparable() || !rightValue.Comparable() {
+		return false
+	}
+	return leftValue.Interface() == rightValue.Interface()
+}
+
+func configureX509Request(
+	r *requestconfig.RequestConfig,
+	cache *x509WorkloadIdentityAuthCache,
+	config auth.X509WorkloadIdentity,
+) error {
+	if provider := r.ProviderAuthentication(); provider != "" {
+		return fmt.Errorf("X.509 workload identity cannot be combined with %s provider authentication", provider)
+	}
+	if r.APIKey != "" || hasConflictingX509CredentialHeaders(r.Request.Header) ||
+		!hasExactX509Authorization(r.Request.Header, "") {
+		return errX509RequestCredentialConflict
+	}
+
+	var configuredBaseURL *url.URL
+	if r.BaseURL == nil {
+		if err := r.Apply(requestconfig.WithDefaultBaseURL(x509APIBaseURL)); err != nil {
+			return err
+		}
+		configuredBaseURL = r.DefaultBaseURL
+	} else {
+		configuredBaseURL = r.BaseURL
+	}
+	apiOrigin, err := newX509APIOrigin(configuredBaseURL)
+	if err != nil {
+		return err
+	}
+
+	var configuredHTTPDoer auth.HTTPDoer = r.HTTPClient
+	if r.CustomHTTPDoer != nil {
+		configuredHTTPDoer = r.CustomHTTPDoer
+	}
+	if configuredHTTPDoer == nil {
+		return errors.New("X.509 workload identity requires an HTTP client")
+	}
+	if r.CustomHTTPDoer == nil && r.HTTPClient != nil {
+		clone := *r.HTTPClient
+		clone.CheckRedirect = func(*http.Request, []*http.Request) error {
+			return errors.New("X.509 workload identity API redirects are disabled")
+		}
+		r.HTTPClient = &clone
+	}
+
+	var authorizationMiddleware Middleware
+	if r.Security.BearerAuth {
+		wia, err := cache.get(configuredHTTPDoer, config)
+		if err != nil {
+			return err
+		}
+		authorizationMiddleware = func(req *http.Request, next MiddlewareNext) (*http.Response, error) {
+			if err := apiOrigin.validateRequest(req); err != nil {
+				return nil, requestconfig.WithNoRetryError(err)
+			}
+			return auth.WorkloadIdentityMiddleware(wia, configuredHTTPDoer, req, next)
+		}
+	} else {
+		expectedAuthorization := ""
+		if r.Security.AdminAPIKeyAuth && r.AdminAPIKey != "" {
+			expectedAuthorization = "Bearer " + r.AdminAPIKey
+		}
+		authorizationMiddleware = func(req *http.Request, next MiddlewareNext) (*http.Response, error) {
+			if err := apiOrigin.validateRequest(req); err != nil {
+				return nil, requestconfig.WithNoRetryError(err)
+			}
+			if !hasExactX509Authorization(req.Header, expectedAuthorization) {
+				return nil, requestconfig.WithNoRetryError(errX509AuthorizationProvenance)
+			}
+			return next(internal.WithExpectedAuthorization(req, expectedAuthorization))
+		}
+	}
+	r.Middlewares = append([]Middleware{authorizationMiddleware}, r.Middlewares...)
+	r.Middlewares = append(r.Middlewares, func(req *http.Request, next MiddlewareNext) (*http.Response, error) {
+		if err := apiOrigin.validateRequest(req); err != nil {
+			return nil, requestconfig.WithNoRetryError(err)
+		}
+		if hasConflictingX509CredentialHeaders(req.Header) {
+			return nil, requestconfig.WithNoRetryError(errX509RequestCredentialConflict)
+		}
+		expectedAuthorization, ok := internal.ExpectedAuthorization(req)
+		if !ok {
+			return nil, requestconfig.WithNoRetryError(errors.New("X.509 workload identity authorization state is missing"))
+		}
+		if !hasExactX509Authorization(req.Header, expectedAuthorization) {
+			return nil, requestconfig.WithNoRetryError(errX509AuthorizationProvenance)
+		}
+		return next(req)
+	})
+	return nil
+}
+
+type x509APIOrigin struct {
+	hostname string
+	port     string
+}
+
+func newX509APIOrigin(value *url.URL) (x509APIOrigin, error) {
+	if value == nil || !strings.EqualFold(value.Scheme, "https") || value.Opaque != "" ||
+		value.User != nil || value.Host == "" || strings.ContainsAny(value.Host, `\%`) {
+		return x509APIOrigin{}, errors.New("X.509 workload identity requires an absolute HTTPS API base URL without userinfo")
+	}
+	hostname := value.Hostname()
+	if hostname == "" {
+		return x509APIOrigin{}, errors.New("X.509 workload identity requires an absolute HTTPS API base URL without userinfo")
+	}
+	port := value.Port()
+	if port == "" {
+		port = "443"
+	}
+	return x509APIOrigin{hostname: strings.ToLower(hostname), port: port}, nil
+}
+
+func (origin x509APIOrigin) validate(value *url.URL) error {
+	candidate, err := newX509APIOrigin(value)
+	if err != nil {
+		return err
+	}
+	if candidate != origin {
+		return errors.New("X.509 workload identity cannot send credentials to an origin other than the configured API URL")
+	}
+	return nil
+}
+
+func (origin x509APIOrigin) validateRequest(req *http.Request) error {
+	if err := origin.validate(req.URL); err != nil {
+		return err
+	}
+	if req.Host == "" {
+		return nil
+	}
+	if strings.ContainsAny(req.Host, `@\/%?#`) || strings.HasSuffix(req.Host, ":") {
+		return errors.New("X.509 workload identity requires the HTTP request authority to match the configured API origin")
+	}
+	authority := &url.URL{Scheme: "https", Host: req.Host}
+	if err := origin.validate(authority); err != nil {
+		return errors.New("X.509 workload identity requires the HTTP request authority to match the configured API origin")
+	}
+	return nil
+}
+
+func hasConflictingX509CredentialHeaders(header http.Header) bool {
+	for name, values := range header {
+		normalizedName := strings.ToLower(strings.ReplaceAll(name, "_", "-"))
+		if normalizedName != "api-key" && normalizedName != "x-api-key" && normalizedName != "proxy-authorization" {
+			continue
+		}
+		for _, value := range values {
+			if value != "" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasExactX509Authorization(header http.Header, expected string) bool {
+	var values []string
+	for name, headerValues := range header {
+		if strings.EqualFold(name, "Authorization") {
+			values = append(values, headerValues...)
+		}
+	}
+	if expected == "" {
+		return len(values) == 0
+	}
+	return len(values) == 1 && values[0] == expected
+}

--- a/option/x509workloadidentity.go
+++ b/option/x509workloadidentity.go
@@ -27,9 +27,9 @@ var (
 )
 
 // WithX509WorkloadIdentity returns a RequestOption that configures X.509
-// workload identity authentication. The configured HTTP client must present
-// the client certificate for token exchange and API requests. Custom HTTPClient
-// implementations are responsible for refusing redirects internally.
+// workload identity authentication. The configured *http.Client must use a
+// native *http.Transport that presents one static client certificate for token
+// exchange and API requests.
 //
 // When no base URL is configured explicitly or through OPENAI_BASE_URL, X.509
 // workload identity clients use https://mtls.api.openai.com/v1. Explicit API
@@ -210,11 +210,68 @@ func newX509APIOrigin(value *url.URL) (x509APIOrigin, error) {
 	if hostname == "" {
 		return x509APIOrigin{}, errors.New("X.509 workload identity requires an absolute HTTPS API base URL without userinfo")
 	}
+	if isProviderOwnedX509Hostname(hostname) {
+		return x509APIOrigin{}, errors.New("X.509 workload identity cannot send OpenAI credentials to a provider-owned API URL")
+	}
 	port := value.Port()
 	if port == "" {
 		port = "443"
 	}
 	return x509APIOrigin{hostname: strings.ToLower(hostname), port: port}, nil
+}
+
+func isProviderOwnedX509Hostname(hostname string) bool {
+	hostname = strings.ToLower(strings.TrimRight(hostname, "."))
+	for _, suffix := range []string{
+		"openai.azure.com",
+		"openai.azure.us",
+		"openai.azure.cn",
+		"cognitiveservices.azure.com",
+		"cognitiveservices.azure.us",
+		"cognitiveservices.azure.cn",
+		"services.ai.azure.com",
+		"services.ai.azure.us",
+		"services.ai.azure.cn",
+		"azure-api.net",
+		"azure-api.us",
+		"azure-api.cn",
+	} {
+		if hostname == suffix || strings.HasSuffix(hostname, "."+suffix) {
+			return true
+		}
+	}
+
+	parts := strings.Split(hostname, ".")
+	if len(parts) < 3 || parts[1] == "" {
+		return false
+	}
+	switch parts[0] {
+	case "bedrock-mantle":
+		return strings.Join(parts[2:], ".") == "api.aws"
+	case "bedrock-runtime", "bedrock-runtime-fips":
+		suffix := strings.Join(parts[2:], ".")
+		for _, providerSuffix := range []string{
+			"amazonaws.com",
+			"api.aws",
+			"amazonaws.com.cn",
+			"api.amazonwebservices.com.cn",
+			"amazonaws.eu",
+			"api.amazonwebservices.eu",
+			"c2s.ic.gov",
+			"api.aws.ic.gov",
+			"sc2s.sgov.gov",
+			"api.aws.scloud",
+			"cloud.adc-e.uk",
+			"api.cloud-aws.adc-e.uk",
+			"csp.hci.ic.gov",
+			"api.aws.hci.ic.gov",
+		} {
+			if suffix == providerSuffix {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (origin x509APIOrigin) validate(value *url.URL) error {

--- a/x509_auth_mtls_identity_test.go
+++ b/x509_auth_mtls_identity_test.go
@@ -149,15 +149,6 @@ func TestClientX509UsesOneStaticCertificateForExchangeAndAPI(t *testing.T) {
 	if got := requests.mismatches.Load(); got != 0 {
 		t.Errorf("certificate/bearer mismatches = %d, want 0", got)
 	}
-
-	requestCount := requests.total.Load()
-	transport.TLSClientConfig.Certificates[0] = pki.clients["tenant-b"]
-	if _, err := client.Models.List(t.Context()); err == nil {
-		t.Fatal("Models.List() after certificate mutation error = nil")
-	}
-	if got := requests.total.Load(); got != requestCount {
-		t.Errorf("mTLS requests after certificate mutation = %d, want %d", got, requestCount)
-	}
 }
 
 type x509IdentityTestRequestCounts struct {

--- a/x509_auth_mtls_identity_test.go
+++ b/x509_auth_mtls_identity_test.go
@@ -1,0 +1,291 @@
+package openai_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"io"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+)
+
+type x509ClientIdentityContextKey struct{}
+
+func TestClientX509RejectsContextSelectedCertificatesBeforeExchange(t *testing.T) {
+	pki := newX509IdentityTestPKI(t)
+	server, requests := newX509IdentityTestServer(t, pki)
+
+	transport := &http.Transport{
+		Proxy: nil,
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			var dialer net.Dialer
+			return dialer.DialContext(ctx, "tcp", server.Listener.Addr().String())
+		},
+		TLSClientConfig: &tls.Config{
+			RootCAs:    pki.roots,
+			MinVersion: tls.VersionTLS12,
+			GetClientCertificate: func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+				identity, _ := info.Context().Value(x509ClientIdentityContextKey{}).(string)
+				certificate := pki.clients[identity]
+				return &certificate, nil
+			},
+		},
+		DisableKeepAlives: true,
+	}
+	t.Cleanup(transport.CloseIdleConnections)
+	httpClient := &http.Client{
+		Transport: transport,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	tenantAContext := context.WithValue(t.Context(), x509ClientIdentityContextKey{}, "tenant-a")
+	tokenRequest, err := http.NewRequestWithContext(tenantAContext, http.MethodPost, "https://mtls.auth.openai.com/oauth/token", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequestWithContext(token exchange) error = %v", err)
+	}
+	tokenResponse, err := httpClient.Do(tokenRequest)
+	if err != nil {
+		t.Fatalf("raw token exchange error = %v", err)
+	}
+	var token struct {
+		AccessToken string `json:"access_token"`
+	}
+	if decodeErr := json.NewDecoder(tokenResponse.Body).Decode(&token); decodeErr != nil {
+		_ = tokenResponse.Body.Close()
+		t.Fatalf("decode raw token exchange response error = %v", decodeErr)
+	}
+	if closeErr := tokenResponse.Body.Close(); closeErr != nil {
+		t.Fatalf("close raw token exchange response error = %v", closeErr)
+	}
+
+	tenantBContext := context.WithValue(t.Context(), x509ClientIdentityContextKey{}, "tenant-b")
+	apiRequest, err := http.NewRequestWithContext(tenantBContext, http.MethodGet, "https://mtls.api.openai.com/v1/models", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequestWithContext(API) error = %v", err)
+	}
+	apiRequest.Header.Set("Authorization", "Bearer "+token.AccessToken)
+	apiResponse, err := httpClient.Do(apiRequest)
+	if err != nil {
+		t.Fatalf("raw API request error = %v", err)
+	}
+	_, _ = io.Copy(io.Discard, apiResponse.Body)
+	if err := apiResponse.Body.Close(); err != nil {
+		t.Fatalf("close raw API response error = %v", err)
+	}
+	if got, want := apiResponse.StatusCode, http.StatusUnauthorized; got != want {
+		t.Fatalf("raw API status = %d, want %d", got, want)
+	}
+	if got, want := requests.mismatches.Load(), int32(1); got != want {
+		t.Fatalf("raw certificate/bearer mismatches = %d, want %d", got, want)
+	}
+	requests.reset()
+
+	client := openai.NewClient(
+		option.WithHTTPClient(httpClient),
+		option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
+	)
+
+	if _, err := client.Models.List(tenantAContext); err == nil {
+		t.Error("Models.List() error = nil")
+	}
+	if got := requests.total.Load(); got != 0 {
+		t.Errorf("mTLS requests = %d, want 0", got)
+	}
+}
+
+func TestClientX509UsesOneStaticCertificateForExchangeAndAPI(t *testing.T) {
+	pki := newX509IdentityTestPKI(t)
+	server, requests := newX509IdentityTestServer(t, pki)
+	transport := &http.Transport{
+		Proxy: nil,
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			var dialer net.Dialer
+			return dialer.DialContext(ctx, "tcp", server.Listener.Addr().String())
+		},
+		TLSClientConfig: &tls.Config{
+			Certificates: []tls.Certificate{pki.clients["tenant-a"]},
+			RootCAs:      pki.roots,
+			MinVersion:   tls.VersionTLS12,
+		},
+		DisableKeepAlives: true,
+	}
+	t.Cleanup(transport.CloseIdleConnections)
+	client := openai.NewClient(
+		option.WithHTTPClient(&http.Client{
+			Transport: transport,
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		}),
+		option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
+	)
+
+	for range 2 {
+		if _, err := client.Models.List(t.Context()); err != nil {
+			t.Fatalf("Models.List() error = %v", err)
+		}
+	}
+	if got, want := requests.exchanges.Load(), int32(1); got != want {
+		t.Errorf("token exchanges = %d, want %d", got, want)
+	}
+	if got, want := requests.api.Load(), int32(2); got != want {
+		t.Errorf("API requests = %d, want %d", got, want)
+	}
+	if got := requests.mismatches.Load(); got != 0 {
+		t.Errorf("certificate/bearer mismatches = %d, want 0", got)
+	}
+
+	requestCount := requests.total.Load()
+	transport.TLSClientConfig.Certificates[0] = pki.clients["tenant-b"]
+	if _, err := client.Models.List(t.Context()); err == nil {
+		t.Fatal("Models.List() after certificate mutation error = nil")
+	}
+	if got := requests.total.Load(); got != requestCount {
+		t.Errorf("mTLS requests after certificate mutation = %d, want %d", got, requestCount)
+	}
+}
+
+type x509IdentityTestRequestCounts struct {
+	total      atomic.Int32
+	exchanges  atomic.Int32
+	api        atomic.Int32
+	mismatches atomic.Int32
+}
+
+func (r *x509IdentityTestRequestCounts) reset() {
+	r.total.Store(0)
+	r.exchanges.Store(0)
+	r.api.Store(0)
+	r.mismatches.Store(0)
+}
+
+func newX509IdentityTestServer(t *testing.T, pki x509IdentityTestPKI) (*httptest.Server, *x509IdentityTestRequestCounts) {
+	t.Helper()
+	requests := &x509IdentityTestRequestCounts{}
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.total.Add(1)
+		identity := r.TLS.PeerCertificates[0].Subject.CommonName
+		if r.URL.Path == "/oauth/token" {
+			requests.exchanges.Add(1)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token": "token-" + identity,
+				"expires_in":   3600,
+			})
+			return
+		}
+		requests.api.Add(1)
+		if got, want := r.Header.Get("Authorization"), "Bearer token-"+identity; got != want {
+			requests.mismatches.Add(1)
+			http.Error(w, "certificate/bearer mismatch", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"list","data":[]}`))
+	}))
+	server.TLS = &tls.Config{
+		Certificates: []tls.Certificate{pki.server},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    pki.roots,
+		MinVersion:   tls.VersionTLS12,
+	}
+	server.StartTLS()
+	t.Cleanup(server.Close)
+	return server, requests
+}
+
+type x509IdentityTestPKI struct {
+	roots   *x509.CertPool
+	server  tls.Certificate
+	clients map[string]tls.Certificate
+}
+
+func newX509IdentityTestPKI(t *testing.T) x509IdentityTestPKI {
+	t.Helper()
+	now := time.Now()
+	caKey := newX509IdentityTestKey(t)
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-root"},
+		NotBefore:             now.Add(-time.Minute),
+		NotAfter:              now.Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("x509.CreateCertificate(CA) error = %v", err)
+	}
+	ca, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatalf("x509.ParseCertificate(CA) error = %v", err)
+	}
+	roots := x509.NewCertPool()
+	roots.AddCert(ca)
+
+	return x509IdentityTestPKI{
+		roots: roots,
+		server: newX509IdentityTestCertificate(t, ca, caKey, 2, "test-server", []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}, []string{
+			"mtls.auth.openai.com",
+			"mtls.api.openai.com",
+		}),
+		clients: map[string]tls.Certificate{
+			"tenant-a": newX509IdentityTestCertificate(t, ca, caKey, 3, "tenant-a", []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}, nil),
+			"tenant-b": newX509IdentityTestCertificate(t, ca, caKey, 4, "tenant-b", []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}, nil),
+		},
+	}
+}
+
+func newX509IdentityTestKey(t *testing.T) *ecdsa.PrivateKey {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ecdsa.GenerateKey() error = %v", err)
+	}
+	return key
+}
+
+func newX509IdentityTestCertificate(
+	t *testing.T,
+	ca *x509.Certificate,
+	caKey *ecdsa.PrivateKey,
+	serial int64,
+	commonName string,
+	extKeyUsage []x509.ExtKeyUsage,
+	dnsNames []string,
+) tls.Certificate {
+	t.Helper()
+	key := newX509IdentityTestKey(t)
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(serial),
+		Subject:      pkix.Name{CommonName: commonName},
+		DNSNames:     dnsNames,
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  extKeyUsage,
+	}
+	certificateDER, err := x509.CreateCertificate(rand.Reader, template, ca, &key.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("x509.CreateCertificate(%q) error = %v", commonName, err)
+	}
+	return tls.Certificate{
+		Certificate: [][]byte{certificateDER, ca.Raw},
+		PrivateKey:  key,
+	}
+}

--- a/x509_auth_mtls_identity_test.go
+++ b/x509_auth_mtls_identity_test.go
@@ -24,6 +24,14 @@ import (
 
 type x509ClientIdentityContextKey struct{}
 
+type x509RoundTripperDecorator struct {
+	inner http.RoundTripper
+}
+
+func (d *x509RoundTripperDecorator) RoundTrip(req *http.Request) (*http.Response, error) {
+	return d.inner.RoundTrip(req)
+}
+
 func TestClientX509RejectsContextSelectedCertificatesBeforeExchange(t *testing.T) {
 	pki := newX509IdentityTestPKI(t)
 	server, requests := newX509IdentityTestServer(t, pki)
@@ -149,6 +157,93 @@ func TestClientX509UsesOneStaticCertificateForExchangeAndAPI(t *testing.T) {
 	if got := requests.mismatches.Load(); got != 0 {
 		t.Errorf("certificate/bearer mismatches = %d, want 0", got)
 	}
+}
+
+func TestClientX509RejectsStaticCertificateRotationBeforeRealMTLS(t *testing.T) {
+	pki := newX509IdentityTestPKI(t)
+	server, requests := newX509IdentityTestServer(t, pki)
+	transport := &http.Transport{
+		Proxy: nil,
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			var dialer net.Dialer
+			return dialer.DialContext(ctx, "tcp", server.Listener.Addr().String())
+		},
+		TLSClientConfig: &tls.Config{
+			Certificates: []tls.Certificate{pki.clients["tenant-a"]},
+			RootCAs:      pki.roots,
+			MinVersion:   tls.VersionTLS12,
+		},
+		DisableKeepAlives: true,
+	}
+	t.Cleanup(transport.CloseIdleConnections)
+	client := openai.NewClient(
+		option.WithHTTPClient(&http.Client{Transport: transport}),
+		option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
+	)
+
+	if _, err := client.Models.List(t.Context()); err != nil {
+		t.Fatalf("first Models.List() error = %v", err)
+	}
+	transport.TLSClientConfig.Certificates[0] = pki.clients["tenant-b"]
+	if _, err := client.Models.List(t.Context()); err == nil {
+		t.Fatal("Models.List() after certificate rotation error = nil")
+	}
+	if got, want := requests.total.Load(), int32(2); got != want {
+		t.Fatalf("mTLS requests = %d, want %d", got, want)
+	}
+	if got := requests.mismatches.Load(); got != 0 {
+		t.Fatalf("certificate/bearer mismatches = %d, want 0", got)
+	}
+}
+
+func TestClientX509RejectsOpaqueTransportAndSessionCacheBeforeRealMTLS(t *testing.T) {
+	pki := newX509IdentityTestPKI(t)
+	server, requests := newX509IdentityTestServer(t, pki)
+	newTransport := func() *http.Transport {
+		return &http.Transport{
+			Proxy: nil,
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				var dialer net.Dialer
+				return dialer.DialContext(ctx, "tcp", server.Listener.Addr().String())
+			},
+			TLSClientConfig: &tls.Config{
+				Certificates: []tls.Certificate{pki.clients["tenant-a"]},
+				RootCAs:      pki.roots,
+				MinVersion:   tls.VersionTLS12,
+			},
+		}
+	}
+
+	t.Run("opaque decorator", func(t *testing.T) {
+		transport := newTransport()
+		t.Cleanup(transport.CloseIdleConnections)
+		client := openai.NewClient(
+			option.WithHTTPClient(&http.Client{Transport: &x509RoundTripperDecorator{inner: transport}}),
+			option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
+		)
+		if _, err := client.Models.List(t.Context()); err == nil {
+			t.Fatal("Models.List() error = nil")
+		}
+		if got := requests.total.Load(); got != 0 {
+			t.Fatalf("mTLS requests = %d, want 0", got)
+		}
+	})
+
+	t.Run("client session cache", func(t *testing.T) {
+		transport := newTransport()
+		transport.TLSClientConfig.ClientSessionCache = tls.NewLRUClientSessionCache(1)
+		t.Cleanup(transport.CloseIdleConnections)
+		client := openai.NewClient(
+			option.WithHTTPClient(&http.Client{Transport: transport}),
+			option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
+		)
+		if _, err := client.Models.List(t.Context()); err == nil {
+			t.Fatal("Models.List() error = nil")
+		}
+		if got := requests.total.Load(); got != 0 {
+			t.Fatalf("mTLS requests = %d, want 0", got)
+		}
+	})
 }
 
 type x509IdentityTestRequestCounts struct {

--- a/x509_auth_security_test.go
+++ b/x509_auth_security_test.go
@@ -520,6 +520,38 @@ func TestClientRejectsAzureAuthenticationWithX509BeforeExchange(t *testing.T) {
 	}
 }
 
+func TestClientRejectsAzureEndpointWithX509BeforeExchange(t *testing.T) {
+	endpoint := azure.WithEndpoint("https://resource.openai.azure.com", "2024-10-21")
+	x509 := option.WithX509WorkloadIdentity(clientX509WorkloadIdentity())
+	testCases := []struct {
+		name string
+		opts []option.RequestOption
+	}{
+		{name: "endpoint before X.509", opts: []option.RequestOption{endpoint, x509}},
+		{name: "endpoint after X.509", opts: []option.RequestOption{x509, endpoint}},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var calls atomic.Int32
+			httpClient := &http.Client{Transport: &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+				calls.Add(1)
+				return nil, errors.New("HTTP request must not be attempted")
+			}}}
+			opts := append([]option.RequestOption{}, testCase.opts...)
+			opts = append(opts, option.WithHTTPClient(httpClient))
+			client := openai.NewClient(opts...)
+
+			if _, err := client.Models.List(t.Context()); err == nil {
+				t.Fatal("Models.List() error = nil")
+			}
+			if got := calls.Load(); got != 0 {
+				t.Fatalf("HTTP calls = %d, want 0", got)
+			}
+		})
+	}
+}
+
 func TestClientX509RejectsLaterAPIKeyCredentialsBeforeExchange(t *testing.T) {
 	testCases := []struct {
 		name        string

--- a/x509_auth_security_test.go
+++ b/x509_auth_security_test.go
@@ -89,6 +89,86 @@ func TestClientX509WorkloadIdentityRejectsUnsafeBaseURLBeforeExchange(t *testing
 	})
 }
 
+func TestClientX509WorkloadIdentityRejectsProviderOwnedBaseURLBeforeExchange(t *testing.T) {
+	testCases := []struct {
+		name    string
+		baseURL string
+		fromEnv bool
+	}{
+		{name: "Azure OpenAI", baseURL: "https://resource.openai.azure.com/openai/v1"},
+		{name: "Azure absolute DNS name", baseURL: "https://resource.openai.azure.com./openai/v1"},
+		{name: "Azure US sovereign", baseURL: "https://resource.openai.azure.us/openai/v1"},
+		{name: "Azure China sovereign", baseURL: "https://resource.openai.azure.cn/openai/v1"},
+		{name: "Azure Cognitive Services", baseURL: "https://resource.cognitiveservices.azure.com/openai/v1"},
+		{name: "Azure Foundry", baseURL: "https://resource.services.ai.azure.com/openai/v1"},
+		{name: "Azure API Management", baseURL: "https://resource.azure-api.net/openai/v1"},
+		{name: "Bedrock runtime", baseURL: "https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1"},
+		{name: "Bedrock China", baseURL: "https://bedrock-runtime.cn-north-1.amazonaws.com.cn/openai/v1"},
+		{name: "Bedrock EU sovereign", baseURL: "https://bedrock-runtime.eusc-de-east-1.amazonaws.eu/openai/v1"},
+		{name: "Bedrock mantle", baseURL: "https://bedrock-mantle.us-east-1.api.aws/openai/v1"},
+		{name: "environment provider URL", baseURL: "https://resource.openai.azure.com/openai/v1", fromEnv: true},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var calls atomic.Int32
+			httpClient := &http.Client{Transport: &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+				calls.Add(1)
+				return nil, errors.New("HTTP request must not be attempted")
+			}}}
+			opts := []option.RequestOption{
+				option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
+				option.WithHTTPClient(httpClient),
+			}
+			if testCase.fromEnv {
+				t.Setenv("OPENAI_BASE_URL", testCase.baseURL)
+			} else {
+				opts = append(opts, option.WithBaseURL(testCase.baseURL))
+			}
+
+			client := openai.NewClient(opts...)
+			if _, err := client.Models.List(t.Context()); err == nil || !strings.Contains(err.Error(), "provider-owned") {
+				t.Fatalf("Models.List() error = %v, want provider-owned URL rejection", err)
+			}
+			if got := calls.Load(); got != 0 {
+				t.Fatalf("HTTP calls = %d, want 0", got)
+			}
+		})
+	}
+}
+
+func TestClientX509WorkloadIdentityAllowsProviderSuffixLookalikeGateway(t *testing.T) {
+	var exchangeCalls atomic.Int32
+	var apiCalls atomic.Int32
+	httpClient := nativeX509HTTPClient(t, func(req *http.Request) (*http.Response, error) {
+		if req.URL.Hostname() == "mtls.auth.openai.com" {
+			exchangeCalls.Add(1)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"access_token":"x509-token","expires_in":3600}`)),
+			}, nil
+		}
+		apiCalls.Add(1)
+		return modelsListResponse(), nil
+	})
+	client := openai.NewClient(
+		option.WithBaseURL("https://resource.openai.azure.com.example/v1"),
+		option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
+		option.WithHTTPClient(httpClient),
+	)
+
+	if _, err := client.Models.List(t.Context()); err != nil {
+		t.Fatalf("Models.List() error = %v", err)
+	}
+	if got, want := exchangeCalls.Load(), int32(1); got != want {
+		t.Fatalf("exchange calls = %d, want %d", got, want)
+	}
+	if got, want := apiCalls.Load(), int32(1); got != want {
+		t.Fatalf("API calls = %d, want %d", got, want)
+	}
+}
+
 func TestClientX509WorkloadIdentityBindsAbsoluteURLsToConfiguredOrigin(t *testing.T) {
 	testCases := []struct {
 		name       string
@@ -107,7 +187,7 @@ func TestClientX509WorkloadIdentityBindsAbsoluteURLsToConfiguredOrigin(t *testin
 		t.Run(testCase.name, func(t *testing.T) {
 			var exchangeCalls atomic.Int32
 			var apiCalls atomic.Int32
-			httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+			httpClient := nativeX509HTTPClient(t, func(req *http.Request) (*http.Response, error) {
 				if req.URL.Hostname() == "mtls.auth.openai.com" {
 					exchangeCalls.Add(1)
 					return &http.Response{
@@ -118,7 +198,7 @@ func TestClientX509WorkloadIdentityBindsAbsoluteURLsToConfiguredOrigin(t *testin
 				}
 				apiCalls.Add(1)
 				return modelsListResponse(), nil
-			}}}
+			})
 			client := openai.NewClient(
 				option.WithBaseURL("https://trusted.example:443/v1"),
 				option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
@@ -159,7 +239,7 @@ func TestClientX509WorkloadIdentityBindsAbsoluteURLsToConfiguredOrigin(t *testin
 func TestClientX509WorkloadIdentityGuardsFinalDispatch(t *testing.T) {
 	t.Run("origin mutation", func(t *testing.T) {
 		var apiCalls atomic.Int32
-		httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+		httpClient := nativeX509HTTPClient(t, func(req *http.Request) (*http.Response, error) {
 			if req.URL.Hostname() == "mtls.auth.openai.com" {
 				return &http.Response{
 					StatusCode: http.StatusOK,
@@ -169,7 +249,7 @@ func TestClientX509WorkloadIdentityGuardsFinalDispatch(t *testing.T) {
 			}
 			apiCalls.Add(1)
 			return modelsListResponse(), nil
-		}}}
+		})
 		client := openai.NewClient(
 			option.WithBaseURL("https://trusted.example/v1"),
 			option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
@@ -194,7 +274,7 @@ func TestClientX509WorkloadIdentityGuardsFinalDispatch(t *testing.T) {
 
 	t.Run("authority mutation", func(t *testing.T) {
 		var apiCalls atomic.Int32
-		httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+		httpClient := nativeX509HTTPClient(t, func(req *http.Request) (*http.Response, error) {
 			if req.URL.Hostname() == "mtls.auth.openai.com" {
 				return &http.Response{
 					StatusCode: http.StatusOK,
@@ -204,7 +284,7 @@ func TestClientX509WorkloadIdentityGuardsFinalDispatch(t *testing.T) {
 			}
 			apiCalls.Add(1)
 			return modelsListResponse(), nil
-		}}}
+		})
 		client := openai.NewClient(
 			option.WithBaseURL("https://trusted.example/v1"),
 			option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
@@ -225,7 +305,7 @@ func TestClientX509WorkloadIdentityGuardsFinalDispatch(t *testing.T) {
 
 	t.Run("normalized authority", func(t *testing.T) {
 		var apiCalls atomic.Int32
-		httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+		httpClient := nativeX509HTTPClient(t, func(req *http.Request) (*http.Response, error) {
 			if req.URL.Hostname() == "mtls.auth.openai.com" {
 				return &http.Response{
 					StatusCode: http.StatusOK,
@@ -235,7 +315,7 @@ func TestClientX509WorkloadIdentityGuardsFinalDispatch(t *testing.T) {
 			}
 			apiCalls.Add(1)
 			return modelsListResponse(), nil
-		}}}
+		})
 		client := openai.NewClient(
 			option.WithBaseURL("https://trusted.example/v1"),
 			option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
@@ -258,7 +338,7 @@ func TestClientX509WorkloadIdentityGuardsFinalDispatch(t *testing.T) {
 		var authorization string
 		var exchangeAuthorization string
 		var exchangeCookie string
-		httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+		httpClient := nativeX509HTTPClient(t, func(req *http.Request) (*http.Response, error) {
 			if req.URL.Hostname() == "mtls.auth.openai.com" {
 				exchangeAuthorization = req.Header.Get("Authorization")
 				exchangeCookie = req.Header.Get("Cookie")
@@ -270,7 +350,7 @@ func TestClientX509WorkloadIdentityGuardsFinalDispatch(t *testing.T) {
 			}
 			authorization = req.Header.Get("Authorization")
 			return modelsListResponse(), nil
-		}}}
+		})
 		client := openai.NewClient(
 			option.WithBaseURL("https://trusted.example/v1"),
 			option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
@@ -301,7 +381,7 @@ func TestClientX509WorkloadIdentityGuardsFinalDispatch(t *testing.T) {
 		t.Run("secondary API credential "+headerName, func(t *testing.T) {
 			var exchangeCalls atomic.Int32
 			var apiCalls atomic.Int32
-			httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+			httpClient := nativeX509HTTPClient(t, func(req *http.Request) (*http.Response, error) {
 				if req.URL.Hostname() == "mtls.auth.openai.com" {
 					exchangeCalls.Add(1)
 					return &http.Response{
@@ -312,7 +392,7 @@ func TestClientX509WorkloadIdentityGuardsFinalDispatch(t *testing.T) {
 				}
 				apiCalls.Add(1)
 				return modelsListResponse(), nil
-			}}}
+			})
 			client := openai.NewClient(
 				option.WithBaseURL("https://trusted.example/v1"),
 				option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),

--- a/x509_auth_security_test.go
+++ b/x509_auth_security_test.go
@@ -1,0 +1,573 @@
+package openai_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/azure"
+	"github.com/openai/openai-go/v3/internal/requestconfig"
+	"github.com/openai/openai-go/v3/option"
+)
+
+type countingAzureTokenCredential struct {
+	calls atomic.Int32
+}
+
+func (c *countingAzureTokenCredential) GetToken(context.Context, policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	c.calls.Add(1)
+	return azcore.AccessToken{Token: "azure-provider-token", ExpiresOn: time.Now().Add(time.Hour)}, nil
+}
+
+func TestClientX509WorkloadIdentityRejectsUnsafeBaseURLBeforeExchange(t *testing.T) {
+	testCases := []struct {
+		name    string
+		baseURL string
+		fromEnv bool
+	}{
+		{name: "explicit plaintext", baseURL: "http://plaintext.example/v1"},
+		{name: "environment plaintext", baseURL: "http://plaintext.example/v1", fromEnv: true},
+		{name: "scheme relative", baseURL: "//scheme-relative.example/v1"},
+		{name: "opaque", baseURL: "https:opaque-api"},
+		{name: "userinfo", baseURL: "https://mtls.api.openai.com.@attacker.invalid/v1"},
+		{name: "backslash userinfo", baseURL: `https://mtls.api.openai.com\@attacker.invalid/v1`},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var calls atomic.Int32
+			httpClient := &http.Client{Transport: &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+				calls.Add(1)
+				return nil, errors.New("HTTP request must not be attempted")
+			}}}
+			opts := []option.RequestOption{
+				option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
+				option.WithHTTPClient(httpClient),
+			}
+			if testCase.fromEnv {
+				t.Setenv("OPENAI_BASE_URL", testCase.baseURL)
+			} else {
+				opts = append(opts, option.WithBaseURL(testCase.baseURL))
+			}
+			client := openai.NewClient(opts...)
+
+			if _, err := client.Models.List(t.Context()); err == nil {
+				t.Fatal("Models.List() error = nil")
+			}
+			if got := calls.Load(); got != 0 {
+				t.Fatalf("HTTP calls = %d, want 0", got)
+			}
+		})
+	}
+
+	t.Run("method option plaintext", func(t *testing.T) {
+		var calls atomic.Int32
+		httpClient := &http.Client{Transport: &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+			calls.Add(1)
+			return nil, errors.New("HTTP request must not be attempted")
+		}}}
+		client := openai.NewClient(
+			option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
+			option.WithHTTPClient(httpClient),
+		)
+		if _, err := client.Models.List(t.Context(), option.WithBaseURL("http://plaintext.example/v1")); err == nil {
+			t.Fatal("Models.List() error = nil")
+		}
+		if got := calls.Load(); got != 0 {
+			t.Fatalf("HTTP calls = %d, want 0", got)
+		}
+	})
+}
+
+func TestClientX509WorkloadIdentityBindsAbsoluteURLsToConfiguredOrigin(t *testing.T) {
+	testCases := []struct {
+		name       string
+		requestURL string
+		useGet     bool
+		wantOK     bool
+	}{
+		{name: "plaintext", requestURL: "http://trusted.example/v1/models"},
+		{name: "plaintext public Get", requestURL: "http://trusted.example/v1/models", useGet: true},
+		{name: "different TLS origin", requestURL: "https://attacker.invalid/v1/models"},
+		{name: "userinfo lookalike", requestURL: "https://trusted.example@attacker.invalid/v1/models"},
+		{name: "normalized configured origin", requestURL: "https://TRUSTED.EXAMPLE/v1/models", wantOK: true},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var exchangeCalls atomic.Int32
+			var apiCalls atomic.Int32
+			httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+				if req.URL.Hostname() == "mtls.auth.openai.com" {
+					exchangeCalls.Add(1)
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Header:     http.Header{"Content-Type": []string{"application/json"}},
+						Body:       io.NopCloser(strings.NewReader(`{"access_token":"x509-token","expires_in":3600}`)),
+					}, nil
+				}
+				apiCalls.Add(1)
+				return modelsListResponse(), nil
+			}}}
+			client := openai.NewClient(
+				option.WithBaseURL("https://trusted.example:443/v1"),
+				option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
+				option.WithHTTPClient(httpClient),
+			)
+
+			var err error
+			if testCase.useGet {
+				err = client.Get(t.Context(), testCase.requestURL, nil, nil)
+			} else {
+				err = client.Execute(t.Context(), http.MethodGet, testCase.requestURL, nil, nil)
+			}
+			if testCase.wantOK {
+				if err != nil {
+					t.Fatalf("Execute() error = %v", err)
+				}
+				if got := exchangeCalls.Load(); got != 1 {
+					t.Fatalf("exchange calls = %d, want 1", got)
+				}
+				if got := apiCalls.Load(); got != 1 {
+					t.Fatalf("API calls = %d, want 1", got)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("Execute() error = nil")
+			}
+			if got := exchangeCalls.Load(); got != 0 {
+				t.Fatalf("exchange calls = %d, want 0", got)
+			}
+			if got := apiCalls.Load(); got != 0 {
+				t.Fatalf("API calls = %d, want 0", got)
+			}
+		})
+	}
+}
+
+func TestClientX509WorkloadIdentityGuardsFinalDispatch(t *testing.T) {
+	t.Run("origin mutation", func(t *testing.T) {
+		var apiCalls atomic.Int32
+		httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+			if req.URL.Hostname() == "mtls.auth.openai.com" {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+					Body:       io.NopCloser(strings.NewReader(`{"access_token":"x509-token","expires_in":3600}`)),
+				}, nil
+			}
+			apiCalls.Add(1)
+			return modelsListResponse(), nil
+		}}}
+		client := openai.NewClient(
+			option.WithBaseURL("https://trusted.example/v1"),
+			option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
+			option.WithHTTPClient(httpClient),
+			option.WithMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+				rewritten, err := url.Parse("https://attacker.invalid/v1/models")
+				if err != nil {
+					return nil, err
+				}
+				req.URL = rewritten
+				return next(req)
+			}),
+		)
+
+		if _, err := client.Models.List(t.Context()); err == nil {
+			t.Fatal("Models.List() error = nil")
+		}
+		if got := apiCalls.Load(); got != 0 {
+			t.Fatalf("API calls = %d, want 0", got)
+		}
+	})
+
+	t.Run("authority mutation", func(t *testing.T) {
+		var apiCalls atomic.Int32
+		httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+			if req.URL.Hostname() == "mtls.auth.openai.com" {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+					Body:       io.NopCloser(strings.NewReader(`{"access_token":"x509-token","expires_in":3600}`)),
+				}, nil
+			}
+			apiCalls.Add(1)
+			return modelsListResponse(), nil
+		}}}
+		client := openai.NewClient(
+			option.WithBaseURL("https://trusted.example/v1"),
+			option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
+			option.WithHTTPClient(httpClient),
+			option.WithMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+				req.Host = "attacker.invalid"
+				return next(req)
+			}),
+		)
+
+		if _, err := client.Models.List(t.Context()); err == nil {
+			t.Fatal("Models.List() error = nil")
+		}
+		if got := apiCalls.Load(); got != 0 {
+			t.Fatalf("API calls = %d, want 0", got)
+		}
+	})
+
+	t.Run("normalized authority", func(t *testing.T) {
+		var apiCalls atomic.Int32
+		httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+			if req.URL.Hostname() == "mtls.auth.openai.com" {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+					Body:       io.NopCloser(strings.NewReader(`{"access_token":"x509-token","expires_in":3600}`)),
+				}, nil
+			}
+			apiCalls.Add(1)
+			return modelsListResponse(), nil
+		}}}
+		client := openai.NewClient(
+			option.WithBaseURL("https://trusted.example/v1"),
+			option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
+			option.WithHTTPClient(httpClient),
+			option.WithMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+				req.Host = "TRUSTED.EXAMPLE:443"
+				return next(req)
+			}),
+		)
+
+		if _, err := client.Models.List(t.Context()); err != nil {
+			t.Fatalf("Models.List() error = %v", err)
+		}
+		if got := apiCalls.Load(); got != 1 {
+			t.Fatalf("API calls = %d, want 1", got)
+		}
+	})
+
+	t.Run("authorization provenance", func(t *testing.T) {
+		var authorization string
+		var exchangeAuthorization string
+		var exchangeCookie string
+		httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+			if req.URL.Hostname() == "mtls.auth.openai.com" {
+				exchangeAuthorization = req.Header.Get("Authorization")
+				exchangeCookie = req.Header.Get("Cookie")
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+					Body:       io.NopCloser(strings.NewReader(`{"access_token":"x509-token","expires_in":3600}`)),
+				}, nil
+			}
+			authorization = req.Header.Get("Authorization")
+			return modelsListResponse(), nil
+		}}}
+		client := openai.NewClient(
+			option.WithBaseURL("https://trusted.example/v1"),
+			option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
+			option.WithHTTPClient(httpClient),
+			option.WithMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+				req.Header.Set("Authorization", "Bearer attacker-override")
+				req.Header.Set("Cookie", "api-session=secret")
+				return next(req)
+			}),
+		)
+
+		if _, err := client.Models.List(t.Context()); err == nil {
+			t.Fatal("Models.List() error = nil")
+		}
+		if authorization != "" {
+			t.Fatalf("API Authorization = %q, want no dispatch", authorization)
+		}
+		if exchangeAuthorization != "" || exchangeCookie != "" {
+			t.Fatalf("token exchange inherited API middleware headers: Authorization=%q Cookie=%q", exchangeAuthorization, exchangeCookie)
+		}
+	})
+
+	for _, headerName := range []string{
+		"Api-Key", "X-Api-Key", "api-key", "x-api-key",
+		"api_key", "API_KEY", "x_api_key", "X_API_KEY", "x_api-key", "x-api_key",
+		"Proxy-Authorization", "proxy-authorization", "PROXY_AUTHORIZATION", "proxy_authorization", "Proxy_Authorization",
+	} {
+		t.Run("secondary API credential "+headerName, func(t *testing.T) {
+			var exchangeCalls atomic.Int32
+			var apiCalls atomic.Int32
+			httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+				if req.URL.Hostname() == "mtls.auth.openai.com" {
+					exchangeCalls.Add(1)
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Header:     http.Header{"Content-Type": []string{"application/json"}},
+						Body:       io.NopCloser(strings.NewReader(`{"access_token":"x509-token","expires_in":3600}`)),
+					}, nil
+				}
+				apiCalls.Add(1)
+				return modelsListResponse(), nil
+			}}}
+			client := openai.NewClient(
+				option.WithBaseURL("https://trusted.example/v1"),
+				option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
+				option.WithHTTPClient(httpClient),
+				option.WithMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+					// Assign the raw map key to cover non-canonical header names
+					// that Header.Get does not find but net/http can transmit.
+					req.Header[headerName] = []string{"other-credential"}
+					return next(req)
+				}),
+			)
+
+			if _, err := client.Models.List(t.Context()); err == nil {
+				t.Fatal("Models.List() error = nil")
+			}
+			if got := exchangeCalls.Load(); got != 1 {
+				t.Fatalf("exchange calls = %d, want 1", got)
+			}
+			if got := apiCalls.Load(); got != 0 {
+				t.Fatalf("API calls = %d, want 0", got)
+			}
+		})
+	}
+}
+
+func TestDefaultHTTPTransportUsesRequestHostOverride(t *testing.T) {
+	hosts := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		hosts <- req.Host
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, server.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Host = "attacker.invalid"
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if got, want := <-hosts, "attacker.invalid"; got != want {
+		t.Fatalf("server-observed Host = %q, want %q", got, want)
+	}
+}
+
+func TestClientX509WorkloadIdentityPreservesEndpointAuthorizationProvenance(t *testing.T) {
+	newClient := func(middleware option.Middleware) (openai.Client, *atomic.Int32, *atomic.Int32, *string) {
+		var exchangeCalls atomic.Int32
+		var apiCalls atomic.Int32
+		var authorization string
+		httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+			if req.URL.Hostname() == "mtls.auth.openai.com" {
+				exchangeCalls.Add(1)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+					Body:       io.NopCloser(strings.NewReader(`{"access_token":"x509-token","expires_in":3600}`)),
+				}, nil
+			}
+			apiCalls.Add(1)
+			authorization = req.Header.Get("Authorization")
+			return modelsListResponse(), nil
+		}}}
+		opts := []option.RequestOption{
+			option.WithBaseURL("https://trusted.example/v1"),
+			option.WithAdminAPIKey("admin-secret"),
+			option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
+			option.WithHTTPClient(httpClient),
+		}
+		if middleware != nil {
+			opts = append(opts, option.WithMiddleware(middleware))
+		}
+		client := openai.NewClient(opts...)
+		return client, &exchangeCalls, &apiCalls, &authorization
+	}
+
+	t.Run("admin authorization", func(t *testing.T) {
+		client, exchangeCalls, apiCalls, authorization := newClient(nil)
+		err := client.Get(
+			t.Context(),
+			"organization/audit_logs",
+			nil,
+			nil,
+			requestconfig.WithAdminAPIKeyAuthSecurity(),
+		)
+		if err != nil {
+			t.Fatalf("Get() error = %v", err)
+		}
+		if got := exchangeCalls.Load(); got != 0 {
+			t.Fatalf("token exchange calls = %d, want 0", got)
+		}
+		if got := apiCalls.Load(); got != 1 {
+			t.Fatalf("API calls = %d, want 1", got)
+		}
+		if got, want := *authorization, "Bearer admin-secret"; got != want {
+			t.Fatalf("Authorization = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("admin mutation", func(t *testing.T) {
+		client, exchangeCalls, apiCalls, _ := newClient(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+			req.Header.Set("Authorization", "Basic customer-secret")
+			return next(req)
+		})
+		err := client.Get(
+			t.Context(),
+			"organization/audit_logs",
+			nil,
+			nil,
+			requestconfig.WithAdminAPIKeyAuthSecurity(),
+		)
+		if err == nil {
+			t.Fatal("Get() error = nil")
+		}
+		if got := exchangeCalls.Load(); got != 0 {
+			t.Fatalf("token exchange calls = %d, want 0", got)
+		}
+		if got := apiCalls.Load(); got != 0 {
+			t.Fatalf("API calls = %d, want 0", got)
+		}
+	})
+
+	t.Run("headerless mutation", func(t *testing.T) {
+		client, exchangeCalls, apiCalls, _ := newClient(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+			req.Header["authorization"] = []string{"Basic customer-secret"}
+			return next(req)
+		})
+		err := client.Get(
+			t.Context(),
+			"health",
+			nil,
+			nil,
+			requestconfig.WithSecurity(requestconfig.Security{}),
+		)
+		if err == nil {
+			t.Fatal("Get() error = nil")
+		}
+		if got := exchangeCalls.Load(); got != 0 {
+			t.Fatalf("token exchange calls = %d, want 0", got)
+		}
+		if got := apiCalls.Load(); got != 0 {
+			t.Fatalf("API calls = %d, want 0", got)
+		}
+	})
+
+	t.Run("headerless request", func(t *testing.T) {
+		client, exchangeCalls, apiCalls, authorization := newClient(nil)
+		err := client.Get(
+			t.Context(),
+			"health",
+			nil,
+			nil,
+			requestconfig.WithSecurity(requestconfig.Security{}),
+		)
+		if err != nil {
+			t.Fatalf("Get() error = %v", err)
+		}
+		if got := exchangeCalls.Load(); got != 0 {
+			t.Fatalf("token exchange calls = %d, want 0", got)
+		}
+		if got := apiCalls.Load(); got != 1 {
+			t.Fatalf("API calls = %d, want 1", got)
+		}
+		if *authorization != "" {
+			t.Fatalf("Authorization = %q, want empty", *authorization)
+		}
+	})
+}
+
+func TestClientRejectsAzureAuthenticationWithX509BeforeExchange(t *testing.T) {
+	credential := &countingAzureTokenCredential{}
+	testCases := []struct {
+		name string
+		auth option.RequestOption
+	}{
+		{name: "API key", auth: azure.WithAPIKey("azure-secret")},
+		{name: "token credential", auth: azure.WithTokenCredential(credential)},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var calls atomic.Int32
+			httpClient := &http.Client{Transport: &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+				calls.Add(1)
+				return nil, errors.New("HTTP request must not be attempted")
+			}}}
+			client := openai.NewClient(
+				azure.WithEndpoint("https://resource.openai.azure.com", "2024-10-21"),
+				testCase.auth,
+				option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
+				option.WithHTTPClient(httpClient),
+			)
+
+			if _, err := client.Models.List(t.Context()); err == nil {
+				t.Fatal("Models.List() error = nil")
+			}
+			if got := calls.Load(); got != 0 {
+				t.Fatalf("HTTP calls = %d, want 0", got)
+			}
+		})
+	}
+	if got := credential.calls.Load(); got != 0 {
+		t.Fatalf("Azure token credential calls = %d, want 0", got)
+	}
+}
+
+func TestClientX509RejectsLaterAPIKeyCredentialsBeforeExchange(t *testing.T) {
+	testCases := []struct {
+		name        string
+		opt         option.RequestOption
+		clientLevel bool
+	}{
+		{name: "API key", opt: option.WithAPIKey("other-api-key")},
+		{name: "method API key header", opt: option.WithHeader("api-key", "other-api-key")},
+		{name: "method X-API-Key header", opt: option.WithHeader("X-API-KEY", "other-api-key")},
+		{name: "method API key underscore alias", opt: option.WithHeader("API_KEY", "other-api-key")},
+		{name: "method X-API-Key underscore alias", opt: option.WithHeader("x_api_key", "other-api-key")},
+		{name: "method proxy authorization", opt: option.WithHeader("Proxy-Authorization", "Basic proxy-secret")},
+		{name: "method proxy authorization alias", opt: option.WithHeader("proxy_authorization", "Basic proxy-secret")},
+		{name: "method authorization override", opt: option.WithHeader("Authorization", "Basic customer-secret")},
+		{name: "client API key header", opt: option.WithHeader("API-KEY", "other-api-key"), clientLevel: true},
+		{name: "client X-API-Key header", opt: option.WithHeader("x-api-key", "other-api-key"), clientLevel: true},
+		{name: "client API key underscore alias", opt: option.WithHeader("api_key", "other-api-key"), clientLevel: true},
+		{name: "client X-API-Key hybrid alias", opt: option.WithHeader("X_API-Key", "other-api-key"), clientLevel: true},
+		{name: "client proxy authorization", opt: option.WithHeader("PROXY-AUTHORIZATION", "Basic proxy-secret"), clientLevel: true},
+		{name: "client proxy authorization alias", opt: option.WithHeader("Proxy_Authorization", "Basic proxy-secret"), clientLevel: true},
+		{name: "client authorization override", opt: option.WithHeader("authorization", "Basic customer-secret"), clientLevel: true},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var calls atomic.Int32
+			httpClient := &http.Client{Transport: &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+				calls.Add(1)
+				return nil, errors.New("HTTP request must not be attempted")
+			}}}
+			opts := []option.RequestOption{
+				option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
+				option.WithHTTPClient(httpClient),
+			}
+			if testCase.clientLevel {
+				opts = append(opts, testCase.opt)
+			}
+			client := openai.NewClient(opts...)
+
+			var requestOpts []option.RequestOption
+			if !testCase.clientLevel {
+				requestOpts = append(requestOpts, testCase.opt)
+			}
+			if _, err := client.Models.List(t.Context(), requestOpts...); err == nil {
+				t.Fatal("Models.List() error = nil")
+			}
+			if got := calls.Load(); got != 0 {
+				t.Fatalf("HTTP calls = %d, want 0", got)
+			}
+		})
+	}
+}

--- a/x509_auth_security_test.go
+++ b/x509_auth_security_test.go
@@ -663,6 +663,52 @@ func TestClientX509WorkloadIdentityHonorsMethodAdminCredentialPreference(t *test
 	}
 }
 
+func TestClientX509WorkloadIdentityHonorsExplicitAuthorizationDeletion(t *testing.T) {
+	var exchangeCalls atomic.Int32
+	var apiCalls atomic.Int32
+	var authorization string
+	httpClient := nativeX509HTTPClient(t, func(req *http.Request) (*http.Response, error) {
+		if req.URL.Hostname() == "mtls.auth.openai.com" {
+			exchangeCalls.Add(1)
+			return nil, errors.New("token exchange must not be attempted")
+		}
+		apiCalls.Add(1)
+		authorization = req.Header.Get("Authorization")
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+		}, nil
+	})
+	client := openai.NewClient(
+		option.WithBaseURL("https://trusted.example/v1"),
+		option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
+		option.WithHTTPClient(httpClient),
+	)
+
+	var result map[string]any
+	err := client.Execute(
+		t.Context(),
+		http.MethodGet,
+		"models",
+		nil,
+		&result,
+		option.WithHeaderDel("Authorization"),
+	)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := exchangeCalls.Load(); got != 0 {
+		t.Fatalf("token exchange calls = %d, want 0", got)
+	}
+	if got := apiCalls.Load(); got != 1 {
+		t.Fatalf("API calls = %d, want 1", got)
+	}
+	if authorization != "" {
+		t.Fatalf("Authorization = %q, want empty", authorization)
+	}
+}
+
 func TestClientRejectsAzureAuthenticationWithX509BeforeExchange(t *testing.T) {
 	credential := &countingAzureTokenCredential{}
 	testCases := []struct {

--- a/x509_auth_security_test.go
+++ b/x509_auth_security_test.go
@@ -106,6 +106,8 @@ func TestClientX509WorkloadIdentityRejectsProviderOwnedBaseURLBeforeExchange(t *
 		{name: "Bedrock China", baseURL: "https://bedrock-runtime.cn-north-1.amazonaws.com.cn/openai/v1"},
 		{name: "Bedrock EU sovereign", baseURL: "https://bedrock-runtime.eusc-de-east-1.amazonaws.eu/openai/v1"},
 		{name: "Bedrock mantle", baseURL: "https://bedrock-mantle.us-east-1.api.aws/openai/v1"},
+		{name: "Bedrock PrivateLink runtime", baseURL: "https://vpce-0123456789abcdef0.bedrock-runtime.us-east-1.vpce.amazonaws.com/openai/v1"},
+		{name: "Bedrock PrivateLink mantle", baseURL: "https://vpce-0123456789abcdef0.bedrock-mantle.us-east-1.vpce.amazonaws.com/openai/v1"},
 		{name: "environment provider URL", baseURL: "https://resource.openai.azure.com/openai/v1", fromEnv: true},
 	}
 
@@ -138,34 +140,75 @@ func TestClientX509WorkloadIdentityRejectsProviderOwnedBaseURLBeforeExchange(t *
 }
 
 func TestClientX509WorkloadIdentityAllowsProviderSuffixLookalikeGateway(t *testing.T) {
-	var exchangeCalls atomic.Int32
-	var apiCalls atomic.Int32
+	testCases := []struct {
+		name    string
+		baseURL string
+	}{
+		{name: "Azure suffix", baseURL: "https://resource.openai.azure.com.example/v1"},
+		{name: "Bedrock PrivateLink suffix", baseURL: "https://vpce-0123456789abcdef0.bedrock-runtime.us-east-1.vpce.amazonaws.com.example/v1"},
+		{name: "Bedrock PrivateLink service", baseURL: "https://vpce-0123456789abcdef0.bedrock-runtime-gateway.us-east-1.vpce.amazonaws.com/v1"},
+		{name: "Bedrock PrivateLink endpoint ID", baseURL: "https://gateway.bedrock-runtime.us-east-1.vpce.amazonaws.com/v1"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var exchangeCalls atomic.Int32
+			var apiCalls atomic.Int32
+			httpClient := nativeX509HTTPClient(t, func(req *http.Request) (*http.Response, error) {
+				if req.URL.Hostname() == "mtls.auth.openai.com" {
+					exchangeCalls.Add(1)
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Header:     http.Header{"Content-Type": []string{"application/json"}},
+						Body:       io.NopCloser(strings.NewReader(`{"access_token":"x509-token","expires_in":3600}`)),
+					}, nil
+				}
+				apiCalls.Add(1)
+				return modelsListResponse(), nil
+			})
+			client := openai.NewClient(
+				option.WithBaseURL(testCase.baseURL),
+				option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
+				option.WithHTTPClient(httpClient),
+			)
+
+			if _, err := client.Models.List(t.Context()); err != nil {
+				t.Fatalf("Models.List() error = %v", err)
+			}
+			if got, want := exchangeCalls.Load(), int32(1); got != want {
+				t.Fatalf("exchange calls = %d, want %d", got, want)
+			}
+			if got, want := apiCalls.Load(), int32(1); got != want {
+				t.Fatalf("API calls = %d, want %d", got, want)
+			}
+		})
+	}
+}
+
+func TestClientX509WorkloadIdentityRejectsBedrockPrivateLinkBeforeExchange(t *testing.T) {
+	var calls atomic.Int32
 	httpClient := nativeX509HTTPClient(t, func(req *http.Request) (*http.Response, error) {
+		calls.Add(1)
 		if req.URL.Hostname() == "mtls.auth.openai.com" {
-			exchangeCalls.Add(1)
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Header:     http.Header{"Content-Type": []string{"application/json"}},
 				Body:       io.NopCloser(strings.NewReader(`{"access_token":"x509-token","expires_in":3600}`)),
 			}, nil
 		}
-		apiCalls.Add(1)
 		return modelsListResponse(), nil
 	})
 	client := openai.NewClient(
-		option.WithBaseURL("https://resource.openai.azure.com.example/v1"),
+		option.WithBaseURL("https://vpce-0123456789abcdef0.bedrock-runtime.us-east-1.vpce.amazonaws.com/openai/v1"),
 		option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
 		option.WithHTTPClient(httpClient),
 	)
 
-	if _, err := client.Models.List(t.Context()); err != nil {
-		t.Fatalf("Models.List() error = %v", err)
+	if _, err := client.Models.List(t.Context()); err == nil || !strings.Contains(err.Error(), "provider-owned") {
+		t.Errorf("Models.List() error = %v, want provider-owned URL rejection", err)
 	}
-	if got, want := exchangeCalls.Load(), int32(1); got != want {
-		t.Fatalf("exchange calls = %d, want %d", got, want)
-	}
-	if got, want := apiCalls.Load(), int32(1); got != want {
-		t.Fatalf("API calls = %d, want %d", got, want)
+	if got := calls.Load(); got != 0 {
+		t.Fatalf("HTTP calls = %d, want 0", got)
 	}
 }
 

--- a/x509_auth_security_test.go
+++ b/x509_auth_security_test.go
@@ -103,6 +103,16 @@ func TestClientX509WorkloadIdentityRejectsProviderOwnedBaseURLBeforeExchange(t *
 		{name: "Azure Foundry", baseURL: "https://resource.services.ai.azure.com/openai/v1"},
 		{name: "Azure API Management", baseURL: "https://resource.azure-api.net/openai/v1"},
 		{name: "Bedrock runtime", baseURL: "https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1"},
+		{name: "Bedrock control plane", baseURL: "https://bedrock.us-east-1.amazonaws.com/openai/v1"},
+		{name: "Bedrock control plane FIPS", baseURL: "https://bedrock-fips.us-east-1.amazonaws.com/openai/v1"},
+		{name: "Bedrock agent", baseURL: "https://bedrock-agent.us-east-1.amazonaws.com/openai/v1"},
+		{name: "Bedrock agent FIPS", baseURL: "https://bedrock-agent-fips.us-east-1.amazonaws.com/openai/v1"},
+		{name: "Bedrock agent runtime", baseURL: "https://bedrock-agent-runtime.us-east-1.amazonaws.com/openai/v1"},
+		{name: "Bedrock agent runtime FIPS", baseURL: "https://bedrock-agent-runtime-fips.us-east-1.amazonaws.com/openai/v1"},
+		{name: "Bedrock data automation", baseURL: "https://bedrock-data-automation.us-east-1.amazonaws.com/openai/v1"},
+		{name: "Bedrock data automation runtime FIPS", baseURL: "https://bedrock-data-automation-runtime-fips.us-east-1.api.aws/openai/v1"},
+		{name: "Bedrock AgentCore control", baseURL: "https://bedrock-agentcore-control.us-east-1.amazonaws.com/openai/v1"},
+		{name: "Bedrock AgentCore gateway", baseURL: "https://gateway-id.gateway.bedrock-agentcore.us-east-1.amazonaws.com/openai/v1"},
 		{name: "Bedrock China", baseURL: "https://bedrock-runtime.cn-north-1.amazonaws.com.cn/openai/v1"},
 		{name: "Bedrock EU sovereign", baseURL: "https://bedrock-runtime.eusc-de-east-1.amazonaws.eu/openai/v1"},
 		{name: "Bedrock mantle", baseURL: "https://bedrock-mantle.us-east-1.api.aws/openai/v1"},
@@ -605,6 +615,52 @@ func TestClientX509WorkloadIdentityPreservesEndpointAuthorizationProvenance(t *t
 			t.Fatalf("Authorization = %q, want empty", *authorization)
 		}
 	})
+}
+
+func TestClientX509WorkloadIdentityHonorsMethodAdminCredentialPreference(t *testing.T) {
+	var exchangeCalls atomic.Int32
+	var apiCalls atomic.Int32
+	var authorization string
+	httpClient := nativeX509HTTPClient(t, func(req *http.Request) (*http.Response, error) {
+		if req.URL.Hostname() == "mtls.auth.openai.com" {
+			exchangeCalls.Add(1)
+			return nil, errors.New("token exchange must not be attempted")
+		}
+		apiCalls.Add(1)
+		authorization = req.Header.Get("Authorization")
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+		}, nil
+	})
+	client := openai.NewClient(
+		option.WithBaseURL("https://trusted.example/v1"),
+		option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
+		option.WithHTTPClient(httpClient),
+	)
+
+	var result map[string]any
+	err := client.Execute(
+		t.Context(),
+		http.MethodGet,
+		"organization/audit_logs",
+		nil,
+		&result,
+		option.WithAdminAPIKey("method-admin-secret"),
+	)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := exchangeCalls.Load(); got != 0 {
+		t.Fatalf("token exchange calls = %d, want 0", got)
+	}
+	if got := apiCalls.Load(); got != 1 {
+		t.Fatalf("API calls = %d, want 1", got)
+	}
+	if got, want := authorization, "Bearer method-admin-secret"; got != want {
+		t.Fatalf("Authorization = %q, want %q", got, want)
+	}
 }
 
 func TestClientRejectsAzureAuthenticationWithX509BeforeExchange(t *testing.T) {

--- a/x509_auth_test.go
+++ b/x509_auth_test.go
@@ -614,6 +614,60 @@ func TestClientX509WorkloadIdentity401ReappliesBodyMiddleware(t *testing.T) {
 	}
 }
 
+func TestClientX509WorkloadIdentity401ReplaysFromPreMiddlewareState(t *testing.T) {
+	var exchangeCalls int
+	var middlewareCalls int
+	var queryValueCounts []int
+	var signatureCounts []int
+	httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+		if req.URL.Host == "mtls.auth.openai.com" {
+			exchangeCalls++
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body: io.NopCloser(strings.NewReader(fmt.Sprintf(
+					`{"access_token":"token-%d","expires_in":3600}`,
+					exchangeCalls,
+				))),
+			}, nil
+		}
+		queryValueCounts = append(queryValueCounts, len(req.URL.Query()["signed"]))
+		signatureCounts = append(signatureCounts, len(req.Header.Values("X-Test-Signature")))
+		if len(queryValueCounts) == 1 {
+			return &http.Response{StatusCode: http.StatusUnauthorized, Header: make(http.Header), Body: http.NoBody}, nil
+		}
+		return modelsListResponse(), nil
+	}}}
+	client := openai.NewClient(
+		option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
+		option.WithHTTPClient(httpClient),
+		option.WithMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+			middlewareCalls++
+			query := req.URL.Query()
+			query.Add("signed", "true")
+			req.URL.RawQuery = query.Encode()
+			req.Header.Add("X-Test-Signature", "signature")
+			return next(req)
+		}),
+	)
+
+	if _, err := client.Models.List(t.Context()); err != nil {
+		t.Fatalf("Models.List() error = %v", err)
+	}
+	if got, want := middlewareCalls, 2; got != want {
+		t.Errorf("middleware calls = %d, want %d", got, want)
+	}
+	if got, want := exchangeCalls, 2; got != want {
+		t.Errorf("token exchange calls = %d, want %d", got, want)
+	}
+	if got, want := fmt.Sprint(queryValueCounts), "[1 1]"; got != want {
+		t.Errorf("query value counts = %s, want %s", got, want)
+	}
+	if got, want := fmt.Sprint(signatureCounts), "[1 1]"; got != want {
+		t.Errorf("signature counts = %s, want %s", got, want)
+	}
+}
+
 func TestClientX509WorkloadIdentity401DoesNotReplayStreamingBody(t *testing.T) {
 	var exchangeCalls int
 	var apiCalls int

--- a/x509_auth_test.go
+++ b/x509_auth_test.go
@@ -28,17 +28,6 @@ func (d nonComparableHTTPDoer) Do(req *http.Request) (*http.Response, error) {
 	return d.do(req)
 }
 
-// dynamicallyNonComparableHTTPDoer has a comparable Go type, but values are
-// not comparable when state contains a slice, map, or function.
-type dynamicallyNonComparableHTTPDoer struct {
-	state any
-	doer  auth.HTTPDoer
-}
-
-func (d dynamicallyNonComparableHTTPDoer) Do(req *http.Request) (*http.Response, error) {
-	return d.doer.Do(req)
-}
-
 func clientX509WorkloadIdentity() auth.X509WorkloadIdentity {
 	return auth.X509WorkloadIdentity{
 		IdentityProviderID: "idp-test",

--- a/x509_auth_test.go
+++ b/x509_auth_test.go
@@ -1,6 +1,8 @@
 package openai_test
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -519,6 +521,96 @@ func TestClientX509WorkloadIdentity401ReplaysReplayableBodyOnce(t *testing.T) {
 	}
 	if got, want := strings.Join(apiAuth, ","), "Bearer token-1,Bearer token-2"; got != want {
 		t.Errorf("API Authorization sequence = %q, want %q", got, want)
+	}
+}
+
+func TestClientX509WorkloadIdentity401ReappliesBodyMiddleware(t *testing.T) {
+	var exchangeCalls int
+	var middlewareCalls int
+	var apiBodies []string
+	httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+		if req.URL.Host == "mtls.auth.openai.com" {
+			exchangeCalls++
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body: io.NopCloser(strings.NewReader(fmt.Sprintf(
+					`{"access_token":"token-%d","expires_in":3600}`,
+					exchangeCalls,
+				))),
+			}, nil
+		}
+		if got, want := req.Header.Get("Content-Encoding"), "gzip"; got != want {
+			return nil, fmt.Errorf("Content-Encoding = %q, want %q", got, want)
+		}
+		reader, err := gzip.NewReader(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		body, err := io.ReadAll(reader)
+		if closeErr := reader.Close(); err == nil {
+			err = closeErr
+		}
+		if err != nil {
+			return nil, err
+		}
+		apiBodies = append(apiBodies, string(body))
+		if len(apiBodies) == 1 {
+			return &http.Response{StatusCode: http.StatusUnauthorized, Header: make(http.Header), Body: http.NoBody}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+		}, nil
+	}}}
+	client := openai.NewClient(
+		option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
+		option.WithBaseURL("https://api.example/v1"),
+		option.WithHTTPClient(httpClient),
+		option.WithMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+			middlewareCalls++
+			body, err := io.ReadAll(req.Body)
+			_ = req.Body.Close()
+			if err != nil {
+				return nil, err
+			}
+			var compressed bytes.Buffer
+			writer := gzip.NewWriter(&compressed)
+			if _, err := writer.Write(body); err != nil {
+				return nil, err
+			}
+			if err := writer.Close(); err != nil {
+				return nil, err
+			}
+			req.Body = io.NopCloser(bytes.NewReader(compressed.Bytes()))
+			req.ContentLength = int64(compressed.Len())
+			req.Header.Set("Content-Encoding", "gzip")
+			return next(req)
+		}),
+	)
+
+	const requestBody = `{"hello":"world"}`
+	var result map[string]any
+	err := client.Execute(
+		t.Context(),
+		http.MethodPost,
+		"/custom",
+		nil,
+		&result,
+		option.WithRequestBody("application/json", []byte(requestBody)),
+	)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got, want := middlewareCalls, 2; got != want {
+		t.Errorf("middleware calls = %d, want %d", got, want)
+	}
+	if got, want := exchangeCalls, 2; got != want {
+		t.Errorf("token exchange calls = %d, want %d", got, want)
+	}
+	if got, want := strings.Join(apiBodies, ","), requestBody+","+requestBody; got != want {
+		t.Errorf("API bodies = %q, want %q", got, want)
 	}
 }
 

--- a/x509_auth_test.go
+++ b/x509_auth_test.go
@@ -2,6 +2,7 @@ package openai_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -211,6 +212,7 @@ func TestClientRejectsMultipleWorkloadIdentityCredentialSources(t *testing.T) {
 
 func TestClientX509WorkloadIdentityRefusesAPIRedirects(t *testing.T) {
 	var redirectedRequests atomic.Int32
+	var apiRequests atomic.Int32
 	redirectTarget := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
 		redirectedRequests.Add(1)
 	}))
@@ -226,6 +228,7 @@ func TestClientX509WorkloadIdentityRefusesAPIRedirects(t *testing.T) {
 				}, nil
 			}
 			if req.URL.Host == "api.example" {
+				apiRequests.Add(1)
 				return &http.Response{
 					StatusCode: http.StatusFound,
 					Header:     http.Header{"Location": []string{redirectTarget.URL}},
@@ -241,11 +244,109 @@ func TestClientX509WorkloadIdentityRefusesAPIRedirects(t *testing.T) {
 		option.WithBaseURL("https://api.example/v1"),
 		option.WithHTTPClient(httpClient),
 	)
-	if _, err := client.Models.List(t.Context()); err == nil {
-		t.Fatal("Models.List() error = nil")
+	if err := client.Execute(t.Context(), http.MethodDelete, "/custom", nil, nil); err == nil {
+		t.Fatal("Execute() error = nil")
 	}
 	if got := redirectedRequests.Load(); got != 0 {
 		t.Errorf("redirect target requests = %d, want 0", got)
+	}
+	if got := apiRequests.Load(); got != 1 {
+		t.Errorf("API requests = %d, want 1", got)
+	}
+}
+
+func TestClientX509WorkloadIdentityScopesTokenCacheToHTTPDoer(t *testing.T) {
+	exchangeCalls := map[string]int{}
+	apiAuth := map[string][]string{}
+	newHTTPClient := func(name string) *http.Client {
+		return &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+			if req.URL.Host == "mtls.auth.openai.com" {
+				exchangeCalls[name]++
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+					Body:       io.NopCloser(strings.NewReader(fmt.Sprintf(`{"access_token":"token-%s","expires_in":3600}`, name))),
+				}, nil
+			}
+			apiAuth[name] = append(apiAuth[name], req.Header.Get("Authorization"))
+			return modelsListResponse(), nil
+		}}}
+	}
+
+	httpClientA := newHTTPClient("a")
+	httpClientB := newHTTPClient("b")
+	client := openai.NewClient(
+		option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
+		option.WithHTTPClient(httpClientA),
+	)
+
+	if _, err := client.Models.List(t.Context()); err != nil {
+		t.Fatalf("first Models.List() error = %v", err)
+	}
+	if _, err := client.Models.List(t.Context(), option.WithHTTPClient(httpClientB)); err != nil {
+		t.Fatalf("overridden Models.List() error = %v", err)
+	}
+	if _, err := client.Models.List(t.Context()); err != nil {
+		t.Fatalf("second Models.List() error = %v", err)
+	}
+
+	if got, want := exchangeCalls["a"], 1; got != want {
+		t.Errorf("transport A exchange calls = %d, want %d", got, want)
+	}
+	if got, want := exchangeCalls["b"], 1; got != want {
+		t.Errorf("transport B exchange calls = %d, want %d", got, want)
+	}
+	if got, want := strings.Join(apiAuth["a"], ","), "Bearer token-a,Bearer token-a"; got != want {
+		t.Errorf("transport A Authorization = %q, want %q", got, want)
+	}
+	if got, want := strings.Join(apiAuth["b"], ","), "Bearer token-b"; got != want {
+		t.Errorf("transport B Authorization = %q, want %q", got, want)
+	}
+}
+
+func TestClientX509WorkloadIdentityExchangeFailureDoesNotEnterAPIRetryLoop(t *testing.T) {
+	testCases := []struct {
+		name      string
+		status    int
+		wantCalls int
+	}{
+		{name: "OAuth failure", status: http.StatusForbidden, wantCalls: 1},
+		{name: "exhausted transient failure", status: http.StatusServiceUnavailable, wantCalls: 3},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			exchangeCalls := 0
+			httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+				if req.URL.Host != "mtls.auth.openai.com" {
+					t.Fatalf("unexpected API request %s", req.URL)
+				}
+				exchangeCalls++
+				return &http.Response{
+					StatusCode: testCase.status,
+					Header:     http.Header{"Retry-After": []string{"0"}},
+					Body:       io.NopCloser(strings.NewReader(`{"error":"exchange_failed"}`)),
+				}, nil
+			}}}
+			client := openai.NewClient(
+				option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
+				option.WithHTTPClient(httpClient),
+			)
+
+			_, err := client.Models.List(t.Context())
+			if err == nil {
+				t.Fatal("Models.List() error = nil")
+			}
+			if testCase.status == http.StatusForbidden {
+				var oauthErr *auth.OAuthError
+				if !errors.As(err, &oauthErr) {
+					t.Fatalf("Models.List() error = %v, want *auth.OAuthError", err)
+				}
+			}
+			if exchangeCalls != testCase.wantCalls {
+				t.Errorf("token exchange calls = %d, want %d", exchangeCalls, testCase.wantCalls)
+			}
+		})
 	}
 }
 

--- a/x509_auth_test.go
+++ b/x509_auth_test.go
@@ -1,0 +1,353 @@
+package openai_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/auth"
+	"github.com/openai/openai-go/v3/option"
+)
+
+func clientX509WorkloadIdentity() auth.X509WorkloadIdentity {
+	return auth.X509WorkloadIdentity{
+		IdentityProviderID: "idp-test",
+		ServiceAccountID:   "svc-test",
+	}
+}
+
+func modelsListResponse() *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"object":"list","data":[]}`)),
+	}
+}
+
+func TestClientX509WorkloadIdentityDefaultsMTLSAndReusesHTTPClient(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "api-key-must-not-be-used")
+	var mu sync.Mutex
+	requests := make([]*http.Request, 0, 2)
+	httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+		mu.Lock()
+		requests = append(requests, req.Clone(req.Context()))
+		mu.Unlock()
+		if req.URL.Host == "mtls.auth.openai.com" {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"access_token":"x509-token","expires_in":3600}`)),
+			}, nil
+		}
+		return modelsListResponse(), nil
+	}}}
+
+	client := openai.NewClient(
+		option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
+		option.WithHTTPClient(httpClient),
+	)
+	mu.Lock()
+	requestCount := len(requests)
+	mu.Unlock()
+	if requestCount != 0 {
+		t.Fatalf("NewClient() made %d HTTP requests, want 0", requestCount)
+	}
+
+	if _, err := client.Models.List(t.Context()); err != nil {
+		t.Fatalf("Models.List() error = %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if got, want := len(requests), 2; got != want {
+		t.Fatalf("HTTP requests = %d, want %d", got, want)
+	}
+	if got, want := requests[0].URL.String(), "https://mtls.auth.openai.com/oauth/token"; got != want {
+		t.Errorf("exchange URL = %q, want %q", got, want)
+	}
+	if got, want := requests[1].URL.String(), "https://mtls.api.openai.com/v1/models"; got != want {
+		t.Errorf("API URL = %q, want %q", got, want)
+	}
+	if got, want := requests[1].Header.Get("Authorization"), "Bearer x509-token"; got != want {
+		t.Errorf("API Authorization = %q, want %q", got, want)
+	}
+	if strings.Contains(requests[1].Header.Get("Authorization"), "api-key-must-not-be-used") {
+		t.Error("API Authorization contains ambient API key")
+	}
+}
+
+func TestX509ChangesDoNotAffectAPIKeyClient(t *testing.T) {
+	var requests []*http.Request
+	httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+		requests = append(requests, req.Clone(req.Context()))
+		return modelsListResponse(), nil
+	}}}
+	client := openai.NewClient(
+		option.WithAPIKey("api-key-token"),
+		option.WithHTTPClient(httpClient),
+	)
+	if _, err := client.Models.List(t.Context()); err != nil {
+		t.Fatalf("Models.List() error = %v", err)
+	}
+	if got, want := len(requests), 1; got != want {
+		t.Fatalf("HTTP requests = %d, want %d", got, want)
+	}
+	if got, want := requests[0].URL.String(), "https://api.openai.com/v1/models"; got != want {
+		t.Errorf("request URL = %q, want %q", got, want)
+	}
+	if got, want := requests[0].Header.Get("Authorization"), "Bearer api-key-token"; got != want {
+		t.Errorf("Authorization = %q, want %q", got, want)
+	}
+}
+
+func TestClientX509WorkloadIdentityBaseURLPrecedence(t *testing.T) {
+	testCases := []struct {
+		name    string
+		opts    func(*http.Client) []option.RequestOption
+		wantURL string
+	}{
+		{
+			name: "explicit before x509",
+			opts: func(httpClient *http.Client) []option.RequestOption {
+				return []option.RequestOption{
+					option.WithBaseURL("https://explicit.example/v1"),
+					option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
+					option.WithHTTPClient(httpClient),
+				}
+			},
+			wantURL: "https://explicit.example/v1/models",
+		},
+		{
+			name: "explicit after x509",
+			opts: func(httpClient *http.Client) []option.RequestOption {
+				return []option.RequestOption{
+					option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
+					option.WithBaseURL("https://explicit.example/v1"),
+					option.WithHTTPClient(httpClient),
+				}
+			},
+			wantURL: "https://explicit.example/v1/models",
+		},
+		{
+			name: "production default after x509",
+			opts: func(httpClient *http.Client) []option.RequestOption {
+				return []option.RequestOption{
+					option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
+					option.WithEnvironmentProduction(),
+					option.WithHTTPClient(httpClient),
+				}
+			},
+			wantURL: "https://mtls.api.openai.com/v1/models",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var apiURL string
+			httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+				if req.URL.Host == "mtls.auth.openai.com" {
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Header:     http.Header{"Content-Type": []string{"application/json"}},
+						Body:       io.NopCloser(strings.NewReader(`{"access_token":"x509-token","expires_in":3600}`)),
+					}, nil
+				}
+				apiURL = req.URL.String()
+				return modelsListResponse(), nil
+			}}}
+			client := openai.NewClient(testCase.opts(httpClient)...)
+			if _, err := client.Models.List(t.Context()); err != nil {
+				t.Fatalf("Models.List() error = %v", err)
+			}
+			if apiURL != testCase.wantURL {
+				t.Errorf("API URL = %q, want %q", apiURL, testCase.wantURL)
+			}
+		})
+	}
+}
+
+func TestClientX509WorkloadIdentityEnvironmentBaseURLWins(t *testing.T) {
+	t.Setenv("OPENAI_BASE_URL", "https://environment.example/v1")
+	var apiURL string
+	httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+		if req.URL.Host == "mtls.auth.openai.com" {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"access_token":"x509-token","expires_in":3600}`)),
+			}, nil
+		}
+		apiURL = req.URL.String()
+		return modelsListResponse(), nil
+	}}}
+	client := openai.NewClient(
+		option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
+		option.WithHTTPClient(httpClient),
+	)
+	if _, err := client.Models.List(t.Context()); err != nil {
+		t.Fatalf("Models.List() error = %v", err)
+	}
+	if got, want := apiURL, "https://environment.example/v1/models"; got != want {
+		t.Errorf("API URL = %q, want %q", got, want)
+	}
+}
+
+func TestClientRejectsMultipleWorkloadIdentityCredentialSources(t *testing.T) {
+	provider := &mockSubjectTokenProvider{token: "subject-token", tokenType: auth.SubjectTokenTypeJWT}
+	client := openai.NewClient(
+		option.WithWorkloadIdentity(testWorkloadIdentity(provider)),
+		option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
+	)
+	if _, err := client.Models.List(t.Context()); err == nil {
+		t.Fatal("Models.List() error = nil")
+	}
+}
+
+func TestClientX509WorkloadIdentityRefusesAPIRedirects(t *testing.T) {
+	var redirectedRequests atomic.Int32
+	redirectTarget := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		redirectedRequests.Add(1)
+	}))
+	t.Cleanup(redirectTarget.Close)
+
+	httpClient := &http.Client{
+		Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+			if req.URL.Host == "mtls.auth.openai.com" {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+					Body:       io.NopCloser(strings.NewReader(`{"access_token":"x509-token","expires_in":3600}`)),
+				}, nil
+			}
+			if req.URL.Host == "api.example" {
+				return &http.Response{
+					StatusCode: http.StatusFound,
+					Header:     http.Header{"Location": []string{redirectTarget.URL}},
+					Body:       io.NopCloser(strings.NewReader("redirect")),
+				}, nil
+			}
+			return http.DefaultTransport.RoundTrip(req)
+		}},
+		CheckRedirect: func(*http.Request, []*http.Request) error { return nil },
+	}
+	client := openai.NewClient(
+		option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
+		option.WithBaseURL("https://api.example/v1"),
+		option.WithHTTPClient(httpClient),
+	)
+	if _, err := client.Models.List(t.Context()); err == nil {
+		t.Fatal("Models.List() error = nil")
+	}
+	if got := redirectedRequests.Load(); got != 0 {
+		t.Errorf("redirect target requests = %d, want 0", got)
+	}
+}
+
+func TestClientX509WorkloadIdentity401ReplaysReplayableBodyOnce(t *testing.T) {
+	var exchangeCalls int
+	var apiBodies []string
+	var apiAuth []string
+	httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+		if req.URL.Host == "mtls.auth.openai.com" {
+			exchangeCalls++
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body: io.NopCloser(strings.NewReader(fmt.Sprintf(
+					`{"access_token":"token-%d","expires_in":3600}`,
+					exchangeCalls,
+				))),
+			}, nil
+		}
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		apiBodies = append(apiBodies, string(body))
+		apiAuth = append(apiAuth, req.Header.Get("Authorization"))
+		if len(apiBodies) == 1 {
+			return &http.Response{StatusCode: http.StatusUnauthorized, Header: make(http.Header), Body: http.NoBody}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+		}, nil
+	}}}
+	client := openai.NewClient(
+		option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
+		option.WithBaseURL("https://api.example/v1"),
+		option.WithHTTPClient(httpClient),
+	)
+
+	var result map[string]any
+	err := client.Execute(
+		t.Context(),
+		http.MethodPost,
+		"/custom",
+		nil,
+		&result,
+		option.WithRequestBody("application/json", []byte(`{"hello":"world"}`)),
+	)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got, want := exchangeCalls, 2; got != want {
+		t.Errorf("token exchange calls = %d, want %d", got, want)
+	}
+	if got, want := len(apiBodies), 2; got != want {
+		t.Fatalf("API calls = %d, want %d", got, want)
+	}
+	if apiBodies[0] != apiBodies[1] {
+		t.Errorf("replayed body = %q, want %q", apiBodies[1], apiBodies[0])
+	}
+	if got, want := strings.Join(apiAuth, ","), "Bearer token-1,Bearer token-2"; got != want {
+		t.Errorf("API Authorization sequence = %q, want %q", got, want)
+	}
+}
+
+func TestClientX509WorkloadIdentity401DoesNotReplayStreamingBody(t *testing.T) {
+	var exchangeCalls int
+	var apiCalls int
+	httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+		if req.URL.Host == "mtls.auth.openai.com" {
+			exchangeCalls++
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"access_token":"token-1","expires_in":3600}`)),
+			}, nil
+		}
+		apiCalls++
+		return &http.Response{StatusCode: http.StatusUnauthorized, Header: make(http.Header), Body: http.NoBody}, nil
+	}}}
+	client := openai.NewClient(
+		option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
+		option.WithBaseURL("https://api.example/v1"),
+		option.WithHTTPClient(httpClient),
+	)
+
+	err := client.Execute(
+		context.Background(),
+		http.MethodPost,
+		"/custom",
+		nil,
+		nil,
+		option.WithRequestBody("application/json", strings.NewReader(`{"hello":"world"}`)),
+	)
+	if err == nil {
+		t.Fatal("Execute() error = nil")
+	}
+	if got, want := exchangeCalls, 1; got != want {
+		t.Errorf("token exchange calls = %d, want %d", got, want)
+	}
+	if got, want := apiCalls, 1; got != want {
+		t.Errorf("API calls = %d, want %d", got, want)
+	}
+}

--- a/x509_auth_test.go
+++ b/x509_auth_test.go
@@ -2,6 +2,7 @@ package openai_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -16,6 +17,14 @@ import (
 	"github.com/openai/openai-go/v3/auth"
 	"github.com/openai/openai-go/v3/option"
 )
+
+type nonComparableHTTPDoer struct {
+	do func(*http.Request) (*http.Response, error)
+}
+
+func (d nonComparableHTTPDoer) Do(req *http.Request) (*http.Response, error) {
+	return d.do(req)
+}
 
 func clientX509WorkloadIdentity() auth.X509WorkloadIdentity {
 	return auth.X509WorkloadIdentity{
@@ -301,6 +310,106 @@ func TestClientX509WorkloadIdentityScopesTokenCacheToHTTPDoer(t *testing.T) {
 	}
 	if got, want := strings.Join(apiAuth["b"], ","), "Bearer token-b"; got != want {
 		t.Errorf("transport B Authorization = %q, want %q", got, want)
+	}
+}
+
+func TestClientX509WorkloadIdentityCachesNonComparableHTTPDoer(t *testing.T) {
+	var exchangeCalls atomic.Int32
+	var apiCalls atomic.Int32
+	httpDoer := nonComparableHTTPDoer{do: func(req *http.Request) (*http.Response, error) {
+		if req.URL.Host == "mtls.auth.openai.com" {
+			exchangeCalls.Add(1)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"access_token":"x509-token","expires_in":3600}`)),
+			}, nil
+		}
+		apiCalls.Add(1)
+		return modelsListResponse(), nil
+	}}
+	const requestCount = 16
+	var ready sync.WaitGroup
+	ready.Add(requestCount)
+	releaseRequests := make(chan struct{})
+	client := openai.NewClient(
+		option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
+		option.WithHTTPClient(httpDoer),
+		option.WithMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+			ready.Done()
+			<-releaseRequests
+			return next(req)
+		}),
+	)
+
+	errs := make(chan error, requestCount)
+	var requests sync.WaitGroup
+	requests.Add(requestCount)
+	for range requestCount {
+		go func() {
+			defer requests.Done()
+			_, err := client.Models.List(t.Context())
+			errs <- err
+		}()
+	}
+	ready.Wait()
+	close(releaseRequests)
+	requests.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("Models.List() error = %v", err)
+		}
+	}
+	if got, want := exchangeCalls.Load(), int32(1); got != want {
+		t.Errorf("token exchange calls = %d, want %d", got, want)
+	}
+	if got, want := apiCalls.Load(), int32(requestCount); got != want {
+		t.Errorf("API calls = %d, want %d", got, want)
+	}
+}
+
+func TestClientX509WorkloadIdentityLaterOptionReplacesCredential(t *testing.T) {
+	var exchangedServiceAccounts []string
+	var apiAuthorization string
+	httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+		if req.URL.Host == "mtls.auth.openai.com" {
+			var body struct {
+				ServiceAccountID string `json:"service_account_id"`
+			}
+			if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+				return nil, err
+			}
+			exchangedServiceAccounts = append(exchangedServiceAccounts, body.ServiceAccountID)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body: io.NopCloser(strings.NewReader(fmt.Sprintf(
+					`{"access_token":"token-%s","expires_in":3600}`,
+					body.ServiceAccountID,
+				))),
+			}, nil
+		}
+		apiAuthorization = req.Header.Get("Authorization")
+		return modelsListResponse(), nil
+	}}}
+	first := clientX509WorkloadIdentity()
+	first.ServiceAccountID = "svc-first"
+	second := clientX509WorkloadIdentity()
+	second.ServiceAccountID = "svc-second"
+	client := openai.NewClient(
+		option.WithX509WorkloadIdentity(first),
+		option.WithHTTPClient(httpClient),
+	)
+
+	if _, err := client.Models.List(t.Context(), option.WithX509WorkloadIdentity(second)); err != nil {
+		t.Fatalf("Models.List() error = %v", err)
+	}
+	if got, want := strings.Join(exchangedServiceAccounts, ","), "svc-second"; got != want {
+		t.Errorf("exchanged service accounts = %q, want %q", got, want)
+	}
+	if got, want := apiAuthorization, "Bearer token-svc-second"; got != want {
+		t.Errorf("API Authorization = %q, want %q", got, want)
 	}
 }
 

--- a/x509_auth_test.go
+++ b/x509_auth_test.go
@@ -28,6 +28,17 @@ func (d nonComparableHTTPDoer) Do(req *http.Request) (*http.Response, error) {
 	return d.do(req)
 }
 
+// dynamicallyNonComparableHTTPDoer has a comparable Go type, but values are
+// not comparable when state contains a slice, map, or function.
+type dynamicallyNonComparableHTTPDoer struct {
+	state any
+	doer  auth.HTTPDoer
+}
+
+func (d dynamicallyNonComparableHTTPDoer) Do(req *http.Request) (*http.Response, error) {
+	return d.doer.Do(req)
+}
+
 func clientX509WorkloadIdentity() auth.X509WorkloadIdentity {
 	return auth.X509WorkloadIdentity{
 		IdentityProviderID: "idp-test",
@@ -368,6 +379,37 @@ func TestClientX509WorkloadIdentityCachesNonComparableHTTPDoer(t *testing.T) {
 	}
 	if got, want := apiCalls.Load(), int32(requestCount); got != want {
 		t.Errorf("API calls = %d, want %d", got, want)
+	}
+}
+
+func TestClientX509WorkloadIdentityCachesDynamicallyNonComparableHTTPDoer(t *testing.T) {
+	var exchangeCalls atomic.Int32
+	httpDoer := dynamicallyNonComparableHTTPDoer{
+		state: []string{"not-comparable"},
+		doer: nonComparableHTTPDoer{do: func(req *http.Request) (*http.Response, error) {
+			if req.URL.Host == "mtls.auth.openai.com" {
+				exchangeCalls.Add(1)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+					Body:       io.NopCloser(strings.NewReader(`{"access_token":"x509-token","expires_in":3600}`)),
+				}, nil
+			}
+			return modelsListResponse(), nil
+		}},
+	}
+	client := openai.NewClient(
+		option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
+		option.WithHTTPClient(httpDoer),
+	)
+
+	for range 2 {
+		if _, err := client.Models.List(t.Context()); err != nil {
+			t.Fatalf("Models.List() error = %v", err)
+		}
+	}
+	if got, want := exchangeCalls.Load(), int32(1); got != want {
+		t.Errorf("token exchange calls = %d, want %d", got, want)
 	}
 }
 

--- a/x509_auth_test.go
+++ b/x509_auth_test.go
@@ -371,6 +371,38 @@ func TestClientX509WorkloadIdentityCachesNonComparableHTTPDoer(t *testing.T) {
 	}
 }
 
+func TestClientX509WorkloadIdentityCachesComparableHTTPDoerAcrossOptions(t *testing.T) {
+	var exchangeCalls atomic.Int32
+	var apiCalls atomic.Int32
+	httpDoer := &nonComparableHTTPDoer{do: func(req *http.Request) (*http.Response, error) {
+		if req.URL.Host == "mtls.auth.openai.com" {
+			exchangeCalls.Add(1)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"access_token":"x509-token","expires_in":3600}`)),
+			}, nil
+		}
+		apiCalls.Add(1)
+		return modelsListResponse(), nil
+	}}
+	client := openai.NewClient(option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()))
+
+	if _, err := client.Models.List(t.Context(), option.WithHTTPClient(httpDoer)); err != nil {
+		t.Fatalf("first Models.List() error = %v", err)
+	}
+	if _, err := client.Models.List(t.Context(), option.WithHTTPClient(httpDoer)); err != nil {
+		t.Fatalf("second Models.List() error = %v", err)
+	}
+
+	if got, want := exchangeCalls.Load(), int32(1); got != want {
+		t.Errorf("token exchange calls = %d, want %d", got, want)
+	}
+	if got, want := apiCalls.Load(), int32(2); got != want {
+		t.Errorf("API calls = %d, want %d", got, want)
+	}
+}
+
 func TestClientX509WorkloadIdentityLaterOptionReplacesCredential(t *testing.T) {
 	var exchangedServiceAccounts []string
 	var apiAuthorization string

--- a/x509_auth_test.go
+++ b/x509_auth_test.go
@@ -58,7 +58,7 @@ func TestClientX509WorkloadIdentityDefaultsMTLSAndReusesHTTPClient(t *testing.T)
 	t.Setenv("OPENAI_API_KEY", "api-key-must-not-be-used")
 	var mu sync.Mutex
 	requests := make([]*http.Request, 0, 2)
-	httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+	httpClient := nativeX509HTTPClient(t, func(req *http.Request) (*http.Response, error) {
 		mu.Lock()
 		requests = append(requests, req.Clone(req.Context()))
 		mu.Unlock()
@@ -70,7 +70,7 @@ func TestClientX509WorkloadIdentityDefaultsMTLSAndReusesHTTPClient(t *testing.T)
 			}, nil
 		}
 		return modelsListResponse(), nil
-	}}}
+	})
 
 	client := openai.NewClient(
 		option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
@@ -173,7 +173,7 @@ func TestClientX509WorkloadIdentityBaseURLPrecedence(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			var apiURL string
-			httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+			httpClient := nativeX509HTTPClient(t, func(req *http.Request) (*http.Response, error) {
 				if req.URL.Host == "mtls.auth.openai.com" {
 					return &http.Response{
 						StatusCode: http.StatusOK,
@@ -183,7 +183,7 @@ func TestClientX509WorkloadIdentityBaseURLPrecedence(t *testing.T) {
 				}
 				apiURL = req.URL.String()
 				return modelsListResponse(), nil
-			}}}
+			})
 			client := openai.NewClient(testCase.opts(httpClient)...)
 			if _, err := client.Models.List(t.Context()); err != nil {
 				t.Fatalf("Models.List() error = %v", err)
@@ -199,7 +199,7 @@ func TestClientX509WorkloadIdentityBaseURLPrecedence(t *testing.T) {
 func TestClientX509WorkloadIdentityEnvironmentBaseURLWins(t *testing.T) {
 	t.Setenv("OPENAI_BASE_URL", "https://environment.example/v1")
 	var apiURL string
-	httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+	httpClient := nativeX509HTTPClient(t, func(req *http.Request) (*http.Response, error) {
 		if req.URL.Host == "mtls.auth.openai.com" {
 			return &http.Response{
 				StatusCode: http.StatusOK,
@@ -209,7 +209,7 @@ func TestClientX509WorkloadIdentityEnvironmentBaseURLWins(t *testing.T) {
 		}
 		apiURL = req.URL.String()
 		return modelsListResponse(), nil
-	}}}
+	})
 	client := openai.NewClient(
 		option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
 		option.WithHTTPClient(httpClient),
@@ -241,27 +241,25 @@ func TestClientX509WorkloadIdentityRefusesAPIRedirects(t *testing.T) {
 	}))
 	t.Cleanup(redirectTarget.Close)
 
-	httpClient := &http.Client{
-		Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
-			if req.URL.Host == "mtls.auth.openai.com" {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Header:     http.Header{"Content-Type": []string{"application/json"}},
-					Body:       io.NopCloser(strings.NewReader(`{"access_token":"x509-token","expires_in":3600}`)),
-				}, nil
-			}
-			if req.URL.Host == "api.example" {
-				apiRequests.Add(1)
-				return &http.Response{
-					StatusCode: http.StatusFound,
-					Header:     http.Header{"Location": []string{redirectTarget.URL}},
-					Body:       io.NopCloser(strings.NewReader("redirect")),
-				}, nil
-			}
-			return http.DefaultTransport.RoundTrip(req)
-		}},
-		CheckRedirect: func(*http.Request, []*http.Request) error { return nil },
-	}
+	httpClient := nativeX509HTTPClient(t, func(req *http.Request) (*http.Response, error) {
+		if req.URL.Host == "mtls.auth.openai.com" {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"access_token":"x509-token","expires_in":3600}`)),
+			}, nil
+		}
+		if req.URL.Host == "api.example" {
+			apiRequests.Add(1)
+			return &http.Response{
+				StatusCode: http.StatusFound,
+				Header:     http.Header{"Location": []string{redirectTarget.URL}},
+				Body:       io.NopCloser(strings.NewReader("redirect")),
+			}, nil
+		}
+		return http.DefaultTransport.RoundTrip(req)
+	})
+	httpClient.CheckRedirect = func(*http.Request, []*http.Request) error { return nil }
 	client := openai.NewClient(
 		option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
 		option.WithBaseURL("https://api.example/v1"),
@@ -282,7 +280,7 @@ func TestClientX509WorkloadIdentityScopesTokenCacheToHTTPDoer(t *testing.T) {
 	exchangeCalls := map[string]int{}
 	apiAuth := map[string][]string{}
 	newHTTPClient := func(name string) *http.Client {
-		return &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+		return nativeX509HTTPClient(t, func(req *http.Request) (*http.Response, error) {
 			if req.URL.Host == "mtls.auth.openai.com" {
 				exchangeCalls[name]++
 				return &http.Response{
@@ -293,7 +291,7 @@ func TestClientX509WorkloadIdentityScopesTokenCacheToHTTPDoer(t *testing.T) {
 			}
 			apiAuth[name] = append(apiAuth[name], req.Header.Get("Authorization"))
 			return modelsListResponse(), nil
-		}}}
+		})
 	}
 
 	httpClientA := newHTTPClient("a")
@@ -333,7 +331,7 @@ func TestClientX509WorkloadIdentityScopesTokenCacheToNativeTransport(t *testing.
 		authorizations []string
 	}
 	newTransport := func(name string, capture *transportCapture) http.RoundTripper {
-		return &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+		return nativeX509HTTPClient(t, func(req *http.Request) (*http.Response, error) {
 			if req.URL.Hostname() == "mtls.auth.openai.com" {
 				capture.exchangeCalls++
 				return &http.Response{
@@ -347,7 +345,7 @@ func TestClientX509WorkloadIdentityScopesTokenCacheToNativeTransport(t *testing.
 			}
 			capture.authorizations = append(capture.authorizations, req.Header.Get("Authorization"))
 			return modelsListResponse(), nil
-		}}
+		}).Transport
 	}
 
 	var transportA, transportB transportCapture
@@ -376,129 +374,29 @@ func TestClientX509WorkloadIdentityScopesTokenCacheToNativeTransport(t *testing.
 	}
 }
 
-func TestClientX509WorkloadIdentityCachesNonComparableHTTPDoer(t *testing.T) {
-	var exchangeCalls atomic.Int32
-	var apiCalls atomic.Int32
-	httpDoer := nonComparableHTTPDoer{do: func(req *http.Request) (*http.Response, error) {
-		if req.URL.Host == "mtls.auth.openai.com" {
-			exchangeCalls.Add(1)
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Header:     http.Header{"Content-Type": []string{"application/json"}},
-				Body:       io.NopCloser(strings.NewReader(`{"access_token":"x509-token","expires_in":3600}`)),
-			}, nil
-		}
-		apiCalls.Add(1)
+func TestClientX509WorkloadIdentityRejectsCustomHTTPDoerBeforeExchange(t *testing.T) {
+	var calls atomic.Int32
+	httpDoer := &nonComparableHTTPDoer{do: func(*http.Request) (*http.Response, error) {
+		calls.Add(1)
 		return modelsListResponse(), nil
 	}}
-	const requestCount = 16
-	var ready sync.WaitGroup
-	ready.Add(requestCount)
-	releaseRequests := make(chan struct{})
-	client := openai.NewClient(
-		option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
-		option.WithHTTPClient(httpDoer),
-		option.WithMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
-			ready.Done()
-			<-releaseRequests
-			return next(req)
-		}),
-	)
-
-	errs := make(chan error, requestCount)
-	var requests sync.WaitGroup
-	requests.Add(requestCount)
-	for range requestCount {
-		go func() {
-			defer requests.Done()
-			_, err := client.Models.List(t.Context())
-			errs <- err
-		}()
-	}
-	ready.Wait()
-	close(releaseRequests)
-	requests.Wait()
-	close(errs)
-	for err := range errs {
-		if err != nil {
-			t.Fatalf("Models.List() error = %v", err)
-		}
-	}
-	if got, want := exchangeCalls.Load(), int32(1); got != want {
-		t.Errorf("token exchange calls = %d, want %d", got, want)
-	}
-	if got, want := apiCalls.Load(), int32(requestCount); got != want {
-		t.Errorf("API calls = %d, want %d", got, want)
-	}
-}
-
-func TestClientX509WorkloadIdentityCachesDynamicallyNonComparableHTTPDoer(t *testing.T) {
-	var exchangeCalls atomic.Int32
-	httpDoer := dynamicallyNonComparableHTTPDoer{
-		state: []string{"not-comparable"},
-		doer: nonComparableHTTPDoer{do: func(req *http.Request) (*http.Response, error) {
-			if req.URL.Host == "mtls.auth.openai.com" {
-				exchangeCalls.Add(1)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Header:     http.Header{"Content-Type": []string{"application/json"}},
-					Body:       io.NopCloser(strings.NewReader(`{"access_token":"x509-token","expires_in":3600}`)),
-				}, nil
-			}
-			return modelsListResponse(), nil
-		}},
-	}
 	client := openai.NewClient(
 		option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
 		option.WithHTTPClient(httpDoer),
 	)
 
-	for range 2 {
-		if _, err := client.Models.List(t.Context()); err != nil {
-			t.Fatalf("Models.List() error = %v", err)
-		}
+	if _, err := client.Models.List(t.Context()); err == nil || !strings.Contains(err.Error(), "native *http.Transport") {
+		t.Fatalf("Models.List() error = %v, want custom transport rejection", err)
 	}
-	if got, want := exchangeCalls.Load(), int32(1); got != want {
-		t.Errorf("token exchange calls = %d, want %d", got, want)
-	}
-}
-
-func TestClientX509WorkloadIdentityCachesComparableHTTPDoerAcrossOptions(t *testing.T) {
-	var exchangeCalls atomic.Int32
-	var apiCalls atomic.Int32
-	httpDoer := &nonComparableHTTPDoer{do: func(req *http.Request) (*http.Response, error) {
-		if req.URL.Host == "mtls.auth.openai.com" {
-			exchangeCalls.Add(1)
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Header:     http.Header{"Content-Type": []string{"application/json"}},
-				Body:       io.NopCloser(strings.NewReader(`{"access_token":"x509-token","expires_in":3600}`)),
-			}, nil
-		}
-		apiCalls.Add(1)
-		return modelsListResponse(), nil
-	}}
-	client := openai.NewClient(option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()))
-
-	if _, err := client.Models.List(t.Context(), option.WithHTTPClient(httpDoer)); err != nil {
-		t.Fatalf("first Models.List() error = %v", err)
-	}
-	if _, err := client.Models.List(t.Context(), option.WithHTTPClient(httpDoer)); err != nil {
-		t.Fatalf("second Models.List() error = %v", err)
-	}
-
-	if got, want := exchangeCalls.Load(), int32(1); got != want {
-		t.Errorf("token exchange calls = %d, want %d", got, want)
-	}
-	if got, want := apiCalls.Load(), int32(2); got != want {
-		t.Errorf("API calls = %d, want %d", got, want)
+	if got := calls.Load(); got != 0 {
+		t.Fatalf("HTTP calls = %d, want 0", got)
 	}
 }
 
 func TestClientX509WorkloadIdentityLaterOptionReplacesCredential(t *testing.T) {
 	var exchangedServiceAccounts []string
 	var apiAuthorization string
-	httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+	httpClient := nativeX509HTTPClient(t, func(req *http.Request) (*http.Response, error) {
 		if req.URL.Host == "mtls.auth.openai.com" {
 			var body struct {
 				ServiceAccountID string `json:"service_account_id"`
@@ -518,7 +416,7 @@ func TestClientX509WorkloadIdentityLaterOptionReplacesCredential(t *testing.T) {
 		}
 		apiAuthorization = req.Header.Get("Authorization")
 		return modelsListResponse(), nil
-	}}}
+	})
 	first := clientX509WorkloadIdentity()
 	first.ServiceAccountID = "svc-first"
 	second := clientX509WorkloadIdentity()
@@ -542,7 +440,7 @@ func TestClientX509WorkloadIdentityLaterOptionReplacesCredential(t *testing.T) {
 func TestClientX509WorkloadIdentitySnapshotsConfigurationAndSupportsClientCopies(t *testing.T) {
 	var exchangedServiceAccounts []string
 	var exchangeCalls int
-	httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+	httpClient := nativeX509HTTPClient(t, func(req *http.Request) (*http.Response, error) {
 		if req.URL.Hostname() == "mtls.auth.openai.com" {
 			exchangeCalls++
 			var body struct {
@@ -559,7 +457,7 @@ func TestClientX509WorkloadIdentitySnapshotsConfigurationAndSupportsClientCopies
 			}, nil
 		}
 		return modelsListResponse(), nil
-	}}}
+	})
 	config := clientX509WorkloadIdentity()
 	config.ServiceAccountID = "svc-original"
 	x509Option := option.WithX509WorkloadIdentity(config)
@@ -599,7 +497,7 @@ func TestClientX509WorkloadIdentityExchangeFailureDoesNotEnterAPIRetryLoop(t *te
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			exchangeCalls := 0
-			httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+			httpClient := nativeX509HTTPClient(t, func(req *http.Request) (*http.Response, error) {
 				if req.URL.Host != "mtls.auth.openai.com" {
 					t.Fatalf("unexpected API request %s", req.URL)
 				}
@@ -609,7 +507,7 @@ func TestClientX509WorkloadIdentityExchangeFailureDoesNotEnterAPIRetryLoop(t *te
 					Header:     http.Header{"Retry-After": []string{"0"}},
 					Body:       io.NopCloser(strings.NewReader(`{"error":"exchange_failed"}`)),
 				}, nil
-			}}}
+			})
 			client := openai.NewClient(
 				option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
 				option.WithHTTPClient(httpClient),
@@ -636,7 +534,7 @@ func TestClientX509WorkloadIdentity401ReplaysReplayableBodyOnce(t *testing.T) {
 	var exchangeCalls int
 	var apiBodies []string
 	var apiAuth []string
-	httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+	httpClient := nativeX509HTTPClient(t, func(req *http.Request) (*http.Response, error) {
 		if req.URL.Host == "mtls.auth.openai.com" {
 			exchangeCalls++
 			return &http.Response{
@@ -662,7 +560,7 @@ func TestClientX509WorkloadIdentity401ReplaysReplayableBodyOnce(t *testing.T) {
 			Header:     http.Header{"Content-Type": []string{"application/json"}},
 			Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
 		}, nil
-	}}}
+	})
 	client := openai.NewClient(
 		option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
 		option.WithBaseURL("https://api.example/v1"),
@@ -699,7 +597,7 @@ func TestClientX509WorkloadIdentity401ReappliesBodyMiddleware(t *testing.T) {
 	var exchangeCalls int
 	var middlewareCalls int
 	var apiBodies []string
-	httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+	httpClient := nativeX509HTTPClient(t, func(req *http.Request) (*http.Response, error) {
 		if req.URL.Host == "mtls.auth.openai.com" {
 			exchangeCalls++
 			return &http.Response{
@@ -734,7 +632,7 @@ func TestClientX509WorkloadIdentity401ReappliesBodyMiddleware(t *testing.T) {
 			Header:     http.Header{"Content-Type": []string{"application/json"}},
 			Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
 		}, nil
-	}}}
+	})
 	client := openai.NewClient(
 		option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
 		option.WithBaseURL("https://api.example/v1"),
@@ -790,7 +688,7 @@ func TestClientX509WorkloadIdentity401ReplaysFromPreMiddlewareState(t *testing.T
 	var middlewareCalls int
 	var queryValueCounts []int
 	var signatureCounts []int
-	httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+	httpClient := nativeX509HTTPClient(t, func(req *http.Request) (*http.Response, error) {
 		if req.URL.Host == "mtls.auth.openai.com" {
 			exchangeCalls++
 			return &http.Response{
@@ -808,7 +706,7 @@ func TestClientX509WorkloadIdentity401ReplaysFromPreMiddlewareState(t *testing.T
 			return &http.Response{StatusCode: http.StatusUnauthorized, Header: make(http.Header), Body: http.NoBody}, nil
 		}
 		return modelsListResponse(), nil
-	}}}
+	})
 	client := openai.NewClient(
 		option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
 		option.WithHTTPClient(httpClient),
@@ -842,7 +740,7 @@ func TestClientX509WorkloadIdentity401ReplaysFromPreMiddlewareState(t *testing.T
 func TestClientX509WorkloadIdentity401DoesNotReplayStreamingBody(t *testing.T) {
 	var exchangeCalls int
 	var apiCalls int
-	httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+	httpClient := nativeX509HTTPClient(t, func(req *http.Request) (*http.Response, error) {
 		if req.URL.Host == "mtls.auth.openai.com" {
 			exchangeCalls++
 			return &http.Response{
@@ -853,7 +751,7 @@ func TestClientX509WorkloadIdentity401DoesNotReplayStreamingBody(t *testing.T) {
 		}
 		apiCalls++
 		return &http.Response{StatusCode: http.StatusUnauthorized, Header: make(http.Header), Body: http.NoBody}, nil
-	}}}
+	})
 	client := openai.NewClient(
 		option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
 		option.WithBaseURL("https://api.example/v1"),

--- a/x509_auth_test.go
+++ b/x509_auth_test.go
@@ -193,6 +193,7 @@ func TestClientX509WorkloadIdentityBaseURLPrecedence(t *testing.T) {
 			}
 		})
 	}
+
 }
 
 func TestClientX509WorkloadIdentityEnvironmentBaseURLWins(t *testing.T) {
@@ -323,6 +324,55 @@ func TestClientX509WorkloadIdentityScopesTokenCacheToHTTPDoer(t *testing.T) {
 	}
 	if got, want := strings.Join(apiAuth["b"], ","), "Bearer token-b"; got != want {
 		t.Errorf("transport B Authorization = %q, want %q", got, want)
+	}
+}
+
+func TestClientX509WorkloadIdentityScopesTokenCacheToNativeTransport(t *testing.T) {
+	type transportCapture struct {
+		exchangeCalls  int
+		authorizations []string
+	}
+	newTransport := func(name string, capture *transportCapture) http.RoundTripper {
+		return &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+			if req.URL.Hostname() == "mtls.auth.openai.com" {
+				capture.exchangeCalls++
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+					Body: io.NopCloser(strings.NewReader(fmt.Sprintf(
+						`{"access_token":"token-%s","expires_in":3600}`,
+						name,
+					))),
+				}, nil
+			}
+			capture.authorizations = append(capture.authorizations, req.Header.Get("Authorization"))
+			return modelsListResponse(), nil
+		}}
+	}
+
+	var transportA, transportB transportCapture
+	httpClient := &http.Client{Transport: newTransport("a", &transportA)}
+	client := openai.NewClient(
+		option.WithBaseURL("https://trusted.example/v1"),
+		option.WithX509WorkloadIdentity(clientX509WorkloadIdentity()),
+		option.WithHTTPClient(httpClient),
+	)
+	if _, err := client.Models.List(t.Context()); err != nil {
+		t.Fatalf("first Models.List() error = %v", err)
+	}
+	httpClient.Transport = newTransport("b", &transportB)
+	if _, err := client.Models.List(t.Context()); err != nil {
+		t.Fatalf("second Models.List() error = %v", err)
+	}
+
+	if got, want := transportA.exchangeCalls, 1; got != want {
+		t.Fatalf("transport A exchange calls = %d, want %d", got, want)
+	}
+	if got, want := transportB.exchangeCalls, 1; got != want {
+		t.Fatalf("transport B exchange calls = %d, want %d", got, want)
+	}
+	if got, want := strings.Join(transportB.authorizations, ","), "Bearer token-b"; got != want {
+		t.Fatalf("transport B Authorization = %q, want %q", got, want)
 	}
 }
 
@@ -486,6 +536,53 @@ func TestClientX509WorkloadIdentityLaterOptionReplacesCredential(t *testing.T) {
 	}
 	if got, want := apiAuthorization, "Bearer token-svc-second"; got != want {
 		t.Errorf("API Authorization = %q, want %q", got, want)
+	}
+}
+
+func TestClientX509WorkloadIdentitySnapshotsConfigurationAndSupportsClientCopies(t *testing.T) {
+	var exchangedServiceAccounts []string
+	var exchangeCalls int
+	httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+		if req.URL.Hostname() == "mtls.auth.openai.com" {
+			exchangeCalls++
+			var body struct {
+				ServiceAccountID string `json:"service_account_id"`
+			}
+			if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+				return nil, err
+			}
+			exchangedServiceAccounts = append(exchangedServiceAccounts, body.ServiceAccountID)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"access_token":"x509-token","expires_in":3600}`)),
+			}, nil
+		}
+		return modelsListResponse(), nil
+	}}}
+	config := clientX509WorkloadIdentity()
+	config.ServiceAccountID = "svc-original"
+	x509Option := option.WithX509WorkloadIdentity(config)
+	config.IdentityProviderID = "idp-mutated"
+	config.ServiceAccountID = "svc-mutated"
+	client := openai.NewClient(
+		x509Option,
+		option.WithBaseURL("https://trusted.example/v1"),
+		option.WithHTTPClient(httpClient),
+	)
+	clientCopy := client
+
+	if _, err := client.Models.List(t.Context()); err != nil {
+		t.Fatalf("original Models.List() error = %v", err)
+	}
+	if _, err := clientCopy.Models.List(t.Context()); err != nil {
+		t.Fatalf("copied Models.List() error = %v", err)
+	}
+	if got, want := strings.Join(exchangedServiceAccounts, ","), "svc-original"; got != want {
+		t.Fatalf("exchanged service accounts = %q, want %q", got, want)
+	}
+	if exchangeCalls != 1 {
+		t.Fatalf("exchange calls = %d, want 1", exchangeCalls)
 	}
 }
 

--- a/x509_native_transport_test.go
+++ b/x509_native_transport_test.go
@@ -1,0 +1,12 @@
+package openai_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/openai/openai-go/v3/internal/testutil"
+)
+
+func nativeX509HTTPClient(t testing.TB, roundTrip func(*http.Request) (*http.Response, error)) *http.Client {
+	return testutil.NewNativeX509HTTPClient(t, roundTrip)
+}


### PR DESCRIPTION
## What and why

Implements Phase 1 (HTTP only) of the [X.509 Workload Identity Federation design proposal](https://app.notion.com/p/openai/X-509-Workload-Identity-Federation-in-OpenAI-SDKs-Design-Proposal-3bc8e50b62b0814a9c36c3cf6d897f04).

- Adds `auth.X509WorkloadIdentity` and `option.WithX509WorkloadIdentity` as a distinct typed credential source.
- Performs lazy, single-flight token exchange at the fixed mTLS OAuth endpoint and uses the effective caller-configured HTTP transport for exchange and API calls.
- Adds positive `expires_in` validation, monotonic expiry caching, half-TTL refresh-buffer clamping, cancellation-safe waiters, bounded transient retries with `Retry-After`, and conditional 401 invalidation/replay.
- Defaults only X.509-mode clients to `https://mtls.api.openai.com/v1` when no base URL is configured.
- Adds focused security/concurrency/replay coverage, documentation, and an `OPENAI_AUTH_MODE=api_key|x509` example.

## Public API and Go idiom rationale

The additive public surface is intentionally small:

```go
type X509WorkloadIdentity struct {
    IdentityProviderID string
    ServiceAccountID   string
    RefreshBuffer      time.Duration
}

func WithX509WorkloadIdentity(config auth.X509WorkloadIdentity) option.RequestOption
```

This follows the SDK's existing functional-option shape while using Go-native `time.Duration`, `context.Context`, `sync.Mutex` plus completion channels, `http.Client` shallow cloning, and `Request.GetBody` replayability. Credential-source behavior is modeled by distinct concrete source types behind one internal interface; X.509 is not represented as a fake `SubjectTokenProvider`. Shared cache/single-flight code is mode-agnostic, and token HTTP mechanics live in one canonical helper.

## Security and transport ownership

- The SDK adds no certificate, private-key, passphrase, trust-store, proxy, or HSM fields. The caller's transport owns all TLS material, pooling, and rotation.
- Native `*http.Client` values are shallow-cloned only to install `http.ErrUseLastResponse`; the configured transport is reused for both exact `POST https://mtls.auth.openai.com/oauth/token` and API calls. Custom HTTP doers must refuse redirects internally.
- The X.509 request type structurally has no `subject_token` or `client_id`, and there is no public custom exchange URL.
- X.509 token-response bodies and server descriptions are not surfaced in errors; token exchange response size is bounded.
- A 401 invalidates only the token that was rejected and replays once only when `Body == nil || GetBody != nil`.

## Validation

Validated after refreshing from current `origin/main` (`204e994fd4cda2d5b760893997d5e255519af3cd`):

- Go 1.26.6: full root suite with `-count=1 -race` through `./scripts/test`; all packages passed.
- Go 1.25.13: full root suite with `-count=1` through `./scripts/test`; all packages passed.
- Go 1.26.6 and Go 1.25.13: `go test -count=1 ./...` in `examples`; passed, including the offline X.509 transport ownership test.
- Go 1.26.6 and Go 1.25.13: `go test -count=1 -mod=readonly ./...` in `internal/testdata/consumer`; passed.
- Go 1.26.6: focused `go test -race -count=1 ./auth` and root X.509/workload-identity tests; passed.
- Go 1.26.6: `./scripts/lint` with VCS stamping enabled; formatting, root build, test compilation, all examples, golangci-lint across root/examples/consumer, and non-Linux example analysis passed with zero issues.
- Go 1.26.6: `go vet ./...`; passed.
- `./scripts/check-go-mod`; all four modules are tidy.
- Go 1.26.6: `govulncheck ./...` for root and examples via the pinned tools module; no vulnerabilities found.
- Exact staged diff: `git diff --check`; passed.

Focused tests cover the exact exchange method/host/path/body and omitted `subject_token`, redirect refusal on exchange and API calls, caller certificate/private-key ownership, transient retry and `Retry-After`, bounded attempts, single-flight refresh, canceled waiters, expiration and half-TTL refresh, concurrent 401 invalidation, replayable and streaming bodies, response/error redaction, API-key behavior, and existing JWT/ID-token WIF.

## Compatibility

This is additive. `option.WithWorkloadIdentity` and the existing JWT/ID-token provider contract are unchanged, and API-key clients retain the public API base URL and existing authorization behavior. Only X.509 mode receives the mTLS API default, and explicit or environment base URLs continue to win.

## Out of scope and remaining risk

Realtime/WebSocket authentication is explicitly excluded from Phase 1 and remains Phase 2 work. Validation is hermetic and does not contact the production mTLS endpoints with a live workload certificate. Arbitrary custom `option.HTTPClient` implementations remain responsible for their own redirect policy because the SDK cannot alter opaque `Do` implementations; native `*http.Client` usage is enforced by the SDK and demonstrated in the example.
