### PR TITLE
feat: add Bedrock Runtime endpoint support (SDK-290)

### DIFF
--- a/bedrock/README.md
+++ b/bedrock/README.md
@@ -1,0 +1,84 @@
+# Amazon Bedrock
+
+Use the `bedrock` package to configure the normal OpenAI client for Amazon Bedrock's OpenAI-compatible API. The default Mantle endpoint and its existing authentication behavior remain unchanged.
+
+| Endpoint | Default API root | SigV4 service |
+| --- | --- | --- |
+| `bedrock.EndpointMantle` (default) | `https://bedrock-mantle.<region>.api.aws/openai/v1` | `bedrock-mantle` |
+| `bedrock.EndpointRuntime` | `https://bedrock-runtime.<region>.amazonaws.com/openai/v1` | `bedrock` |
+
+Runtime hostnames use the correct suffix for the selected AWS partition. Canonical Runtime, FIPS, and dual-stack `BaseURL` overrides automatically select the endpoint family when `Endpoint` is omitted. Canonical AWS hosts must use HTTPS and match the configured region and endpoint. Custom or proxy hosts require an explicit `Endpoint` when using SigV4 credentials.
+
+## Runtime Chat Completions
+
+```go
+import (
+	"context"
+	"fmt"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/bedrock"
+)
+
+client, err := bedrock.NewClient(context.Background(), bedrock.Config{
+	Endpoint:  bedrock.EndpointRuntime,
+	AWSRegion: "us-east-1",
+})
+if err != nil {
+	panic(err)
+}
+
+completion, err := client.Chat.Completions.New(context.Background(), openai.ChatCompletionNewParams{
+	Model:    openai.ChatModel("us.openai.gpt-5.6-sol"),
+	Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("Say hello!")},
+})
+if err != nil {
+	panic(err)
+}
+fmt.Println(completion.Choices[0].Message.Content)
+```
+
+The target US cross-Region inference profile IDs are `us.openai.gpt-5.6-sol`, `us.openai.gpt-5.6-terra`, and `us.openai.gpt-5.6-luna`. A global profile such as `global.openai.gpt-5.6-sol` requires account, role, and AWS Organizations policy access. The deployment requires the complete inference profile ID, not a bare model ID.
+
+For the target US profiles, non-streaming Chat Completions at `/openai/v1/chat/completions` with the SigV4 `bedrock` signing service is the live-verified integration. The SDK also supports Responses and streaming, but support for a specific model, profile, authentication method, route, and stream is controlled by AWS and must be verified for that deployment.
+
+AWS documentation describes both `/openai/v1` and `/v1` for different Bedrock OpenAI-compatible routes. If a deployment requires the alternative path, configure it explicitly:
+
+```go
+bedrock.Config{
+	Endpoint:  bedrock.EndpointRuntime,
+	AWSRegion: "us-east-1",
+	BaseURL:   "https://bedrock-runtime.us-east-1.amazonaws.com/v1",
+}
+```
+
+## Authentication
+
+Credential precedence is unchanged:
+
+1. Explicit `APIKey` or `BedrockTokenProvider`.
+2. Explicit static AWS credentials, `AWSProfile`, or `AWSCredentialsProvider`.
+3. `AWS_BEARER_TOKEN_BEDROCK`.
+4. The standard AWS credential chain.
+
+An expired `AWS_BEARER_TOKEN_BEDROCK` takes precedence over the implicit AWS credential chain. Unset it or configure an explicit AWS profile or credentials provider when SigV4 is required. Bearer providers are evaluated before each request attempt; AWS credentials and SigV4 signatures are refreshed as needed for retries. AWS determines whether a given deployment accepts bearer authentication.
+
+The runnable Runtime Chat example defaults to SigV4 and clears any ambient Bedrock bearer token so it cannot shadow the default AWS credentials provider:
+
+```sh
+AWS_REGION=us-east-1 go -C examples run ./bedrock-runtime
+AWS_REGION=us-east-1 BEDROCK_MODEL=us.openai.gpt-5.6-terra BEDROCK_STREAM=1 go -C examples run ./bedrock-runtime
+AWS_REGION=us-east-1 BEDROCK_AUTH=bearer BEDROCK_MODEL=us.openai.gpt-5.6-luna go -C examples run ./bedrock-runtime
+```
+
+Run these commands from the repository root. Bearer mode requires `AWS_BEARER_TOKEN_BEDROCK`. Streaming is opt-in and requires support from the selected AWS deployment.
+
+## Optional live verification
+
+The Runtime live test never contacts AWS unless `BEDROCK_LIVE_TEST=1` is explicitly set. Choose one authentication mode from `bearer`, `environment-bearer`, `token-provider`, `default-chain`, `profile`, `static`, or `custom-provider`:
+
+```sh
+BEDROCK_LIVE_TEST=1 BEDROCK_LIVE_AUTH=default-chain AWS_REGION=us-east-1 go test -run TestRuntimeLive -v ./bedrock
+```
+
+By default, it sends non-streaming Chat requests for the three US inference profiles. `BEDROCK_MODEL` selects one profile; `BEDROCK_LIVE_MODELS` selects a comma-separated list. Set `BEDROCK_LIVE_RESPONSES=1` and `BEDROCK_LIVE_STREAM=1` only when that deployment supports the corresponding paths.

--- a/bedrock/README.md
+++ b/bedrock/README.md
@@ -7,7 +7,7 @@ Use the `bedrock` package to configure the normal OpenAI client for Amazon Bedro
 | `bedrock.EndpointMantle` (default) | `https://bedrock-mantle.<region>.api.aws/openai/v1` | `bedrock-mantle` |
 | `bedrock.EndpointRuntime` | `https://bedrock-runtime.<region>.amazonaws.com/openai/v1` | `bedrock` |
 
-Runtime hostnames use the correct suffix for the selected AWS partition. Canonical Runtime, FIPS, and dual-stack `BaseURL` overrides automatically select the endpoint family when `Endpoint` is omitted. Canonical AWS hosts must use HTTPS and match the configured region and endpoint. Custom or proxy hosts require an explicit `Endpoint` when using SigV4 credentials.
+Runtime hostnames use the correct suffix for the selected AWS partition. Canonical Runtime, FIPS, and dual-stack `BaseURL` overrides automatically select the endpoint family when `Endpoint` is omitted. Canonical AWS hosts must use HTTPS and match the configured region and endpoint. Custom or proxy hosts default to the Mantle signer; set `EndpointRuntime` explicitly when a custom host requires Runtime signing.
 
 ## Runtime Chat Completions
 

--- a/bedrock/auth.go
+++ b/bedrock/auth.go
@@ -131,7 +131,7 @@ func resolveConfig(ctx context.Context, cfg Config, now func() time.Time) (resol
 	if err != nil {
 		return resolvedConfig{}, err
 	}
-	endpoint, err := resolveEndpoint(cfg.Endpoint, baseURL, mode)
+	endpoint, err := resolveEndpoint(cfg.Endpoint, baseURL)
 	if err != nil {
 		return resolvedConfig{}, err
 	}
@@ -320,7 +320,7 @@ func normalizeBaseURL(value *url.URL) *url.URL {
 	return &copy
 }
 
-func resolveEndpoint(endpoint Endpoint, baseURL *url.URL, mode authMode) (Endpoint, error) {
+func resolveEndpoint(endpoint Endpoint, baseURL *url.URL) (Endpoint, error) {
 	if endpoint != "" && endpoint != EndpointMantle && endpoint != EndpointRuntime {
 		return "", errors.New("bedrock: `Endpoint` must be `EndpointMantle` or `EndpointRuntime`")
 	}
@@ -336,8 +336,6 @@ func resolveEndpoint(endpoint Endpoint, baseURL *url.URL, mode authMode) (Endpoi
 			if endpoint == "" {
 				endpoint = canonicalEndpoint
 			}
-		} else if mode == authModeSigV4 && endpoint == "" {
-			return "", errors.New("bedrock: a custom endpoint requires an explicit `Endpoint` when using AWS credential authentication")
 		}
 	}
 	if endpoint == "" {

--- a/bedrock/auth.go
+++ b/bedrock/auth.go
@@ -23,7 +23,8 @@ import (
 )
 
 const (
-	bedrockService = "bedrock-mantle"
+	bedrockService        = "bedrock-mantle"
+	bedrockRuntimeService = "bedrock"
 
 	missingRegionMessage        = "bedrock: an AWS region is required; pass `AWSRegion` in `bedrock.Config`, or set `AWS_REGION` or `AWS_DEFAULT_REGION`"
 	missingCredentialsMessage   = "bedrock: credentials not found; pass a bearer credential or AWS credentials in `bedrock.Config`, set `AWS_BEARER_TOKEN_BEDROCK`, or configure the default AWS credential chain"
@@ -31,10 +32,7 @@ const (
 	nonReplayableBodyMessage    = "bedrock: SigV4 authentication requires a replayable request body; buffer the body before sending or use bearer authentication"
 )
 
-var (
-	canonicalBedrockHost = regexp.MustCompile(`(?i)^bedrock-mantle\.([a-z0-9-]+)\.api\.aws$`)
-	awsRegionPattern     = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)+$`)
-)
+var awsRegionPattern = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)+$`)
 
 type authMode int
 
@@ -47,6 +45,7 @@ const (
 
 type resolvedConfig struct {
 	mode       authMode
+	endpoint   Endpoint
 	region     string
 	baseURL    *url.URL
 	middleware option.Middleware
@@ -132,6 +131,10 @@ func resolveConfig(ctx context.Context, cfg Config, now func() time.Time) (resol
 	if err != nil {
 		return resolvedConfig{}, err
 	}
+	endpoint, err := resolveEndpoint(cfg.Endpoint, baseURL, mode)
+	if err != nil {
+		return resolvedConfig{}, err
+	}
 	if baseURL != nil {
 		region, err = reconcileEndpointRegion(baseURL, region)
 		if err != nil {
@@ -142,7 +145,7 @@ func resolveConfig(ctx context.Context, cfg Config, now func() time.Time) (resol
 		}
 	}
 
-	resolved := resolvedConfig{mode: mode, region: region, baseURL: baseURL}
+	resolved := resolvedConfig{mode: mode, endpoint: endpoint, region: region, baseURL: baseURL}
 	var awsCfg aws.Config
 	switch mode {
 	case authModeSkip:
@@ -179,9 +182,7 @@ func resolveConfig(ctx context.Context, cfg Config, now func() time.Time) (resol
 		if region == "" {
 			return resolvedConfig{}, errors.New(missingRegionMessage)
 		}
-		// /openai/v1 is the Bedrock OpenAI compatibility contract. The generic
-		// /v1 route is a different API surface and is not interchangeable.
-		resolved.baseURL, err = parseBaseURL(fmt.Sprintf("https://bedrock-mantle.%s.api.aws/openai/v1/", region))
+		resolved.baseURL, err = parseBaseURL(defaultEndpointURL(endpoint, region))
 		if err != nil {
 			return resolvedConfig{}, err
 		}
@@ -192,7 +193,7 @@ func resolveConfig(ctx context.Context, cfg Config, now func() time.Time) (resol
 		resolved.middleware = bearerMiddleware(resolved.baseURL, tokenProvider)
 	}
 	if mode == authModeSigV4 {
-		resolved.middleware = sigV4Middleware(resolved.baseURL, awsCfg, v4.NewSigner(), now)
+		resolved.middleware = endpointSigV4Middleware(resolved.baseURL, awsCfg, v4.NewSigner(), now, endpoint)
 	}
 
 	return resolved, nil
@@ -319,12 +320,82 @@ func normalizeBaseURL(value *url.URL) *url.URL {
 	return &copy
 }
 
+func resolveEndpoint(endpoint Endpoint, baseURL *url.URL, mode authMode) (Endpoint, error) {
+	if endpoint != "" && endpoint != EndpointMantle && endpoint != EndpointRuntime {
+		return "", errors.New("bedrock: `Endpoint` must be `EndpointMantle` or `EndpointRuntime`")
+	}
+	if baseURL != nil {
+		canonicalEndpoint, _, canonical := parseBedrockEndpointHostname(baseURL.Hostname())
+		if canonical {
+			if !strings.EqualFold(baseURL.Scheme, "https") {
+				return "", errors.New("bedrock: canonical AWS endpoints require HTTPS")
+			}
+			if endpoint != "" && endpoint != canonicalEndpoint {
+				return "", fmt.Errorf("bedrock: %s hostname does not match the selected %s endpoint", canonicalEndpoint, endpoint)
+			}
+			if endpoint == "" {
+				endpoint = canonicalEndpoint
+			}
+		} else if mode == authModeSigV4 && endpoint == "" {
+			return "", errors.New("bedrock: a custom endpoint requires an explicit `Endpoint` when using AWS credential authentication")
+		}
+	}
+	if endpoint == "" {
+		return EndpointMantle, nil
+	}
+	return endpoint, nil
+}
+
+func defaultEndpointURL(endpoint Endpoint, region string) string {
+	if endpoint == EndpointRuntime {
+		standardSuffix, _ := runtimeDNSSuffixes(region)
+		return fmt.Sprintf("https://bedrock-runtime.%s.%s/openai/v1/", region, standardSuffix)
+	}
+	return fmt.Sprintf("https://bedrock-mantle.%s.api.aws/openai/v1/", region)
+}
+
+func runtimeDNSSuffixes(region string) (standard string, dualStack string) {
+	switch {
+	case strings.HasPrefix(region, "cn-"):
+		return "amazonaws.com.cn", "api.amazonwebservices.com.cn"
+	case strings.HasPrefix(region, "eusc-"):
+		return "amazonaws.eu", "api.amazonwebservices.eu"
+	case strings.HasPrefix(region, "us-iso-"):
+		return "c2s.ic.gov", "api.aws.ic.gov"
+	case strings.HasPrefix(region, "us-isob-"):
+		return "sc2s.sgov.gov", "api.aws.scloud"
+	case strings.HasPrefix(region, "eu-isoe-"):
+		return "cloud.adc-e.uk", "api.cloud-aws.adc-e.uk"
+	case strings.HasPrefix(region, "us-isof-"):
+		return "csp.hci.ic.gov", "api.aws.hci.ic.gov"
+	default:
+		return "amazonaws.com", "api.aws"
+	}
+}
+
+func parseBedrockEndpointHostname(hostname string) (Endpoint, string, bool) {
+	parts := strings.Split(strings.ToLower(strings.TrimSuffix(hostname, ".")), ".")
+	if len(parts) < 3 {
+		return "", "", false
+	}
+	service, region, suffix := parts[0], parts[1], strings.Join(parts[2:], ".")
+	if service == "bedrock-mantle" && region != "" && suffix == "api.aws" {
+		return EndpointMantle, region, true
+	}
+	if (service == "bedrock-runtime" || service == "bedrock-runtime-fips") && region != "" {
+		standard, dualStack := runtimeDNSSuffixes(region)
+		if suffix == standard || suffix == dualStack {
+			return EndpointRuntime, region, true
+		}
+	}
+	return "", "", false
+}
+
 func reconcileEndpointRegion(baseURL *url.URL, region string) (string, error) {
-	match := canonicalBedrockHost.FindStringSubmatch(baseURL.Hostname())
-	if len(match) != 2 {
+	_, endpointRegion, canonical := parseBedrockEndpointHostname(baseURL.Hostname())
+	if !canonical {
 		return region, nil
 	}
-	endpointRegion := strings.ToLower(match[1])
 	if region != "" && !strings.EqualFold(endpointRegion, region) {
 		return "", fmt.Errorf("bedrock: endpoint region %q does not match SigV4 region %q", endpointRegion, region)
 	}
@@ -421,6 +492,14 @@ type httpSigner interface {
 }
 
 func sigV4Middleware(baseURL *url.URL, cfg aws.Config, signer httpSigner, now func() time.Time) option.Middleware {
+	return endpointSigV4Middleware(baseURL, cfg, signer, now, EndpointMantle)
+}
+
+func endpointSigV4Middleware(baseURL *url.URL, cfg aws.Config, signer httpSigner, now func() time.Time, endpoint Endpoint) option.Middleware {
+	service := bedrockService
+	if endpoint == EndpointRuntime {
+		service = bedrockRuntimeService
+	}
 	return func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
 		if err := validateProviderRequest(req, baseURL); err != nil {
 			return nil, requestconfig.WithNoRetryError(err)
@@ -457,7 +536,7 @@ func sigV4Middleware(baseURL *url.URL, cfg aws.Config, signer httpSigner, now fu
 		// wire length before the request is sent.
 		contentLength := req.ContentLength
 		req.ContentLength = -1
-		signErr := signer.SignHTTP(req.Context(), credentials, req, encodedHash, bedrockService, cfg.Region, now().UTC())
+		signErr := signer.SignHTTP(req.Context(), credentials, req, encodedHash, service, cfg.Region, now().UTC())
 		req.ContentLength = contentLength
 		if signErr != nil {
 			return nil, &safeError{message: "bedrock: failed to sign request", cause: signErr}

--- a/bedrock/auth.go
+++ b/bedrock/auth.go
@@ -32,7 +32,7 @@ const (
 	nonReplayableBodyMessage    = "bedrock: SigV4 authentication requires a replayable request body; buffer the body before sending or use bearer authentication"
 )
 
-var awsRegionPattern = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)+$`)
+var awsRegionPattern = regexp.MustCompile(`^[a-z]{2,8}(?:-[a-z0-9]+)+-[0-9]+$`)
 
 type authMode int
 

--- a/bedrock/auth_test.go
+++ b/bedrock/auth_test.go
@@ -519,6 +519,7 @@ func TestSigV4DisablesRedirects(t *testing.T) {
 	defer source.Close()
 
 	client, err := NewClient(context.Background(), Config{
+		Endpoint:           EndpointMantle,
 		AWSRegion:          "us-east-1",
 		AWSAccessKeyID:     "access-key",
 		AWSSecretAccessKey: "secret-key",

--- a/bedrock/auth_test.go
+++ b/bedrock/auth_test.go
@@ -519,7 +519,6 @@ func TestSigV4DisablesRedirects(t *testing.T) {
 	defer source.Close()
 
 	client, err := NewClient(context.Background(), Config{
-		Endpoint:           EndpointMantle,
 		AWSRegion:          "us-east-1",
 		AWSAccessKeyID:     "access-key",
 		AWSSecretAccessKey: "secret-key",

--- a/bedrock/bedrock.go
+++ b/bedrock/bedrock.go
@@ -4,7 +4,7 @@
 // New clients use the AWS SDK for Go v2 credential chain by default, including
 // environment credentials, shared credentials and config files, named profiles,
 // workload identity, and instance or container roles. Requests are signed with
-// AWS Signature Version 4 using the bedrock-mantle service name.
+// AWS Signature Version 4 using the service name for the selected endpoint.
 package bedrock
 
 import (
@@ -20,6 +20,17 @@ import (
 // request attempt so expiring credentials can be refreshed for retries.
 type TokenProvider func(context.Context) (string, error)
 
+// Endpoint selects an Amazon Bedrock endpoint and its SigV4 signing service.
+type Endpoint string
+
+const (
+	// EndpointMantle preserves the existing Bedrock Mantle endpoint and signer.
+	EndpointMantle Endpoint = "mantle"
+
+	// EndpointRuntime uses the Bedrock Runtime endpoint and bedrock signer.
+	EndpointRuntime Endpoint = "runtime"
+)
+
 // Config configures an Amazon Bedrock client.
 //
 // Authentication is selected in this order:
@@ -31,6 +42,11 @@ type TokenProvider func(context.Context) (string, error)
 //
 // Configure at most one explicit authentication mode.
 type Config struct {
+	// Endpoint selects the Bedrock endpoint family. Mantle remains the default.
+	// Canonical AWS BaseURL overrides infer their endpoint when it is omitted.
+	// Custom or proxy hosts require an explicit endpoint for SigV4 signing.
+	Endpoint Endpoint
+
 	// APIKey is an explicit Amazon Bedrock bearer credential.
 	APIKey string
 
@@ -62,10 +78,10 @@ type Config struct {
 	// according to normal AWS semantics.
 	AWSCredentialsProvider aws.CredentialsProvider
 
-	// BaseURL overrides AWS_BEDROCK_BASE_URL and the regional Mantle endpoint.
-	// The default is https://bedrock-mantle.{region}.api.aws/openai/v1. The
-	// /openai/v1 prefix is the Bedrock OpenAI compatibility contract; /v1 is a
-	// different API surface.
+	// BaseURL overrides AWS_BEDROCK_BASE_URL and the selected regional endpoint.
+	// Mantle defaults to https://bedrock-mantle.{region}.api.aws/openai/v1;
+	// Runtime defaults to https://bedrock-runtime.{region}.amazonaws.com/openai/v1
+	// in the standard AWS partition. Use BaseURL if a deployment requires /v1.
 	BaseURL string
 
 	// SkipAuth disables Bedrock bearer and SigV4 authentication. Use this only

--- a/bedrock/bedrock.go
+++ b/bedrock/bedrock.go
@@ -44,7 +44,7 @@ const (
 type Config struct {
 	// Endpoint selects the Bedrock endpoint family. Mantle remains the default.
 	// Canonical AWS BaseURL overrides infer their endpoint when it is omitted.
-	// Custom or proxy hosts require an explicit endpoint for SigV4 signing.
+	// Custom or proxy hosts default to Mantle; select Runtime explicitly.
 	Endpoint Endpoint
 
 	// APIKey is an explicit Amazon Bedrock bearer credential.

--- a/bedrock/runtime_live_test.go
+++ b/bedrock/runtime_live_test.go
@@ -1,0 +1,147 @@
+package bedrock
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+	"github.com/openai/openai-go/v3/responses"
+)
+
+// TestRuntimeLive makes AWS requests only when BEDROCK_LIVE_TEST=1 is set.
+// Select credentials with BEDROCK_LIVE_AUTH and optionally enable Responses
+// and streaming with BEDROCK_LIVE_RESPONSES=1 and BEDROCK_LIVE_STREAM=1.
+func TestRuntimeLive(t *testing.T) {
+	if os.Getenv("BEDROCK_LIVE_TEST") != "1" {
+		t.Skip("set BEDROCK_LIVE_TEST=1 to make live Amazon Bedrock requests")
+	}
+	mode := strings.TrimSpace(os.Getenv("BEDROCK_LIVE_AUTH"))
+	if mode == "" {
+		t.Fatal("set BEDROCK_LIVE_AUTH before making live Amazon Bedrock requests")
+	}
+	config := liveRuntimeConfig(t, mode)
+	client, err := NewClient(context.Background(), config, option.WithMaxRetries(0))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	models := []string{"us.openai.gpt-5.6-sol", "us.openai.gpt-5.6-terra", "us.openai.gpt-5.6-luna"}
+	if configured := os.Getenv("BEDROCK_LIVE_MODELS"); configured != "" {
+		models = strings.Split(configured, ",")
+	} else if configured := os.Getenv("BEDROCK_MODEL"); configured != "" {
+		models = []string{configured}
+	}
+	for _, configured := range models {
+		model := strings.TrimSpace(configured)
+		if model == "" {
+			t.Fatal("BEDROCK_LIVE_MODELS contains an empty inference profile")
+		}
+		t.Run(fmt.Sprintf("%s/%s", mode, model), func(t *testing.T) {
+			chatParams := openai.ChatCompletionNewParams{
+				Model:    openai.ChatModel(model),
+				Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("Reply with exactly: bedrock live test passed")},
+			}
+			completion, err := client.Chat.Completions.New(context.Background(), chatParams)
+			if err != nil || len(completion.Choices) == 0 || completion.Choices[0].Message.Content == "" {
+				t.Fatalf("chat completion = %#v, error = %v", completion, err)
+			}
+
+			if os.Getenv("BEDROCK_LIVE_STREAM") == "1" {
+				stream := client.Chat.Completions.NewStreaming(context.Background(), chatParams)
+				var content string
+				for stream.Next() {
+					if choices := stream.Current().Choices; len(choices) != 0 {
+						content += choices[0].Delta.Content
+					}
+				}
+				if streamErr := stream.Err(); streamErr != nil || content == "" {
+					t.Fatalf("chat stream content = %q, error = %v", content, streamErr)
+				}
+			}
+
+			if os.Getenv("BEDROCK_LIVE_RESPONSES") != "1" {
+				return
+			}
+			responseParams := responses.ResponseNewParams{
+				Model: openai.ChatModel(model),
+				Input: responses.ResponseNewParamsInputUnion{OfString: openai.String("Reply with exactly: bedrock live test passed")},
+			}
+			response, err := client.Responses.New(context.Background(), responseParams)
+			if err != nil || response.OutputText() == "" {
+				t.Fatalf("response = %#v, error = %v", response, err)
+			}
+			if os.Getenv("BEDROCK_LIVE_STREAM") == "1" {
+				stream := client.Responses.NewStreaming(context.Background(), responseParams)
+				var content string
+				for stream.Next() {
+					content += stream.Current().Delta
+				}
+				if streamErr := stream.Err(); streamErr != nil || content == "" {
+					t.Fatalf("response stream content = %q, error = %v", content, streamErr)
+				}
+			}
+		})
+	}
+}
+
+func liveRuntimeConfig(t *testing.T, mode string) Config {
+	t.Helper()
+	config := Config{Endpoint: EndpointRuntime}
+	switch mode {
+	case "bearer":
+		config.APIKey = requiredLiveRuntimeEnv(t, "AWS_BEARER_TOKEN_BEDROCK")
+	case "environment-bearer":
+		requiredLiveRuntimeEnv(t, "AWS_BEARER_TOKEN_BEDROCK")
+	case "token-provider":
+		requiredLiveRuntimeEnv(t, "AWS_BEARER_TOKEN_BEDROCK")
+		config.BedrockTokenProvider = func(context.Context) (string, error) {
+			token := strings.TrimSpace(os.Getenv("AWS_BEARER_TOKEN_BEDROCK"))
+			if token == "" {
+				return "", fmt.Errorf("AWS_BEARER_TOKEN_BEDROCK is no longer configured")
+			}
+			return token, nil
+		}
+	case "default-chain":
+		if os.Getenv("AWS_BEARER_TOKEN_BEDROCK") != "" {
+			t.Fatal("unset AWS_BEARER_TOKEN_BEDROCK to select default-chain SigV4 authentication")
+		}
+	case "profile":
+		config.AWSProfile = requiredLiveRuntimeEnv(t, "AWS_PROFILE")
+	case "static":
+		config.AWSAccessKeyID = requiredLiveRuntimeEnv(t, "AWS_ACCESS_KEY_ID")
+		config.AWSSecretAccessKey = requiredLiveRuntimeEnv(t, "AWS_SECRET_ACCESS_KEY")
+		config.AWSSessionToken = strings.TrimSpace(os.Getenv("AWS_SESSION_TOKEN"))
+	case "custom-provider":
+		requiredLiveRuntimeEnv(t, "AWS_ACCESS_KEY_ID")
+		requiredLiveRuntimeEnv(t, "AWS_SECRET_ACCESS_KEY")
+		config.AWSCredentialsProvider = aws.CredentialsProviderFunc(func(context.Context) (aws.Credentials, error) {
+			accessKeyID := strings.TrimSpace(os.Getenv("AWS_ACCESS_KEY_ID"))
+			secretAccessKey := strings.TrimSpace(os.Getenv("AWS_SECRET_ACCESS_KEY"))
+			if accessKeyID == "" || secretAccessKey == "" {
+				return aws.Credentials{}, fmt.Errorf("AWS static credentials are no longer configured")
+			}
+			return aws.Credentials{
+				AccessKeyID:     accessKeyID,
+				SecretAccessKey: secretAccessKey,
+				SessionToken:    strings.TrimSpace(os.Getenv("AWS_SESSION_TOKEN")),
+			}, nil
+		})
+	default:
+		t.Fatalf("unsupported BEDROCK_LIVE_AUTH %q; use bearer, environment-bearer, token-provider, default-chain, profile, static, or custom-provider", mode)
+	}
+	return config
+}
+
+func requiredLiveRuntimeEnv(t *testing.T, name string) string {
+	t.Helper()
+	value := strings.TrimSpace(os.Getenv(name))
+	if value == "" {
+		t.Fatalf("set %s before making live Amazon Bedrock requests", name)
+	}
+	return value
+}

--- a/bedrock/runtime_test.go
+++ b/bedrock/runtime_test.go
@@ -1,0 +1,336 @@
+package bedrock
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+	"github.com/openai/openai-go/v3/responses"
+)
+
+func TestBedrockEndpointResolution(t *testing.T) {
+	clearAWSEnvironment(t)
+	tests := []struct {
+		name     string
+		config   Config
+		endpoint Endpoint
+		baseURL  string
+	}{
+		{"Mantle default", Config{APIKey: "token", AWSRegion: "us-east-1"}, EndpointMantle, "https://bedrock-mantle.us-east-1.api.aws/openai/v1/"},
+		{"Runtime standard", Config{Endpoint: EndpointRuntime, APIKey: "token", AWSRegion: "us-east-1"}, EndpointRuntime, "https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1/"},
+		{"Runtime China", Config{Endpoint: EndpointRuntime, APIKey: "token", AWSRegion: "cn-north-1"}, EndpointRuntime, "https://bedrock-runtime.cn-north-1.amazonaws.com.cn/openai/v1/"},
+		{"Runtime European sovereign", Config{Endpoint: EndpointRuntime, APIKey: "token", AWSRegion: "eusc-de-east-1"}, EndpointRuntime, "https://bedrock-runtime.eusc-de-east-1.amazonaws.eu/openai/v1/"},
+		{"Runtime ISO", Config{Endpoint: EndpointRuntime, APIKey: "token", AWSRegion: "us-iso-east-1"}, EndpointRuntime, "https://bedrock-runtime.us-iso-east-1.c2s.ic.gov/openai/v1/"},
+		{"Runtime ISOB", Config{Endpoint: EndpointRuntime, APIKey: "token", AWSRegion: "us-isob-east-1"}, EndpointRuntime, "https://bedrock-runtime.us-isob-east-1.sc2s.sgov.gov/openai/v1/"},
+		{"Runtime ISOE", Config{Endpoint: EndpointRuntime, APIKey: "token", AWSRegion: "eu-isoe-west-1"}, EndpointRuntime, "https://bedrock-runtime.eu-isoe-west-1.cloud.adc-e.uk/openai/v1/"},
+		{"Runtime ISOF", Config{Endpoint: EndpointRuntime, APIKey: "token", AWSRegion: "us-isof-south-1"}, EndpointRuntime, "https://bedrock-runtime.us-isof-south-1.csp.hci.ic.gov/openai/v1/"},
+		{"Runtime inferred", Config{APIKey: "token", BaseURL: "https://bedrock-runtime.us-west-2.amazonaws.com/openai/v1"}, EndpointRuntime, "https://bedrock-runtime.us-west-2.amazonaws.com/openai/v1/"},
+		{"Runtime FIPS inferred", Config{APIKey: "token", BaseURL: "https://bedrock-runtime-fips.us-west-2.amazonaws.com/openai/v1"}, EndpointRuntime, "https://bedrock-runtime-fips.us-west-2.amazonaws.com/openai/v1/"},
+		{"Runtime dual stack inferred", Config{APIKey: "token", BaseURL: "https://bedrock-runtime.us-west-2.api.aws/openai/v1"}, EndpointRuntime, "https://bedrock-runtime.us-west-2.api.aws/openai/v1/"},
+		{"Runtime China dual stack inferred", Config{APIKey: "token", BaseURL: "https://bedrock-runtime.cn-north-1.api.amazonwebservices.com.cn/openai/v1"}, EndpointRuntime, "https://bedrock-runtime.cn-north-1.api.amazonwebservices.com.cn/openai/v1/"},
+		{"Runtime trailing dot inferred", Config{APIKey: "token", BaseURL: "https://bedrock-runtime.us-west-2.amazonaws.com./openai/v1"}, EndpointRuntime, "https://bedrock-runtime.us-west-2.amazonaws.com./openai/v1/"},
+		{"Runtime alternate route", Config{Endpoint: EndpointRuntime, APIKey: "token", BaseURL: "https://bedrock-runtime.us-west-2.amazonaws.com/v1"}, EndpointRuntime, "https://bedrock-runtime.us-west-2.amazonaws.com/v1/"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			resolved, err := resolveConfig(context.Background(), test.config, time.Now)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if resolved.endpoint != test.endpoint || resolved.baseURL.String() != test.baseURL {
+				t.Fatalf("endpoint = %q, URL = %q; want %q, %q", resolved.endpoint, resolved.baseURL, test.endpoint, test.baseURL)
+			}
+		})
+	}
+}
+
+func TestBedrockEndpointValidation(t *testing.T) {
+	clearAWSEnvironment(t)
+	tests := []struct {
+		name    string
+		config  Config
+		message string
+	}{
+		{"unknown endpoint", Config{Endpoint: "unknown", APIKey: "token", AWSRegion: "us-east-1"}, "EndpointMantle` or `EndpointRuntime"},
+		{"Runtime HTTP", Config{APIKey: "token", BaseURL: "http://bedrock-runtime.us-east-1.amazonaws.com/openai/v1"}, "require HTTPS"},
+		{"Mantle HTTP", Config{APIKey: "token", BaseURL: "http://bedrock-mantle.us-east-1.api.aws/openai/v1"}, "require HTTPS"},
+		{"Runtime hostname mismatch", Config{Endpoint: EndpointMantle, APIKey: "token", BaseURL: "https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1"}, "does not match"},
+		{"Mantle hostname mismatch", Config{Endpoint: EndpointRuntime, APIKey: "token", BaseURL: "https://bedrock-mantle.us-east-1.api.aws/openai/v1"}, "does not match"},
+		{"Runtime region mismatch", Config{APIKey: "token", AWSRegion: "us-west-2", BaseURL: "https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1"}, "does not match"},
+		{"Runtime malformed region", Config{APIKey: "token", BaseURL: "https://bedrock-runtime.us--east-1.amazonaws.com/openai/v1"}, "invalid AWS region"},
+		{"custom SigV4 endpoint", Config{AWSRegion: "us-east-1", AWSAccessKeyID: "access", AWSSecretAccessKey: "secret", BaseURL: "https://proxy.example/openai/v1"}, "requires an explicit `Endpoint`"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := NewClient(context.Background(), test.config)
+			if err == nil || !strings.Contains(err.Error(), test.message) {
+				t.Fatalf("error = %v, want substring %q", err, test.message)
+			}
+		})
+	}
+}
+
+func TestRuntimeChatAndResponsesAuthentication(t *testing.T) {
+	clearAWSEnvironment(t)
+	models := []string{"us.openai.gpt-5.6-sol", "us.openai.gpt-5.6-terra", "us.openai.gpt-5.6-luna"}
+	for _, authentication := range []string{"bearer", "SigV4"} {
+		for _, api := range []string{"chat", "responses"} {
+			for _, streaming := range []bool{false, true} {
+				for _, model := range models {
+					t.Run(fmt.Sprintf("%s/%s/stream=%t/%s", authentication, api, streaming, model), func(t *testing.T) {
+						config := Config{Endpoint: EndpointRuntime, AWSRegion: "us-east-1"}
+						if authentication == "bearer" {
+							config.APIKey = "runtime-token"
+						} else {
+							config.AWSAccessKeyID = "runtime-access-key"
+							config.AWSSecretAccessKey = "runtime-secret-key"
+							config.AWSSessionToken = "runtime-session-token"
+						}
+
+						client, err := NewClient(context.Background(), config,
+							option.WithMaxRetries(0),
+							option.WithHTTPClient(&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+								assertRuntimeRequest(t, req, authentication, api, streaming, model)
+								return runtimeResponse(req, api, streaming, model), nil
+							})}),
+						)
+						if err != nil {
+							t.Fatal(err)
+						}
+
+						if api == "chat" {
+							params := openai.ChatCompletionNewParams{
+								Model:    openai.ChatModel(model),
+								Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hello")},
+							}
+							if streaming {
+								stream := client.Chat.Completions.NewStreaming(context.Background(), params)
+								var content string
+								for stream.Next() {
+									if choices := stream.Current().Choices; len(choices) != 0 {
+										content += choices[0].Delta.Content
+									}
+								}
+								if err := stream.Err(); err != nil || content != "hello" {
+									t.Fatalf("stream content = %q, error = %v", content, err)
+								}
+							} else {
+								completion, err := client.Chat.Completions.New(context.Background(), params)
+								if err != nil || len(completion.Choices) != 1 || completion.Choices[0].Message.Content != "hello" {
+									t.Fatalf("completion = %#v, error = %v", completion, err)
+								}
+							}
+							return
+						}
+
+						params := responses.ResponseNewParams{
+							Model: openai.ChatModel(model),
+							Input: responses.ResponseNewParamsInputUnion{OfString: openai.String("hello")},
+						}
+						if streaming {
+							stream := client.Responses.NewStreaming(context.Background(), params)
+							var content string
+							var completed bool
+							for stream.Next() {
+								event := stream.Current()
+								content += event.Delta
+								completed = completed || event.Type == "response.completed"
+							}
+							if err := stream.Err(); err != nil || content != "hello" || !completed {
+								t.Fatalf("stream content = %q, completed = %t, error = %v", content, completed, err)
+							}
+						} else {
+							response, err := client.Responses.New(context.Background(), params)
+							if err != nil || response.OutputText() != "hello" {
+								t.Fatalf("response = %#v, error = %v", response, err)
+							}
+						}
+					})
+				}
+			}
+		}
+	}
+}
+
+func assertRuntimeRequest(t *testing.T, req *http.Request, authentication, api string, streaming bool, model string) {
+	t.Helper()
+	path := "/openai/v1/" + api
+	if api == "chat" {
+		path = "/openai/v1/chat/completions"
+	}
+	if req.URL.Host != "bedrock-runtime.us-east-1.amazonaws.com" || req.URL.Path != path {
+		t.Fatalf("request URL = %q, want Runtime host and path %q", req.URL, path)
+	}
+	authorization := req.Header.Get("Authorization")
+	if authentication == "bearer" {
+		if authorization != "Bearer runtime-token" {
+			t.Fatalf("authorization = %q", authorization)
+		}
+	} else if !strings.Contains(authorization, "Credential=runtime-access-key/") ||
+		!strings.Contains(authorization, "/us-east-1/bedrock/aws4_request") ||
+		req.Header.Get("X-Amz-Security-Token") != "runtime-session-token" {
+		t.Fatalf("unexpected SigV4 credentials or session token: authorization = %q", authorization)
+	}
+	var body struct {
+		Model  string `json:"model"`
+		Stream bool   `json:"stream"`
+	}
+	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Model != model || body.Stream != streaming {
+		t.Fatalf("body model = %q, stream = %t; want %q, %t", body.Model, body.Stream, model, streaming)
+	}
+}
+
+func runtimeResponse(req *http.Request, api string, streaming bool, model string) *http.Response {
+	var body string
+	contentType := "application/json"
+	if api == "chat" {
+		if streaming {
+			contentType = "text/event-stream"
+			body = fmt.Sprintf("data: {\"id\":\"chat_runtime\",\"object\":\"chat.completion.chunk\",\"model\":%q,\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hello\"}}]}\n\ndata: [DONE]\n\n", model)
+		} else {
+			body = fmt.Sprintf(`{"id":"chat_runtime","object":"chat.completion","model":%q,"choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}]}`, model)
+		}
+	} else {
+		response := fmt.Sprintf(`{"id":"resp_runtime","object":"response","model":%q,"status":"completed","output":[{"id":"msg_runtime","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"hello","annotations":[]}]}]}`, model)
+		if streaming {
+			contentType = "text/event-stream"
+			body = "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"hello\",\"item_id\":\"msg_runtime\",\"output_index\":0,\"content_index\":0,\"sequence_number\":1}\n\n" +
+				"event: response.completed\ndata: {\"type\":\"response.completed\",\"sequence_number\":2,\"response\":" + response + "}\n\n"
+		} else {
+			body = response
+		}
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": {contentType}, "X-Request-Id": {"req_runtime"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    req,
+	}
+}
+
+func TestRuntimeCustomHostUsesSelectedSigner(t *testing.T) {
+	clearAWSEnvironment(t)
+	for _, endpoint := range []Endpoint{EndpointMantle, EndpointRuntime} {
+		t.Run(string(endpoint), func(t *testing.T) {
+			var authorization string
+			client, err := NewClient(context.Background(), Config{
+				Endpoint:           endpoint,
+				AWSRegion:          "us-east-1",
+				AWSAccessKeyID:     "access",
+				AWSSecretAccessKey: "secret",
+				BaseURL:            "https://proxy.example/openai/v1",
+			}, option.WithHTTPClient(&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				authorization = req.Header.Get("Authorization")
+				return successfulResponse(req), nil
+			})}))
+			if err != nil {
+				t.Fatal(err)
+			}
+			var response *http.Response
+			if err := client.Get(context.Background(), "/models", nil, &response); err != nil {
+				t.Fatal(err)
+			}
+			service := bedrockService
+			if endpoint == EndpointRuntime {
+				service = bedrockRuntimeService
+			}
+			if !strings.Contains(authorization, "/us-east-1/"+service+"/aws4_request") {
+				t.Fatalf("authorization = %q, want signing service %q", authorization, service)
+			}
+		})
+	}
+}
+
+func TestRuntimeCanonicalHostInfersSigningService(t *testing.T) {
+	clearAWSEnvironment(t)
+	var authorization string
+	client, err := NewClient(context.Background(), Config{
+		AWSAccessKeyID:     "access",
+		AWSSecretAccessKey: "secret",
+		BaseURL:            "https://bedrock-runtime-fips.us-east-1.api.aws/openai/v1",
+	}, option.WithHTTPClient(&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		authorization = req.Header.Get("Authorization")
+		return successfulResponse(req), nil
+	})}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var response *http.Response
+	if err := client.Get(context.Background(), "/models", nil, &response); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(authorization, "/us-east-1/bedrock/aws4_request") {
+		t.Fatalf("authorization = %q, want inferred Runtime signer", authorization)
+	}
+}
+
+func TestRuntimeRetriesRefreshAuthentication(t *testing.T) {
+	clearAWSEnvironment(t)
+	for _, authentication := range []string{"bearer", "SigV4"} {
+		t.Run(authentication, func(t *testing.T) {
+			config := Config{Endpoint: EndpointRuntime, AWSRegion: "us-east-1"}
+			var providerCalls int
+			if authentication == "bearer" {
+				config.BedrockTokenProvider = func(context.Context) (string, error) {
+					providerCalls++
+					return fmt.Sprintf("runtime-token-%d", providerCalls), nil
+				}
+			} else {
+				config.AWSAccessKeyID = "access"
+				config.AWSSecretAccessKey = "secret"
+			}
+
+			var authorizations []string
+			var clockCalls int
+			clock := func() time.Time {
+				clockCalls++
+				return time.Date(2025, 1, 2, 3, clockCalls, 5, 0, time.UTC)
+			}
+			opts, err := newClientOptions(context.Background(), config, clock,
+				option.WithMaxRetries(1),
+				option.WithHTTPClient(&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+					authorizations = append(authorizations, req.Header.Get("Authorization"))
+					if len(authorizations) == 1 {
+						return &http.Response{
+							StatusCode: http.StatusTooManyRequests,
+							Header:     http.Header{"Content-Type": {"application/json"}, "Retry-After": {"0"}},
+							Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"retry"}}`)),
+							Request:    req,
+						}, nil
+					}
+					return runtimeResponse(req, "chat", false, "us.openai.gpt-5.6-sol"), nil
+				})}),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			client := openai.NewClient(opts...)
+			completion, err := client.Chat.Completions.New(context.Background(), openai.ChatCompletionNewParams{
+				Model:    openai.ChatModel("us.openai.gpt-5.6-sol"),
+				Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hello")},
+			})
+			if err != nil || completion.Choices[0].Message.Content != "hello" {
+				t.Fatalf("completion = %#v, error = %v", completion, err)
+			}
+			if len(authorizations) != 2 || authorizations[0] == authorizations[1] {
+				t.Fatalf("authorization attempts = %v, want two independently refreshed values", authorizations)
+			}
+			if authentication == "bearer" && providerCalls != 2 {
+				t.Fatalf("bearer provider calls = %d, want 2", providerCalls)
+			}
+			if authentication == "SigV4" && !strings.Contains(authorizations[1], "/us-east-1/bedrock/aws4_request") {
+				t.Fatalf("retry authorization = %q, want Runtime signer", authorizations[1])
+			}
+		})
+	}
+}

--- a/bedrock/runtime_test.go
+++ b/bedrock/runtime_test.go
@@ -24,6 +24,8 @@ func TestBedrockEndpointResolution(t *testing.T) {
 		baseURL  string
 	}{
 		{"Mantle default", Config{APIKey: "token", AWSRegion: "us-east-1"}, EndpointMantle, "https://bedrock-mantle.us-east-1.api.aws/openai/v1/"},
+		{"custom SigV4 Mantle default", Config{AWSRegion: "us-east-1", AWSAccessKeyID: "access", AWSSecretAccessKey: "secret", BaseURL: "https://proxy.example/openai/v1"}, EndpointMantle, "https://proxy.example/openai/v1/"},
+		{"custom SigV4 Runtime", Config{Endpoint: EndpointRuntime, AWSRegion: "us-east-1", AWSAccessKeyID: "access", AWSSecretAccessKey: "secret", BaseURL: "https://proxy.example/openai/v1"}, EndpointRuntime, "https://proxy.example/openai/v1/"},
 		{"Runtime standard", Config{Endpoint: EndpointRuntime, APIKey: "token", AWSRegion: "us-east-1"}, EndpointRuntime, "https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1/"},
 		{"Runtime China", Config{Endpoint: EndpointRuntime, APIKey: "token", AWSRegion: "cn-north-1"}, EndpointRuntime, "https://bedrock-runtime.cn-north-1.amazonaws.com.cn/openai/v1/"},
 		{"Runtime European sovereign", Config{Endpoint: EndpointRuntime, APIKey: "token", AWSRegion: "eusc-de-east-1"}, EndpointRuntime, "https://bedrock-runtime.eusc-de-east-1.amazonaws.eu/openai/v1/"},
@@ -68,7 +70,6 @@ func TestBedrockEndpointValidation(t *testing.T) {
 		{"Runtime incomplete configured region", Config{Endpoint: EndpointRuntime, APIKey: "token", AWSRegion: "us-east"}, "invalid AWS region"},
 		{"Runtime incomplete canonical region", Config{APIKey: "token", BaseURL: "https://bedrock-runtime.us-east.amazonaws.com/openai/v1"}, "invalid AWS region"},
 		{"Runtime digit-leading region", Config{Endpoint: EndpointRuntime, APIKey: "token", AWSRegion: "1s-east-1"}, "invalid AWS region"},
-		{"custom SigV4 endpoint", Config{AWSRegion: "us-east-1", AWSAccessKeyID: "access", AWSSecretAccessKey: "secret", BaseURL: "https://proxy.example/openai/v1"}, "requires an explicit `Endpoint`"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -223,16 +224,32 @@ func runtimeResponse(req *http.Request, api string, streaming bool, model string
 
 func TestRuntimeCustomHostUsesSelectedSigner(t *testing.T) {
 	clearAWSEnvironment(t)
-	for _, endpoint := range []Endpoint{EndpointMantle, EndpointRuntime} {
-		t.Run(string(endpoint), func(t *testing.T) {
+	tests := []struct {
+		name        string
+		endpoint    Endpoint
+		environment bool
+	}{
+		{"default Mantle", "", false},
+		{"explicit Mantle", EndpointMantle, false},
+		{"explicit Runtime", EndpointRuntime, false},
+		{"environment Mantle", "", true},
+		{"environment Runtime", EndpointRuntime, true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
 			var authorization string
-			client, err := NewClient(context.Background(), Config{
-				Endpoint:           endpoint,
+			config := Config{
+				Endpoint:           test.endpoint,
 				AWSRegion:          "us-east-1",
 				AWSAccessKeyID:     "access",
 				AWSSecretAccessKey: "secret",
-				BaseURL:            "https://proxy.example/openai/v1",
-			}, option.WithHTTPClient(&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			}
+			if test.environment {
+				t.Setenv("AWS_BEDROCK_BASE_URL", "https://proxy.example/openai/v1")
+			} else {
+				config.BaseURL = "https://proxy.example/openai/v1"
+			}
+			client, err := NewClient(context.Background(), config, option.WithHTTPClient(&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 				authorization = req.Header.Get("Authorization")
 				return successfulResponse(req), nil
 			})}))
@@ -244,7 +261,7 @@ func TestRuntimeCustomHostUsesSelectedSigner(t *testing.T) {
 				t.Fatal(err)
 			}
 			service := bedrockService
-			if endpoint == EndpointRuntime {
+			if test.endpoint == EndpointRuntime {
 				service = bedrockRuntimeService
 			}
 			if !strings.Contains(authorization, "/us-east-1/"+service+"/aws4_request") {

--- a/bedrock/runtime_test.go
+++ b/bedrock/runtime_test.go
@@ -65,6 +65,9 @@ func TestBedrockEndpointValidation(t *testing.T) {
 		{"Mantle hostname mismatch", Config{Endpoint: EndpointRuntime, APIKey: "token", BaseURL: "https://bedrock-mantle.us-east-1.api.aws/openai/v1"}, "does not match"},
 		{"Runtime region mismatch", Config{APIKey: "token", AWSRegion: "us-west-2", BaseURL: "https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1"}, "does not match"},
 		{"Runtime malformed region", Config{APIKey: "token", BaseURL: "https://bedrock-runtime.us--east-1.amazonaws.com/openai/v1"}, "invalid AWS region"},
+		{"Runtime incomplete configured region", Config{Endpoint: EndpointRuntime, APIKey: "token", AWSRegion: "us-east"}, "invalid AWS region"},
+		{"Runtime incomplete canonical region", Config{APIKey: "token", BaseURL: "https://bedrock-runtime.us-east.amazonaws.com/openai/v1"}, "invalid AWS region"},
+		{"Runtime digit-leading region", Config{Endpoint: EndpointRuntime, APIKey: "token", AWSRegion: "1s-east-1"}, "invalid AWS region"},
 		{"custom SigV4 endpoint", Config{AWSRegion: "us-east-1", AWSAccessKeyID: "access", AWSSecretAccessKey: "secret", BaseURL: "https://proxy.example/openai/v1"}, "requires an explicit `Endpoint`"},
 	}
 	for _, test := range tests {

--- a/examples/bedrock-runtime/main.go
+++ b/examples/bedrock-runtime/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/bedrock"
+)
+
+func main() {
+	ctx := context.Background()
+	config := bedrock.Config{Endpoint: bedrock.EndpointRuntime, AWSRegion: os.Getenv("AWS_REGION")}
+	switch authentication := os.Getenv("BEDROCK_AUTH"); authentication {
+	case "", "sigv4":
+		// The explicit SigV4 example must not silently select an ambient bearer.
+		if err := os.Unsetenv("AWS_BEARER_TOKEN_BEDROCK"); err != nil {
+			panic(err)
+		}
+	case "bearer":
+		config.APIKey = os.Getenv("AWS_BEARER_TOKEN_BEDROCK")
+		if config.APIKey == "" {
+			panic("bearer authentication requires AWS_BEARER_TOKEN_BEDROCK")
+		}
+	default:
+		panic("BEDROCK_AUTH must be sigv4 or bearer")
+	}
+	client, err := bedrock.NewClient(ctx, config)
+	if err != nil {
+		panic(err)
+	}
+
+	model := os.Getenv("BEDROCK_MODEL")
+	if model == "" {
+		model = "us.openai.gpt-5.6-sol"
+	}
+	params := openai.ChatCompletionNewParams{
+		Model:    openai.ChatModel(model),
+		Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("Say hello from Amazon Bedrock Runtime!")},
+	}
+	if os.Getenv("BEDROCK_STREAM") == "1" {
+		stream := client.Chat.Completions.NewStreaming(ctx, params)
+		for stream.Next() {
+			if choices := stream.Current().Choices; len(choices) != 0 {
+				fmt.Print(choices[0].Delta.Content)
+			}
+		}
+		if streamErr := stream.Err(); streamErr != nil {
+			panic(streamErr)
+		}
+		fmt.Println()
+		return
+	}
+
+	completion, err := client.Chat.Completions.New(ctx, params)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(completion.Choices[0].Message.Content)
+}


### PR DESCRIPTION
## Summary

Add Bedrock Runtime support to the existing handwritten Go Bedrock provider while preserving Mantle as the default.

```go
client, err := bedrock.NewClient(ctx, bedrock.Config{
    Endpoint:  bedrock.EndpointRuntime,
    AWSRegion: "us-east-1",
})
```

- Add typed `bedrock.EndpointMantle` / `bedrock.EndpointRuntime` configuration; existing Mantle clients and its `/openai/v1` route remain unchanged.
- Derive partition-specific Runtime hostnames, default to `/openai/v1`, and sign Runtime requests for AWS service `bedrock` rather than `bedrock-mantle`.
- Infer endpoint family and region from canonical standard/FIPS/dual-stack AWS hostnames; reject canonical plaintext, endpoint-family mismatches, and region mismatches.
- Require explicit endpoint selection before signing a custom/proxy hostname, while continuing to permit explicitly configured custom HTTP transports.
- Preserve bearer, refreshable token providers, default AWS credentials, named profiles, static/session credentials, credential-provider precedence, per-attempt re-signing, redirect safety, and origin restrictions.
- Add dedicated `bedrock/README.md`, a runnable Runtime Chat/streaming example, and a strictly guarded 7-mode live-validation harness. The generated root README is unchanged.

## Verification

- Complete root SDK suite passed against the repository's Steady OpenAPI mock server: `go test ./...`.
- All examples passed: `go -C examples test ./...`.
- External consumer passed: `go -C internal/testdata/consumer test -mod=readonly ./...`.
- Bedrock race detector passed: `go test -race ./bedrock`.
- Full repository lint/static analysis, Windows-example lint, formatting, builds, and compile checks passed: `./scripts/lint`.
- All four module tidy checks passed: `./scripts/check-go-mod`.
- Runtime unit matrix covers bearer/SigV4 × Chat/Responses × streaming/non-streaming × Sol/Terra/Luna, all seven AWS partitions, FIPS/dual-stack/trailing-dot overrides, canonical security, custom proxies, inference, and 429 retry refresh/re-signing.
- Guarded live harness passed **84 actual local loopback requests** across bearer, environment bearer, refreshable token provider, default AWS chain, named profile, static/session credentials, and custom provider × three inference profiles × Chat/Responses × streaming/non-streaming.

## Live AWS evidence

No real AWS requests were made for this change. Existing SDK-290 validation confirms non-streaming Runtime Chat with SigV4 service `bedrock`; Responses, bearer acceptance, streaming, Global CRIS, and alternate `/v1` routes remain deployment-dependent and are documented accordingly.

Refs: SDK-290
Template: https://github.com/openai/openai-node/pull/2348