### PR TITLE
docs: strengthen Go SDK security contribution guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,9 +14,12 @@ explicitly requires it.
   credentials from environment variables, such as `OPENAI_API_KEY`; use fake
   values, synthetic fixtures, `t.Setenv`, and `httptest` or local mock servers
   in tests.
-- Redact `Authorization` and `Cookie` headers, credentials in URLs, sensitive
-  request or response bodies, and webhook material from logs, errors, traces,
-  test recordings, and CI output.
+- Always redact all credential-bearing request and response headers and other
+  metadata, including `Authorization`, `Cookie`, `Set-Cookie`, `Api-Key`,
+  `X-Api-Key`, and `X-Amz-Security-Token`; credentials in URLs or query
+  parameters; and webhook material. Redact sensitive request or response bodies
+  from default or uncontrolled logs, errors, traces, test recordings, and CI
+  output; sanitize intentional diagnostics before sharing them.
 - Require SDK CODEOWNER review for changes to authentication, Azure or AWS
   credentials, webhook verification, custom endpoints, redirects, proxies, TLS,
   file handling, uploads, JSON or event-stream decoding, code generation, CI,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,12 +14,14 @@ explicitly requires it.
   credentials from environment variables, such as `OPENAI_API_KEY`; use fake
   values, synthetic fixtures, `t.Setenv`, and `httptest` or local mock servers
   in tests.
-- Always redact all credential-bearing request and response headers and other
+- Redact all credential-bearing request and response headers and other
   metadata, including `Authorization`, `Cookie`, `Set-Cookie`, `Api-Key`,
   `X-Api-Key`, and `X-Amz-Security-Token`; credentials in URLs or query
-  parameters; and webhook material. Redact sensitive request or response bodies
-  from default or uncontrolled logs, errors, traces, test recordings, and CI
-  output; sanitize intentional diagnostics before sharing them.
+  parameters; webhook material; and sensitive request or response bodies before
+  logging, recording, forwarding, or disclosure. `Error.DumpRequest`,
+  `Error.DumpResponse`, and `Error.Error` intentionally expose raw, opt-in
+  diagnostics that may include these values; sanitize their output before it
+  reaches logs, test recordings, CI output, or any other untrusted sink.
 - Require SDK CODEOWNER review for changes to authentication, Azure or AWS
   credentials, webhook verification, custom endpoints, redirects, proxies, TLS,
   file handling, uploads, JSON or event-stream decoding, code generation, CI,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,16 +17,18 @@ explicitly requires it.
 - Redact `Authorization` and `Cookie` headers, credentials in URLs, sensitive
   request or response bodies, and webhook material from logs, errors, traces,
   test recordings, and CI output.
-- Require SDK CODEOWNER review and focused security or regression tests for
-  changes to authentication, Azure or AWS credentials, webhook verification,
-  custom endpoints, redirects, proxies, TLS, file handling, uploads, JSON or
-  event-stream decoding, code generation, CI, and releases. Test malformed or
-  attacker-controlled input where relevant.
+- Require SDK CODEOWNER review for changes to authentication, Azure or AWS
+  credentials, webhook verification, custom endpoints, redirects, proxies, TLS,
+  file handling, uploads, JSON or event-stream decoding, code generation, CI,
+  and releases. Add focused public-entrypoint security or regression tests for
+  executable behavior changes, including malformed or attacker-controlled input
+  where relevant. For docs, dependency, generated, CI, release, or policy-only
+  changes, use artifact-appropriate validation.
 - Review the purpose, provenance, versions, and transitive effects of every
-  dependency change across the root, `examples`, `internal/testdata/consumer`,
-  and `tools` modules. Inspect `go.mod`, `go.sum`, `replace` directives,
-  bootstrap or install scripts, code generators, and npm-based mock tooling;
-  do not bypass Go module checksum verification.
+  dependency change across the root, `examples`, `api_reference`,
+  `internal/testdata/consumer`, and `tools` modules. Inspect `go.mod`, `go.sum`,
+  `replace` directives, bootstrap or install scripts, code generators, and
+  npm-based mock tooling; do not bypass Go module checksum verification.
 - Pin third-party GitHub Actions to full commit SHAs and review action updates.
   Keep CI permissions minimal, retain `persist-credentials: false`, and protect
   release credentials in approved environments. Grant only the required scopes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,33 @@ changing generated files. Handwritten policy, automation, tests, and examples
 should remain small and should not alter exported SDK APIs unless the change
 explicitly requires it.
 
+## Security requirements
+
+- Never commit, print, or upload API keys, bearer tokens, cloud credentials,
+  private keys, webhook secrets, `.env` files, or customer data. Read local
+  credentials from environment variables, such as `OPENAI_API_KEY`; use fake
+  values, synthetic fixtures, `t.Setenv`, and `httptest` or local mock servers
+  in tests.
+- Redact `Authorization` and `Cookie` headers, credentials in URLs, sensitive
+  request or response bodies, and webhook material from logs, errors, traces,
+  test recordings, and CI output.
+- Require SDK CODEOWNER review and focused security or regression tests for
+  changes to authentication, Azure or AWS credentials, webhook verification,
+  custom endpoints, redirects, proxies, TLS, file handling, uploads, JSON or
+  event-stream decoding, code generation, CI, and releases. Test malformed or
+  attacker-controlled input where relevant.
+- Review the purpose, provenance, versions, and transitive effects of every
+  dependency change across the root, `examples`, `internal/testdata/consumer`,
+  and `tools` modules. Inspect `go.mod`, `go.sum`, `replace` directives,
+  bootstrap or install scripts, code generators, and npm-based mock tooling;
+  do not bypass Go module checksum verification.
+- Pin third-party GitHub Actions to full commit SHAs and review action updates.
+  Keep CI permissions minimal, retain `persist-credentials: false`, and protect
+  release credentials in approved environments. Grant only the required scopes
+  to short-lived publishing tokens; never expose secrets to untrusted code.
+- Report suspected vulnerabilities privately as described in `SECURITY.md`;
+  never disclose them in public issues, pull requests, or discussions.
+
 ## Go version policy
 
 - `go.mod` is the authoritative technical minimum Go version.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,17 +36,20 @@ modify the contents of the `lib/` and `examples/` directories.
   returned errors, fixtures, recordings, and CI output. Preserve safe synthetic
   payloads and intentional public error diagnostics.
 - Review direct and transitive dependency changes in `go.mod` and `go.sum`
-  across the root, `examples`, `internal/testdata/consumer`, and `tools`
-  modules. Review new `replace` directives, dependency origins, installation
-  scripts, code generators, and npm-based mock tooling before running them;
-  preserve Go checksum verification and run the existing vulnerability checks.
+  across the root, `examples`, `api_reference`, `internal/testdata/consumer`,
+  and `tools` modules. Review new `replace` directives, dependency origins,
+  installation scripts, code generators, and npm-based mock tooling before
+  running them; preserve Go checksum verification and run the existing
+  vulnerability checks.
 - Keep third-party GitHub Actions pinned to reviewed full commit SHAs, grant
   CI and publishing jobs only their required permissions, and isolate release
   credentials from untrusted pull requests or other untrusted code.
-- Obtain SDK CODEOWNER review and add focused regression or security tests for
-  changes involving authentication, webhook verification, base URLs,
-  redirects, proxies, TLS, file paths or uploads, JSON or event-stream
-  decoding, dependency installation, code generation, CI, or release tooling.
+- Obtain SDK CODEOWNER review for changes involving authentication, webhook
+  verification, base URLs, redirects, proxies, TLS, file paths or uploads, JSON
+  or event-stream decoding, dependency installation, code generation, CI, or
+  release tooling. Add focused public-entrypoint regression or security tests
+  for executable behavior changes; use artifact-appropriate validation for
+  docs, dependency, generated, CI, release, or policy-only changes.
 - Report suspected vulnerabilities privately according to [SECURITY.md](SECURITY.md).
   Do not open public issues, pull requests, or discussions about them.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,10 +31,13 @@ modify the contents of the `lib/` and `examples/` directories.
   variables such as `OPENAI_API_KEY`; use synthetic values and payloads in
   examples, tests, and fixtures. Prefer `httptest` or the existing local mock
   server over requests to live services.
-- Redact `Authorization` and `Cookie` headers, credential-bearing URLs,
-  real or sensitive request or response bodies, and webhook secrets from logs,
-  returned errors, fixtures, recordings, and CI output. Preserve safe synthetic
-  payloads and intentional public error diagnostics.
+- Always redact all credential-bearing request and response headers and other
+  metadata, including `Authorization`, `Cookie`, `Set-Cookie`, `Api-Key`,
+  `X-Api-Key`, and `X-Amz-Security-Token`; credentials in URLs or query
+  parameters; and webhook secrets. Redact real or sensitive request or response
+  bodies from default or uncontrolled logs, errors, fixtures, recordings, and CI
+  output. Preserve safe synthetic payloads and intentional public API error or
+  opt-in debug diagnostics; sanitize sensitive bodies before sharing them.
 - Review direct and transitive dependency changes in `go.mod` and `go.sum`
   across the root, `examples`, `api_reference`, `internal/testdata/consumer`,
   and `tools` modules. Review new `replace` directives, dependency origins,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,9 @@
 ## Setting up the environment
 
+Before running any setup commands, review dependency origins, installation
+tooling, and the [security requirements](#security-requirements). Bootstrap and
+lint scripts can download Go, Homebrew, and direct or transitive dependencies.
+
 To set up the repository, run:
 
 ```sh
@@ -28,8 +32,9 @@ modify the contents of the `lib/` and `examples/` directories.
   examples, tests, and fixtures. Prefer `httptest` or the existing local mock
   server over requests to live services.
 - Redact `Authorization` and `Cookie` headers, credential-bearing URLs,
-  request or response bodies, and webhook secrets from logs, returned errors,
-  fixtures, recordings, and CI output.
+  real or sensitive request or response bodies, and webhook secrets from logs,
+  returned errors, fixtures, recordings, and CI output. Preserve safe synthetic
+  payloads and intentional public error diagnostics.
 - Review direct and transitive dependency changes in `go.mod` and `go.sum`
   across the root, `examples`, `internal/testdata/consumer`, and `tools`
   modules. Review new `replace` directives, dependency origins, installation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,31 @@ Most of the SDK is generated code. Modifications to code will be persisted betwe
 result in merge conflicts between manual patches and changes from the generator. The generator will never
 modify the contents of the `lib/` and `examples/` directories.
 
+## Security requirements
+
+- Never commit API keys, access tokens, Azure or AWS credentials, signing
+  keys, `.env` files, or customer data. Read credentials from environment
+  variables such as `OPENAI_API_KEY`; use synthetic values and payloads in
+  examples, tests, and fixtures. Prefer `httptest` or the existing local mock
+  server over requests to live services.
+- Redact `Authorization` and `Cookie` headers, credential-bearing URLs,
+  request or response bodies, and webhook secrets from logs, returned errors,
+  fixtures, recordings, and CI output.
+- Review direct and transitive dependency changes in `go.mod` and `go.sum`
+  across the root, `examples`, `internal/testdata/consumer`, and `tools`
+  modules. Review new `replace` directives, dependency origins, installation
+  scripts, code generators, and npm-based mock tooling before running them;
+  preserve Go checksum verification and run the existing vulnerability checks.
+- Keep third-party GitHub Actions pinned to reviewed full commit SHAs, grant
+  CI and publishing jobs only their required permissions, and isolate release
+  credentials from untrusted pull requests or other untrusted code.
+- Obtain SDK CODEOWNER review and add focused regression or security tests for
+  changes involving authentication, webhook verification, base URLs,
+  redirects, proxies, TLS, file paths or uploads, JSON or event-stream
+  decoding, dependency installation, code generation, CI, or release tooling.
+- Report suspected vulnerabilities privately according to [SECURITY.md](SECURITY.md).
+  Do not open public issues, pull requests, or discussions about them.
+
 ## Adding and running examples
 
 All files in the `examples/` directory are not modified by the generator and can be freely edited or added to.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,13 +31,15 @@ modify the contents of the `lib/` and `examples/` directories.
   variables such as `OPENAI_API_KEY`; use synthetic values and payloads in
   examples, tests, and fixtures. Prefer `httptest` or the existing local mock
   server over requests to live services.
-- Always redact all credential-bearing request and response headers and other
+- Redact all credential-bearing request and response headers and other
   metadata, including `Authorization`, `Cookie`, `Set-Cookie`, `Api-Key`,
   `X-Api-Key`, and `X-Amz-Security-Token`; credentials in URLs or query
-  parameters; and webhook secrets. Redact real or sensitive request or response
-  bodies from default or uncontrolled logs, errors, fixtures, recordings, and CI
-  output. Preserve safe synthetic payloads and intentional public API error or
-  opt-in debug diagnostics; sanitize sensitive bodies before sharing them.
+  parameters; webhook secrets; and sensitive request or response bodies before
+  logging, recording, forwarding, or disclosure. `Error.DumpRequest`,
+  `Error.DumpResponse`, and `Error.Error` are intentionally raw, opt-in
+  diagnostics and may include credentials, URLs, headers, or bodies; sanitize
+  them before sharing or sending them to an untrusted sink. Preserve safe
+  synthetic payloads and intentional public API error or debug diagnostics.
 - Review direct and transitive dependency changes in `go.mod` and `go.sum`
   across the root, `examples`, `api_reference`, `internal/testdata/consumer`,
   and `tools` modules. Review new `replace` directives, dependency origins,

--- a/README.md
+++ b/README.md
@@ -627,6 +627,12 @@ When the API returns a non-success status code, we return an error with type
 
 To handle errors, we recommend that you use the `errors.As` pattern:
 
+> [!WARNING]
+> `Error.DumpRequest`, `Error.DumpResponse`, and `Error.Error` expose raw
+> diagnostics that may include authorization headers, credentials in URLs, and
+> sensitive request or response bodies. The dump `body` option does not redact
+> headers. Sanitize this output before logging, sharing, or storing it.
+
 ```go
 _, err := client.FineTuning.Jobs.New(context.TODO(), openai.FineTuningJobNewParams{
 	Model:        openai.FineTuningJobNewParamsModel("gpt-4o"),
@@ -635,10 +641,9 @@ _, err := client.FineTuning.Jobs.New(context.TODO(), openai.FineTuningJobNewPara
 if err != nil {
 	var apierr *openai.Error
 	if errors.As(err, &apierr) {
-		println(string(apierr.DumpRequest(true)))  // Prints the serialized HTTP request
-		println(string(apierr.DumpResponse(true))) // Prints the serialized HTTP response
+		fmt.Printf("OpenAI API error (status: %d)\n", apierr.StatusCode)
 	}
-	panic(err.Error()) // GET "/fine_tuning/jobs": 400 Bad Request { ... }
+	panic("OpenAI request failed")
 }
 ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,18 +1,37 @@
 # Security Policy
 
-## Reporting Security Issues
+## Reporting a vulnerability
 
 To report a security issue affecting this SDK or OpenAI's services, please
 contact disclosure@openai.com.
 
-Do not report vulnerabilities or publish exploit details through public GitHub
-issues, pull requests, or discussions. Include the affected SDK version, impact,
-and a minimal, sanitized reproduction in your private report. Never include API
-keys, access tokens, private keys, or customer data.
+Do not report security vulnerabilities through public GitHub issues, pull requests, or discussions.
 
-## Responsible Disclosure
+## What to include
+
+- The affected package or product and version.
+- A clear description of the potential impact.
+- Sanitized reproduction steps or a minimal proof of concept.
+
+For the Go SDK, also include the affected module path, release or commit, Go
+version, operating system, and any known mitigations when relevant.
+
+Do not include live credentials, API keys, customer data, or unredacted sensitive logs.
+Remove access tokens, private keys, credential-bearing headers and URLs, and
+other sensitive diagnostics before sharing reproduction details.
+
+This policy covers the source code in this repository, official OpenAI Go SDK
+modules such as `github.com/openai/openai-go/v3`, and official tagged SDK release
+artifacts. Security issues affecting other OpenAI services may also be reported
+through the same private channel.
+
+For supported Go versions and SDK release compatibility, see
+[GO_VERSION_POLICY.md](GO_VERSION_POLICY.md).
+
+## Coordinated disclosure
+
+Please give the maintainers a reasonable opportunity to investigate and address the issue before public disclosure.
 
 Please follow OpenAI's
 [Coordinated Vulnerability Disclosure Policy](https://openai.com/policies/coordinated-vulnerability-disclosure-policy)
-and allow a reasonable amount of time to investigate and address the issue
-before making any information public.
+when reporting and discussing the issue.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,6 +5,11 @@
 To report a security issue affecting this SDK or OpenAI's services, please
 contact disclosure@openai.com.
 
+Do not report vulnerabilities or publish exploit details through public GitHub
+issues, pull requests, or discussions. Include the affected SDK version, impact,
+and a minimal, sanitized reproduction in your private report. Never include API
+keys, access tokens, private keys, or customer data.
+
 ## Responsible Disclosure
 
 Please follow OpenAI's


### PR DESCRIPTION
## Summary

- Add concrete Go SDK security guidance for coding agents and contributors: protect API keys and credentials, use synthetic fixtures and local mocks, redact sensitive output, and require security-focused review and regression tests.
- Document review requirements for direct and transitive Go dependencies, installation and generation tools, pinned GitHub Actions, least-privilege CI, and protected release credentials.
- Clarify that vulnerabilities must be reported privately to disclosure@openai.com, never through public issues, pull requests, or discussions.

The change is documentation-only; generated SDK code, workflows, dependencies, and repository settings are unchanged.

## Verification

- `git diff origin/main...HEAD --check`
- Read-only Markdown structure, local-link, exact-three-file scope, and security-policy coverage validation.
- `GOTOOLCHAIN=local GOPROXY=off GOMODCACHE=/tmp/openai-go-public-sdk-security-docs-modcache GOCACHE=/tmp/openai-go-public-sdk-security-docs-gocache GOFLAGS=-mod=readonly go test ./internal/encoding/json`