### PR TITLE
fix(responses): decode shell output delta stream events

### DIFF
--- a/.castiron.stats.yml
+++ b/.castiron.stats.yml
@@ -1,6 +1,6 @@
 schema_version: 1
 generation_id: 72b1e1a8-2bcc-44e5-8f84-e190530d3ca7
 openapi_spec_hash: dd725fb7d43ceec7fb2de6f8713d14b6
-openapi_transformed_spec_hash: 10930179c5f116288e24e0c6fda46559
+openapi_transformed_spec_hash: 1c381652af5dacf14f1dc646d35e94e6
 config_hash: a7196180e219df1555dc3efbeb09495e
 codegen_sha: 4c2de90434c97141cceb1d931d61bbec669abab8

--- a/api_reference/openapi.transformed.yml
+++ b/api_reference/openapi.transformed.yml
@@ -54702,8 +54702,6 @@ components:
       - $ref: '#/components/schemas/ResponseShellCallCommandDeltaStreamingEvent'
       - $ref: '#/components/schemas/ResponseShellCallCommandDoneStreamingEvent'
       - $ref: '#/components/schemas/ResponseShellCallOutputContentDeltaStreamingEvent'
-        x-stainless-skip:
-        - go
       - $ref: '#/components/schemas/ResponseShellCallOutputContentDoneStreamingEvent'
       - $ref: '#/components/schemas/ResponseInProgressEvent'
       - $ref: '#/components/schemas/ResponseFailedEvent'
@@ -55393,8 +55391,6 @@ components:
         description: A streaming event that indicated shell call output was incrementally added.
         allOf:
         - $ref: '#/components/schemas/ResponseShellCallOutputContentDeltaStreamingEvent'
-          x-stainless-skip:
-          - go
         - type: object
           properties:
             stream_id:
@@ -55867,8 +55863,6 @@ components:
         - $ref: '#/components/schemas/ResponseShellCallCommandDeltaStreamingEvent'
         - $ref: '#/components/schemas/ResponseShellCallCommandDoneStreamingEvent'
         - $ref: '#/components/schemas/ResponseShellCallOutputContentDeltaStreamingEvent'
-          x-stainless-skip:
-          - go
         - $ref: '#/components/schemas/ResponseShellCallOutputContentDoneStreamingEvent'
         - $ref: '#/components/schemas/ResponseInProgressEvent'
         - $ref: '#/components/schemas/ResponseFailedEvent'
@@ -77727,8 +77721,6 @@ components:
         description: A streaming event that indicated shell call output was incrementally added.
         allOf:
         - $ref: '#/components/schemas/BetaResponseShellCallOutputContentDeltaStreamingEvent'
-          x-stainless-skip:
-          - go
         - type: object
           properties:
             stream_id:
@@ -78391,8 +78383,6 @@ components:
         - $ref: '#/components/schemas/BetaResponseShellCallCommandDeltaStreamingEvent'
         - $ref: '#/components/schemas/BetaResponseShellCallCommandDoneStreamingEvent'
         - $ref: '#/components/schemas/BetaResponseShellCallOutputContentDeltaStreamingEvent'
-          x-stainless-skip:
-          - go
         - $ref: '#/components/schemas/BetaResponseShellCallOutputContentDoneStreamingEvent'
         - $ref: '#/components/schemas/BetaResponseInProgressEvent'
         - $ref: '#/components/schemas/BetaResponseFailedEvent'
@@ -78773,8 +78763,6 @@ components:
       - $ref: '#/components/schemas/BetaResponseShellCallCommandDeltaStreamingEvent'
       - $ref: '#/components/schemas/BetaResponseShellCallCommandDoneStreamingEvent'
       - $ref: '#/components/schemas/BetaResponseShellCallOutputContentDeltaStreamingEvent'
-        x-stainless-skip:
-        - go
       - $ref: '#/components/schemas/BetaResponseShellCallOutputContentDoneStreamingEvent'
       - $ref: '#/components/schemas/BetaResponseInProgressEvent'
       - $ref: '#/components/schemas/BetaResponseFailedEvent'

--- a/betaresponse.go
+++ b/betaresponse.go
@@ -27582,6 +27582,7 @@ const (
 // [BetaResponseShellCallCommandAddedEvent],
 // [BetaResponseShellCallCommandDeltaEvent],
 // [BetaResponseShellCallCommandDoneEvent],
+// [BetaResponseShellCallOutputContentDeltaEvent],
 // [BetaResponseShellCallOutputContentDoneEvent], [BetaResponseInProgressEvent],
 // [BetaResponseFailedEvent], [BetaResponseIncompleteEvent],
 // [BetaResponseOutputItemAddedEvent], [BetaResponseOutputItemDoneEvent],
@@ -27816,6 +27817,7 @@ func (BetaResponseFunctionCallArgumentsDoneEvent) implBetaResponseStreamEventUni
 func (BetaResponseShellCallCommandAddedEvent) implBetaResponseStreamEventUnion()           {}
 func (BetaResponseShellCallCommandDeltaEvent) implBetaResponseStreamEventUnion()           {}
 func (BetaResponseShellCallCommandDoneEvent) implBetaResponseStreamEventUnion()            {}
+func (BetaResponseShellCallOutputContentDeltaEvent) implBetaResponseStreamEventUnion()     {}
 func (BetaResponseShellCallOutputContentDoneEvent) implBetaResponseStreamEventUnion()      {}
 func (BetaResponseInProgressEvent) implBetaResponseStreamEventUnion()                      {}
 func (BetaResponseFailedEvent) implBetaResponseStreamEventUnion()                          {}
@@ -27877,6 +27879,7 @@ func (BetaResponseCustomToolCallInputDoneEvent) implBetaResponseStreamEventUnion
 //	case openai.BetaResponseShellCallCommandAddedEvent:
 //	case openai.BetaResponseShellCallCommandDeltaEvent:
 //	case openai.BetaResponseShellCallCommandDoneEvent:
+//	case openai.BetaResponseShellCallOutputContentDeltaEvent:
 //	case openai.BetaResponseShellCallOutputContentDoneEvent:
 //	case openai.BetaResponseInProgressEvent:
 //	case openai.BetaResponseFailedEvent:
@@ -27961,6 +27964,8 @@ func (u BetaResponseStreamEventUnion) AsAny() anyBetaResponseStreamEvent {
 		return u.AsResponseShellCallCommandDelta()
 	case "response.shell_call_command.done":
 		return u.AsResponseShellCallCommandDone()
+	case "response.shell_call_output_content.delta":
+		return u.AsResponseShellCallOutputContentDelta()
 	case "response.shell_call_output_content.done":
 		return u.AsResponseShellCallOutputContentDone()
 	case "response.in_progress":
@@ -28141,6 +28146,11 @@ func (u BetaResponseStreamEventUnion) AsResponseShellCallCommandDelta() (v BetaR
 }
 
 func (u BetaResponseStreamEventUnion) AsResponseShellCallCommandDone() (v BetaResponseShellCallCommandDoneEvent) {
+	_ = apijson.UnmarshalRoot(json.RawMessage(u.JSON.raw), &v)
+	return
+}
+
+func (u BetaResponseStreamEventUnion) AsResponseShellCallOutputContentDelta() (v BetaResponseShellCallOutputContentDeltaEvent) {
 	_ = apijson.UnmarshalRoot(json.RawMessage(u.JSON.raw), &v)
 	return
 }

--- a/betaresponse_stream_event_test.go
+++ b/betaresponse_stream_event_test.go
@@ -1,0 +1,35 @@
+package openai_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	openai "github.com/openai/openai-go/v3"
+)
+
+func TestBetaResponseStreamEventShellCallOutputContentDelta(t *testing.T) {
+	raw := []byte(`{
+		"type": "response.shell_call_output_content.delta",
+		"sequence_number": 1,
+		"item_id": "sh_123",
+		"output_index": 0,
+		"command_index": 0,
+		"delta": {"stdout": "hello\n", "stderr": "warning\n"}
+	}`)
+
+	var event openai.BetaResponseStreamEventUnion
+	if err := json.Unmarshal(raw, &event); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	variant, ok := event.AsAny().(openai.BetaResponseShellCallOutputContentDeltaEvent)
+	if !ok {
+		t.Fatalf("AsAny() = %T, want BetaResponseShellCallOutputContentDeltaEvent", event.AsAny())
+	}
+	if variant.Delta.Stdout != "hello\n" {
+		t.Fatalf("Delta.Stdout = %q, want %q", variant.Delta.Stdout, "hello\n")
+	}
+	if variant.Delta.Stderr != "warning\n" {
+		t.Fatalf("Delta.Stderr = %q, want %q", variant.Delta.Stderr, "warning\n")
+	}
+}

--- a/responses/response.go
+++ b/responses/response.go
@@ -21966,6 +21966,7 @@ const (
 // [ResponseFunctionCallArgumentsDeltaEvent],
 // [ResponseFunctionCallArgumentsDoneEvent], [ResponseShellCallCommandAddedEvent],
 // [ResponseShellCallCommandDeltaEvent], [ResponseShellCallCommandDoneEvent],
+// [ResponseShellCallOutputContentDeltaEvent],
 // [ResponseShellCallOutputContentDoneEvent], [ResponseInProgressEvent],
 // [ResponseFailedEvent], [ResponseIncompleteEvent],
 // [ResponseOutputItemAddedEvent], [ResponseOutputItemDoneEvent],
@@ -22144,6 +22145,7 @@ func (ResponseFunctionCallArgumentsDoneEvent) implResponseStreamEventUnion()    
 func (ResponseShellCallCommandAddedEvent) implResponseStreamEventUnion()           {}
 func (ResponseShellCallCommandDeltaEvent) implResponseStreamEventUnion()           {}
 func (ResponseShellCallCommandDoneEvent) implResponseStreamEventUnion()            {}
+func (ResponseShellCallOutputContentDeltaEvent) implResponseStreamEventUnion()     {}
 func (ResponseShellCallOutputContentDoneEvent) implResponseStreamEventUnion()      {}
 func (ResponseInProgressEvent) implResponseStreamEventUnion()                      {}
 func (ResponseFailedEvent) implResponseStreamEventUnion()                          {}
@@ -22205,6 +22207,7 @@ func (ResponseCustomToolCallInputDoneEvent) implResponseStreamEventUnion()      
 //	case responses.ResponseShellCallCommandAddedEvent:
 //	case responses.ResponseShellCallCommandDeltaEvent:
 //	case responses.ResponseShellCallCommandDoneEvent:
+//	case responses.ResponseShellCallOutputContentDeltaEvent:
 //	case responses.ResponseShellCallOutputContentDoneEvent:
 //	case responses.ResponseInProgressEvent:
 //	case responses.ResponseFailedEvent:
@@ -22289,6 +22292,8 @@ func (u ResponseStreamEventUnion) AsAny() anyResponseStreamEvent {
 		return u.AsResponseShellCallCommandDelta()
 	case "response.shell_call_command.done":
 		return u.AsResponseShellCallCommandDone()
+	case "response.shell_call_output_content.delta":
+		return u.AsResponseShellCallOutputContentDelta()
 	case "response.shell_call_output_content.done":
 		return u.AsResponseShellCallOutputContentDone()
 	case "response.in_progress":
@@ -22469,6 +22474,11 @@ func (u ResponseStreamEventUnion) AsResponseShellCallCommandDelta() (v ResponseS
 }
 
 func (u ResponseStreamEventUnion) AsResponseShellCallCommandDone() (v ResponseShellCallCommandDoneEvent) {
+	_ = apijson.UnmarshalRoot(json.RawMessage(u.JSON.raw), &v)
+	return
+}
+
+func (u ResponseStreamEventUnion) AsResponseShellCallOutputContentDelta() (v ResponseShellCallOutputContentDeltaEvent) {
 	_ = apijson.UnmarshalRoot(json.RawMessage(u.JSON.raw), &v)
 	return
 }

--- a/responses/response_stream_event_test.go
+++ b/responses/response_stream_event_test.go
@@ -1,0 +1,35 @@
+package responses_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/openai/openai-go/v3/responses"
+)
+
+func TestResponseStreamEventShellCallOutputContentDelta(t *testing.T) {
+	raw := []byte(`{
+		"type": "response.shell_call_output_content.delta",
+		"sequence_number": 1,
+		"item_id": "sh_123",
+		"output_index": 0,
+		"command_index": 0,
+		"delta": {"stdout": "hello\n", "stderr": "warning\n"}
+	}`)
+
+	var event responses.ResponseStreamEventUnion
+	if err := json.Unmarshal(raw, &event); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	variant, ok := event.AsAny().(responses.ResponseShellCallOutputContentDeltaEvent)
+	if !ok {
+		t.Fatalf("AsAny() = %T, want ResponseShellCallOutputContentDeltaEvent", event.AsAny())
+	}
+	if variant.Delta.Stdout != "hello\n" {
+		t.Fatalf("Delta.Stdout = %q, want %q", variant.Delta.Stdout, "hello\n")
+	}
+	if variant.Delta.Stderr != "warning\n" {
+		t.Fatalf("Delta.Stderr = %q, want %q", variant.Delta.Stderr, "warning\n")
+	}
+}


### PR DESCRIPTION
## Summary

- remove the Go-only generator skip for `response.shell_call_output_content.delta` across stable/beta Responses and WebSocket stream schemas
- register the existing stable and beta concrete delta models in generated stream-union dispatch
- decode the object-valued stdout/stderr delta from raw JSON so the existing public `ResponseStreamEventUnion.Delta string` field remains unchanged
- add stable and beta regression tests using the real object-valued event shape
- synchronize `.castiron.stats.yml` with the transformed OpenAPI hash so the repository mock/drift guard accepts the generator-input change

## Root cause

The concrete shell-output delta models were generated, but `api_reference/openapi.transformed.yml` marked their stream-union discriminators with `x-stainless-skip: [go]`. As a result, `AsAny()` returned `nil` for `response.shell_call_output_content.delta`, forcing callers to manually parse `RawJSON()`.

## User impact

Typed Responses streaming consumers can now switch on `ResponseShellCallOutputContentDeltaEvent` / `BetaResponseShellCallOutputContentDeltaEvent` and read `Delta.Stdout` and `Delta.Stderr` without changing existing string-delta union fields.

## Testing

- `go test ./responses -run TestResponseStreamEventShellCallOutputContentDelta -count=1`
- `go test . -run TestBetaResponseStreamEventShellCallOutputContentDelta -count=1`
- full root `go test ./...` with the repository Steady mock on Go 1.25.13 and Go 1.26.6 using `GOTOOLCHAIN=local`
- `go -C examples test ./...` on Go 1.25.13 and Go 1.26.6
- `go -C internal/testdata/consumer test -mod=readonly ./...` on Go 1.25.13 and Go 1.26.6
- `./scripts/check-go-mod`
- `env GOFLAGS=-buildvcs=false ./scripts/lint`
- transformed-spec MD5 verified against `.castiron.stats.yml`
- thermo-nuclear maintainability review: no findings

Fixes #802.
Replaces #668.
