### PR TITLE
docs: migrate structured outputs example to Responses API

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,9 +294,15 @@ func GenerateSchema[T any]() (map[string]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	var result map[string]any
-	if err := json.Unmarshal(data, &result); err != nil {
+	// Preserve schema values as raw JSON so integer constraints are not rounded
+	// through float64 before the SDK serializes the request.
+	var rawSchema map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawSchema); err != nil {
 		return nil, err
+	}
+	result := make(map[string]any, len(rawSchema))
+	for key, value := range rawSchema {
+		result[key] = value
 	}
 	return result, nil
 }

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ type Origin struct {
 
 // Structured Outputs uses a subset of JSON schema
 // These flags are necessary to comply with the subset
-func GenerateSchema[T any]() map[string]any {
+func GenerateSchema[T any]() (map[string]any, error) {
 	reflector := jsonschema.Reflector{
 		AllowAdditionalProperties: false,
 		DoNotReference:            true,
@@ -290,18 +290,24 @@ func GenerateSchema[T any]() map[string]any {
 	var v T
 	schema := reflector.Reflect(v)
 
-	data, _ := json.Marshal(schema)
+	data, err := json.Marshal(schema)
+	if err != nil {
+		return nil, err
+	}
 	var result map[string]any
-	json.Unmarshal(data, &result)
-	return result
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
 }
-
-// Generate the JSON schema at initialization time
-var HistoricalComputerSchema = GenerateSchema[HistoricalComputer]()
 
 func main() {
 	client := openai.NewClient()
 	ctx := context.Background()
+	schema, err := GenerateSchema[HistoricalComputer]()
+	if err != nil {
+		panic(err)
+	}
 
 	response, err := client.Responses.New(ctx, responses.ResponseNewParams{
 		Model: openai.ChatModelGPT5_2,
@@ -309,10 +315,14 @@ func main() {
 			OfString: openai.String("What computer ran the first neural network?"),
 		},
 		Text: responses.ResponseTextConfigParam{
-			Format: responses.ResponseFormatTextConfigParamOfJSONSchema(
-				"historical_computer",
-				HistoricalComputerSchema,
-			),
+			Format: responses.ResponseFormatTextConfigUnionParam{
+				OfJSONSchema: &responses.ResponseFormatTextJSONSchemaConfigParam{
+					Name:        "historical_computer",
+					Description: openai.String("Notable information about a computer"),
+					Schema:      schema,
+					Strict:      openai.Bool(true),
+				},
+			},
 		},
 	})
 	if err != nil {
@@ -321,7 +331,9 @@ func main() {
 
 	// extract into a well-typed struct
 	var historicalComputer HistoricalComputer
-	_ = json.Unmarshal([]byte(response.OutputText()), &historicalComputer)
+	if err := json.Unmarshal([]byte(response.OutputText()), &historicalComputer); err != nil {
+		panic(err)
+	}
 
 	historicalComputer.Name
 	historicalComputer.Origin.YearBuilt
@@ -332,7 +344,7 @@ func main() {
 }
 ```
 
-> See the [full structured outputs example](./examples/responses-structured-outputs/main.go)
+> See the [full structured outputs example](./examples/structured-outputs/main.go)
 
 </details>
 

--- a/examples/structured-outputs/main.go
+++ b/examples/structured-outputs/main.go
@@ -41,9 +41,15 @@ func GenerateSchema[T any]() (map[string]any, error) {
 	if err != nil {
 		return nil, fmt.Errorf("marshal JSON schema: %w", err)
 	}
-	var result map[string]any
-	if err := json.Unmarshal(data, &result); err != nil {
+	// Preserve schema values as raw JSON so integer constraints are not rounded
+	// through float64 before the SDK serializes the request.
+	var rawSchema map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawSchema); err != nil {
 		return nil, fmt.Errorf("decode JSON schema: %w", err)
+	}
+	result := make(map[string]any, len(rawSchema))
+	for key, value := range rawSchema {
+		result[key] = value
 	}
 	return result, nil
 }

--- a/examples/structured-outputs/main.go
+++ b/examples/structured-outputs/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/invopop/jsonschema"
 	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/responses"
 )
 
 // A struct that will be converted to a Structured Outputs response schema.
@@ -27,7 +28,7 @@ type Origin struct {
 	Organization string `json:"organization" jsonschema_description:"The organization that was in charge of its development"`
 }
 
-func GenerateSchema[T any]() interface{} {
+func GenerateSchema[T any]() (map[string]any, error) {
 	// Structured Outputs uses a subset of JSON schema
 	// These flags are necessary to comply with the subset
 	reflector := jsonschema.Reflector{
@@ -36,11 +37,35 @@ func GenerateSchema[T any]() interface{} {
 	}
 	var v T
 	schema := reflector.Reflect(v)
-	return schema
+	data, err := json.Marshal(schema)
+	if err != nil {
+		return nil, fmt.Errorf("marshal JSON schema: %w", err)
+	}
+	var result map[string]any
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, fmt.Errorf("decode JSON schema: %w", err)
+	}
+	return result, nil
 }
 
-// Generate the JSON schema at initialization time
-var HistoricalComputerResponseSchema = GenerateSchema[HistoricalComputer]()
+func historicalComputerParams(question string, schema map[string]any) responses.ResponseNewParams {
+	return responses.ResponseNewParams{
+		Model: openai.ChatModelGPT5_2,
+		Input: responses.ResponseNewParamsInputUnion{
+			OfString: openai.String(question),
+		},
+		Text: responses.ResponseTextConfigParam{
+			Format: responses.ResponseFormatTextConfigUnionParam{
+				OfJSONSchema: &responses.ResponseFormatTextJSONSchemaConfigParam{
+					Name:        "historical_computer",
+					Description: openai.String("Notable information about a computer"),
+					Schema:      schema,
+					Strict:      openai.Bool(true),
+				},
+			},
+		},
+	}
+}
 
 func main() {
 	client := openai.NewClient()
@@ -51,34 +76,21 @@ func main() {
 	print("> ")
 	println(question)
 
-	schemaParam := openai.ResponseFormatJSONSchemaJSONSchemaParam{
-		Name:        "historical_computer",
-		Description: openai.String("Notable information about a computer"),
-		Schema:      HistoricalComputerResponseSchema,
-		Strict:      openai.Bool(true),
+	schema, err := GenerateSchema[HistoricalComputer]()
+	if err != nil {
+		panic(err)
 	}
 
-	// Query the Chat Completions API
-	chat, err := client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
-		Messages: []openai.ChatCompletionMessageParamUnion{
-			openai.UserMessage(question),
-		},
-		ResponseFormat: openai.ChatCompletionNewParamsResponseFormatUnion{
-			OfJSONSchema: &openai.ResponseFormatJSONSchemaParam{JSONSchema: schemaParam},
-		},
-		// Only certain models can perform structured outputs
-		Model: openai.ChatModelGPT4o2024_08_06,
-	})
-
+	response, err := client.Responses.New(ctx, historicalComputerParams(question, schema))
 	if err != nil {
-		panic(err.Error())
+		panic(err)
 	}
 
 	// The model responds with a JSON string, so parse it into a struct
 	var historicalComputer HistoricalComputer
-	err = json.Unmarshal([]byte(chat.Choices[0].Message.Content), &historicalComputer)
+	err = json.Unmarshal([]byte(response.OutputText()), &historicalComputer)
 	if err != nil {
-		panic(err.Error())
+		panic(err)
 	}
 
 	// Use the model's structured response with a native Go struct

--- a/examples/structured-outputs/main_test.go
+++ b/examples/structured-outputs/main_test.go
@@ -51,3 +51,53 @@ func TestHistoricalComputerParamsSerializesStructuredOutputSchema(t *testing.T) 
 		t.Errorf("format.schema.additionalProperties = %v, want false", format.Schema["additionalProperties"])
 	}
 }
+
+func TestGenerateSchemaPreserves64BitIntegerEnums(t *testing.T) {
+	type exactIntegerEnums struct {
+		Signed   int64  `json:"signed" jsonschema:"enum=-9007199254740993,enum=9007199254740993"`
+		Unsigned uint64 `json:"unsigned" jsonschema:"enum=9007199254740993,enum=18446744073709551615"`
+	}
+
+	schema, err := GenerateSchema[exactIntegerEnums]()
+	if err != nil {
+		t.Fatalf("GenerateSchema() error = %v", err)
+	}
+
+	data, err := json.Marshal(historicalComputerParams("question", schema))
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	var request struct {
+		Text struct {
+			Format struct {
+				Schema struct {
+					Properties map[string]struct {
+						Enum []json.RawMessage `json:"enum"`
+					} `json:"properties"`
+				} `json:"schema"`
+			} `json:"format"`
+		} `json:"text"`
+	}
+	if err := json.Unmarshal(data, &request); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	for _, test := range []struct {
+		property string
+		want     []string
+	}{
+		{property: "signed", want: []string{"-9007199254740993", "9007199254740993"}},
+		{property: "unsigned", want: []string{"9007199254740993", "18446744073709551615"}},
+	} {
+		enum := request.Text.Format.Schema.Properties[test.property].Enum
+		if len(enum) != len(test.want) {
+			t.Fatalf("%s enum has %d values, want %d: %s", test.property, len(enum), len(test.want), data)
+		}
+		for i, value := range enum {
+			if string(value) != test.want[i] {
+				t.Errorf("%s enum[%d] = %s, want exact numeric token %s: %s", test.property, i, value, test.want[i], data)
+			}
+		}
+	}
+}

--- a/examples/structured-outputs/main_test.go
+++ b/examples/structured-outputs/main_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestHistoricalComputerParamsSerializesStructuredOutputSchema(t *testing.T) {
+	schema, err := GenerateSchema[HistoricalComputer]()
+	if err != nil {
+		t.Fatalf("GenerateSchema() error = %v", err)
+	}
+
+	data, err := json.Marshal(historicalComputerParams("question", schema))
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	var request struct {
+		Text struct {
+			Format struct {
+				Name        string         `json:"name"`
+				Description string         `json:"description"`
+				Schema      map[string]any `json:"schema"`
+				Strict      bool           `json:"strict"`
+				Type        string         `json:"type"`
+			} `json:"format"`
+		} `json:"text"`
+	}
+	if err := json.Unmarshal(data, &request); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	format := request.Text.Format
+	if format.Type != "json_schema" {
+		t.Errorf("format.type = %q, want %q", format.Type, "json_schema")
+	}
+	if format.Name != "historical_computer" {
+		t.Errorf("format.name = %q, want %q", format.Name, "historical_computer")
+	}
+	if format.Description == "" {
+		t.Error("format.description is empty")
+	}
+	if !format.Strict {
+		t.Error("format.strict = false, want true")
+	}
+	if format.Schema["type"] != "object" {
+		t.Errorf("format.schema.type = %v, want %q", format.Schema["type"], "object")
+	}
+	if format.Schema["additionalProperties"] != false {
+		t.Errorf("format.schema.additionalProperties = %v, want false", format.Schema["additionalProperties"])
+	}
+}


### PR DESCRIPTION
## Summary

- migrate the structured outputs example from Chat Completions to the Responses API
- document the required JSON-schema-to-map conversion with explicit error handling
- preserve the schema description and strict mode in the Responses request
- fix the README link to the checked-in example
- add an offline regression test for the serialized Responses wire shape

## Root cause

The README's inline example was migrated to Responses separately from the full example. The full example continued to use Chat Completions, while the new README link pointed to a directory that did not exist. The Responses SDK also requires a `map[string]any` for the schema where the Chat Completions type accepted `any`, so the migration needs an explicit conversion.

## Impact

Users now have a complete, runnable Responses API example for structured outputs. This changes documentation and handwritten example code only; exported SDK APIs and generated wire types are unchanged.

## Validation

- `(cd examples && go test ./...)`
- `go test -run '^$' ./...`
- `(cd examples && go build -buildvcs=false ./...)`
- targeted golangci-lint for `./structured-outputs`: 0 issues

Closes #482