### PR TITLE
feat: support named data-residency endpoints

### DIFF
--- a/.castiron.stats.yml
+++ b/.castiron.stats.yml
@@ -1,6 +1,6 @@
 schema_version: 1
-generation_id: 72b1e1a8-2bcc-44e5-8f84-e190530d3ca7
+generation_id: 6120ba67-99b6-40d4-8107-f31b2e9ca0e3
 openapi_spec_hash: dd725fb7d43ceec7fb2de6f8713d14b6
-openapi_transformed_spec_hash: 1c381652af5dacf14f1dc646d35e94e6
-config_hash: a7196180e219df1555dc3efbeb09495e
-codegen_sha: 4c2de90434c97141cceb1d931d61bbec669abab8
+openapi_transformed_spec_hash: 10930179c5f116288e24e0c6fda46559
+config_hash: 85382dd94c503b5d225adc7636a77c9f
+codegen_sha: 88caf7f9a26bb05949e060b3889bd7ce0ad4b783

--- a/admin.go
+++ b/admin.go
@@ -3,6 +3,7 @@
 package openai
 
 import (
+	"github.com/openai/openai-go/v3/internal/requestconfig"
 	"github.com/openai/openai-go/v3/option"
 )
 
@@ -22,7 +23,7 @@ type AdminService struct {
 // is one), and before any request-specific options.
 func NewAdminService(opts ...option.RequestOption) (r AdminService) {
 	r = AdminService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	r.Organization = NewAdminOrganizationService(opts...)
 	return
 }

--- a/adminorganization.go
+++ b/adminorganization.go
@@ -3,6 +3,7 @@
 package openai
 
 import (
+	"github.com/openai/openai-go/v3/internal/requestconfig"
 	"github.com/openai/openai-go/v3/option"
 )
 
@@ -34,7 +35,7 @@ type AdminOrganizationService struct {
 // options (if there is one), and before any request-specific options.
 func NewAdminOrganizationService(opts ...option.RequestOption) (r AdminOrganizationService) {
 	r = AdminOrganizationService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	r.AuditLogs = NewAdminOrganizationAuditLogService(opts...)
 	r.AdminAPIKeys = NewAdminOrganizationAdminAPIKeyService(opts...)
 	r.Usage = NewAdminOrganizationUsageService(opts...)

--- a/adminorganizationadminapikey.go
+++ b/adminorganizationadminapikey.go
@@ -34,7 +34,7 @@ type AdminOrganizationAdminAPIKeyService struct {
 // client's options (if there is one), and before any request-specific options.
 func NewAdminOrganizationAdminAPIKeyService(opts ...option.RequestOption) (r AdminOrganizationAdminAPIKeyService) {
 	r = AdminOrganizationAdminAPIKeyService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/adminorganizationauditlog.go
+++ b/adminorganizationauditlog.go
@@ -34,7 +34,7 @@ type AdminOrganizationAuditLogService struct {
 // client's options (if there is one), and before any request-specific options.
 func NewAdminOrganizationAuditLogService(opts ...option.RequestOption) (r AdminOrganizationAuditLogService) {
 	r = AdminOrganizationAuditLogService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/adminorganizationcertificate.go
+++ b/adminorganizationcertificate.go
@@ -34,7 +34,7 @@ type AdminOrganizationCertificateService struct {
 // client's options (if there is one), and before any request-specific options.
 func NewAdminOrganizationCertificateService(opts ...option.RequestOption) (r AdminOrganizationCertificateService) {
 	r = AdminOrganizationCertificateService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/adminorganizationdataretention.go
+++ b/adminorganizationdataretention.go
@@ -30,7 +30,7 @@ type AdminOrganizationDataRetentionService struct {
 // client's options (if there is one), and before any request-specific options.
 func NewAdminOrganizationDataRetentionService(opts ...option.RequestOption) (r AdminOrganizationDataRetentionService) {
 	r = AdminOrganizationDataRetentionService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/adminorganizationgroup.go
+++ b/adminorganizationgroup.go
@@ -36,7 +36,7 @@ type AdminOrganizationGroupService struct {
 // options (if there is one), and before any request-specific options.
 func NewAdminOrganizationGroupService(opts ...option.RequestOption) (r AdminOrganizationGroupService) {
 	r = AdminOrganizationGroupService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	r.Users = NewAdminOrganizationGroupUserService(opts...)
 	r.Roles = NewAdminOrganizationGroupRoleService(opts...)
 	return

--- a/adminorganizationgrouprole.go
+++ b/adminorganizationgrouprole.go
@@ -34,7 +34,7 @@ type AdminOrganizationGroupRoleService struct {
 // client's options (if there is one), and before any request-specific options.
 func NewAdminOrganizationGroupRoleService(opts ...option.RequestOption) (r AdminOrganizationGroupRoleService) {
 	r = AdminOrganizationGroupRoleService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/adminorganizationgroupuser.go
+++ b/adminorganizationgroupuser.go
@@ -34,7 +34,7 @@ type AdminOrganizationGroupUserService struct {
 // client's options (if there is one), and before any request-specific options.
 func NewAdminOrganizationGroupUserService(opts ...option.RequestOption) (r AdminOrganizationGroupUserService) {
 	r = AdminOrganizationGroupUserService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/adminorganizationinvite.go
+++ b/adminorganizationinvite.go
@@ -34,7 +34,7 @@ type AdminOrganizationInviteService struct {
 // options (if there is one), and before any request-specific options.
 func NewAdminOrganizationInviteService(opts ...option.RequestOption) (r AdminOrganizationInviteService) {
 	r = AdminOrganizationInviteService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/adminorganizationproject.go
+++ b/adminorganizationproject.go
@@ -46,7 +46,7 @@ type AdminOrganizationProjectService struct {
 // client's options (if there is one), and before any request-specific options.
 func NewAdminOrganizationProjectService(opts ...option.RequestOption) (r AdminOrganizationProjectService) {
 	r = AdminOrganizationProjectService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	r.Users = NewAdminOrganizationProjectUserService(opts...)
 	r.ServiceAccounts = NewAdminOrganizationProjectServiceAccountService(opts...)
 	r.APIKeys = NewAdminOrganizationProjectAPIKeyService(opts...)

--- a/adminorganizationprojectapikey.go
+++ b/adminorganizationprojectapikey.go
@@ -34,7 +34,7 @@ type AdminOrganizationProjectAPIKeyService struct {
 // client's options (if there is one), and before any request-specific options.
 func NewAdminOrganizationProjectAPIKeyService(opts ...option.RequestOption) (r AdminOrganizationProjectAPIKeyService) {
 	r = AdminOrganizationProjectAPIKeyService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/adminorganizationprojectcertificate.go
+++ b/adminorganizationprojectcertificate.go
@@ -35,7 +35,7 @@ type AdminOrganizationProjectCertificateService struct {
 // options.
 func NewAdminOrganizationProjectCertificateService(opts ...option.RequestOption) (r AdminOrganizationProjectCertificateService) {
 	r = AdminOrganizationProjectCertificateService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/adminorganizationprojectdataretention.go
+++ b/adminorganizationprojectdataretention.go
@@ -32,7 +32,7 @@ type AdminOrganizationProjectDataRetentionService struct {
 // options.
 func NewAdminOrganizationProjectDataRetentionService(opts ...option.RequestOption) (r AdminOrganizationProjectDataRetentionService) {
 	r = AdminOrganizationProjectDataRetentionService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/adminorganizationprojectgroup.go
+++ b/adminorganizationprojectgroup.go
@@ -35,7 +35,7 @@ type AdminOrganizationProjectGroupService struct {
 // client's options (if there is one), and before any request-specific options.
 func NewAdminOrganizationProjectGroupService(opts ...option.RequestOption) (r AdminOrganizationProjectGroupService) {
 	r = AdminOrganizationProjectGroupService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	r.Roles = NewAdminOrganizationProjectGroupRoleService(opts...)
 	return
 }

--- a/adminorganizationprojectgrouprole.go
+++ b/adminorganizationprojectgrouprole.go
@@ -34,7 +34,7 @@ type AdminOrganizationProjectGroupRoleService struct {
 // client's options (if there is one), and before any request-specific options.
 func NewAdminOrganizationProjectGroupRoleService(opts ...option.RequestOption) (r AdminOrganizationProjectGroupRoleService) {
 	r = AdminOrganizationProjectGroupRoleService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/adminorganizationprojecthostedtoolpermission.go
+++ b/adminorganizationprojecthostedtoolpermission.go
@@ -31,7 +31,7 @@ type AdminOrganizationProjectHostedToolPermissionService struct {
 // options.
 func NewAdminOrganizationProjectHostedToolPermissionService(opts ...option.RequestOption) (r AdminOrganizationProjectHostedToolPermissionService) {
 	r = AdminOrganizationProjectHostedToolPermissionService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/adminorganizationprojectmodelpermission.go
+++ b/adminorganizationprojectmodelpermission.go
@@ -32,7 +32,7 @@ type AdminOrganizationProjectModelPermissionService struct {
 // options.
 func NewAdminOrganizationProjectModelPermissionService(opts ...option.RequestOption) (r AdminOrganizationProjectModelPermissionService) {
 	r = AdminOrganizationProjectModelPermissionService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/adminorganizationprojectratelimit.go
+++ b/adminorganizationprojectratelimit.go
@@ -34,7 +34,7 @@ type AdminOrganizationProjectRateLimitService struct {
 // client's options (if there is one), and before any request-specific options.
 func NewAdminOrganizationProjectRateLimitService(opts ...option.RequestOption) (r AdminOrganizationProjectRateLimitService) {
 	r = AdminOrganizationProjectRateLimitService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/adminorganizationprojectrole.go
+++ b/adminorganizationprojectrole.go
@@ -34,7 +34,7 @@ type AdminOrganizationProjectRoleService struct {
 // client's options (if there is one), and before any request-specific options.
 func NewAdminOrganizationProjectRoleService(opts ...option.RequestOption) (r AdminOrganizationProjectRoleService) {
 	r = AdminOrganizationProjectRoleService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/adminorganizationprojectserviceaccount.go
+++ b/adminorganizationprojectserviceaccount.go
@@ -36,7 +36,7 @@ type AdminOrganizationProjectServiceAccountService struct {
 // options.
 func NewAdminOrganizationProjectServiceAccountService(opts ...option.RequestOption) (r AdminOrganizationProjectServiceAccountService) {
 	r = AdminOrganizationProjectServiceAccountService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	r.APIKeys = NewAdminOrganizationProjectServiceAccountAPIKeyService(opts...)
 	return
 }

--- a/adminorganizationprojectserviceaccountapikey.go
+++ b/adminorganizationprojectserviceaccountapikey.go
@@ -32,7 +32,7 @@ type AdminOrganizationProjectServiceAccountAPIKeyService struct {
 // options.
 func NewAdminOrganizationProjectServiceAccountAPIKeyService(opts ...option.RequestOption) (r AdminOrganizationProjectServiceAccountAPIKeyService) {
 	r = AdminOrganizationProjectServiceAccountAPIKeyService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/adminorganizationprojectspendalert.go
+++ b/adminorganizationprojectspendalert.go
@@ -35,7 +35,7 @@ type AdminOrganizationProjectSpendAlertService struct {
 // options.
 func NewAdminOrganizationProjectSpendAlertService(opts ...option.RequestOption) (r AdminOrganizationProjectSpendAlertService) {
 	r = AdminOrganizationProjectSpendAlertService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/adminorganizationprojectspendlimit.go
+++ b/adminorganizationprojectspendlimit.go
@@ -32,7 +32,7 @@ type AdminOrganizationProjectSpendLimitService struct {
 // options.
 func NewAdminOrganizationProjectSpendLimitService(opts ...option.RequestOption) (r AdminOrganizationProjectSpendLimitService) {
 	r = AdminOrganizationProjectSpendLimitService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/adminorganizationprojectuser.go
+++ b/adminorganizationprojectuser.go
@@ -35,7 +35,7 @@ type AdminOrganizationProjectUserService struct {
 // client's options (if there is one), and before any request-specific options.
 func NewAdminOrganizationProjectUserService(opts ...option.RequestOption) (r AdminOrganizationProjectUserService) {
 	r = AdminOrganizationProjectUserService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	r.Roles = NewAdminOrganizationProjectUserRoleService(opts...)
 	return
 }

--- a/adminorganizationprojectuserrole.go
+++ b/adminorganizationprojectuserrole.go
@@ -34,7 +34,7 @@ type AdminOrganizationProjectUserRoleService struct {
 // client's options (if there is one), and before any request-specific options.
 func NewAdminOrganizationProjectUserRoleService(opts ...option.RequestOption) (r AdminOrganizationProjectUserRoleService) {
 	r = AdminOrganizationProjectUserRoleService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/adminorganizationrole.go
+++ b/adminorganizationrole.go
@@ -34,7 +34,7 @@ type AdminOrganizationRoleService struct {
 // options (if there is one), and before any request-specific options.
 func NewAdminOrganizationRoleService(opts ...option.RequestOption) (r AdminOrganizationRoleService) {
 	r = AdminOrganizationRoleService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/adminorganizationspendalert.go
+++ b/adminorganizationspendalert.go
@@ -34,7 +34,7 @@ type AdminOrganizationSpendAlertService struct {
 // client's options (if there is one), and before any request-specific options.
 func NewAdminOrganizationSpendAlertService(opts ...option.RequestOption) (r AdminOrganizationSpendAlertService) {
 	r = AdminOrganizationSpendAlertService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/adminorganizationspendlimit.go
+++ b/adminorganizationspendlimit.go
@@ -30,7 +30,7 @@ type AdminOrganizationSpendLimitService struct {
 // client's options (if there is one), and before any request-specific options.
 func NewAdminOrganizationSpendLimitService(opts ...option.RequestOption) (r AdminOrganizationSpendLimitService) {
 	r = AdminOrganizationSpendLimitService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/adminorganizationusage.go
+++ b/adminorganizationusage.go
@@ -33,7 +33,7 @@ type AdminOrganizationUsageService struct {
 // options (if there is one), and before any request-specific options.
 func NewAdminOrganizationUsageService(opts ...option.RequestOption) (r AdminOrganizationUsageService) {
 	r = AdminOrganizationUsageService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/adminorganizationuser.go
+++ b/adminorganizationuser.go
@@ -35,7 +35,7 @@ type AdminOrganizationUserService struct {
 // options (if there is one), and before any request-specific options.
 func NewAdminOrganizationUserService(opts ...option.RequestOption) (r AdminOrganizationUserService) {
 	r = AdminOrganizationUserService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	r.Roles = NewAdminOrganizationUserRoleService(opts...)
 	return
 }

--- a/adminorganizationuserrole.go
+++ b/adminorganizationuserrole.go
@@ -34,7 +34,7 @@ type AdminOrganizationUserRoleService struct {
 // client's options (if there is one), and before any request-specific options.
 func NewAdminOrganizationUserRoleService(opts ...option.RequestOption) (r AdminOrganizationUserRoleService) {
 	r = AdminOrganizationUserRoleService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/api_reference/openapi.transformed.yml
+++ b/api_reference/openapi.transformed.yml
@@ -54702,6 +54702,8 @@ components:
       - $ref: '#/components/schemas/ResponseShellCallCommandDeltaStreamingEvent'
       - $ref: '#/components/schemas/ResponseShellCallCommandDoneStreamingEvent'
       - $ref: '#/components/schemas/ResponseShellCallOutputContentDeltaStreamingEvent'
+        x-stainless-skip:
+        - go
       - $ref: '#/components/schemas/ResponseShellCallOutputContentDoneStreamingEvent'
       - $ref: '#/components/schemas/ResponseInProgressEvent'
       - $ref: '#/components/schemas/ResponseFailedEvent'
@@ -55391,6 +55393,8 @@ components:
         description: A streaming event that indicated shell call output was incrementally added.
         allOf:
         - $ref: '#/components/schemas/ResponseShellCallOutputContentDeltaStreamingEvent'
+          x-stainless-skip:
+          - go
         - type: object
           properties:
             stream_id:
@@ -55863,6 +55867,8 @@ components:
         - $ref: '#/components/schemas/ResponseShellCallCommandDeltaStreamingEvent'
         - $ref: '#/components/schemas/ResponseShellCallCommandDoneStreamingEvent'
         - $ref: '#/components/schemas/ResponseShellCallOutputContentDeltaStreamingEvent'
+          x-stainless-skip:
+          - go
         - $ref: '#/components/schemas/ResponseShellCallOutputContentDoneStreamingEvent'
         - $ref: '#/components/schemas/ResponseInProgressEvent'
         - $ref: '#/components/schemas/ResponseFailedEvent'
@@ -77721,6 +77727,8 @@ components:
         description: A streaming event that indicated shell call output was incrementally added.
         allOf:
         - $ref: '#/components/schemas/BetaResponseShellCallOutputContentDeltaStreamingEvent'
+          x-stainless-skip:
+          - go
         - type: object
           properties:
             stream_id:
@@ -78383,6 +78391,8 @@ components:
         - $ref: '#/components/schemas/BetaResponseShellCallCommandDeltaStreamingEvent'
         - $ref: '#/components/schemas/BetaResponseShellCallCommandDoneStreamingEvent'
         - $ref: '#/components/schemas/BetaResponseShellCallOutputContentDeltaStreamingEvent'
+          x-stainless-skip:
+          - go
         - $ref: '#/components/schemas/BetaResponseShellCallOutputContentDoneStreamingEvent'
         - $ref: '#/components/schemas/BetaResponseInProgressEvent'
         - $ref: '#/components/schemas/BetaResponseFailedEvent'
@@ -78763,6 +78773,8 @@ components:
       - $ref: '#/components/schemas/BetaResponseShellCallCommandDeltaStreamingEvent'
       - $ref: '#/components/schemas/BetaResponseShellCallCommandDoneStreamingEvent'
       - $ref: '#/components/schemas/BetaResponseShellCallOutputContentDeltaStreamingEvent'
+        x-stainless-skip:
+        - go
       - $ref: '#/components/schemas/BetaResponseShellCallOutputContentDoneStreamingEvent'
       - $ref: '#/components/schemas/BetaResponseInProgressEvent'
       - $ref: '#/components/schemas/BetaResponseFailedEvent'

--- a/audio.go
+++ b/audio.go
@@ -3,6 +3,7 @@
 package openai
 
 import (
+	"github.com/openai/openai-go/v3/internal/requestconfig"
 	"github.com/openai/openai-go/v3/option"
 )
 
@@ -27,7 +28,7 @@ type AudioService struct {
 // is one), and before any request-specific options.
 func NewAudioService(opts ...option.RequestOption) (r AudioService) {
 	r = AudioService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	r.Transcriptions = NewAudioTranscriptionService(opts...)
 	r.Translations = NewAudioTranslationService(opts...)
 	r.Speech = NewAudioSpeechService(opts...)

--- a/audiospeech.go
+++ b/audiospeech.go
@@ -30,7 +30,7 @@ type AudioSpeechService struct {
 // there is one), and before any request-specific options.
 func NewAudioSpeechService(opts ...option.RequestOption) (r AudioSpeechService) {
 	r = AudioSpeechService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/audiotranscription.go
+++ b/audiotranscription.go
@@ -38,7 +38,7 @@ type AudioTranscriptionService struct {
 // options (if there is one), and before any request-specific options.
 func NewAudioTranscriptionService(opts ...option.RequestOption) (r AudioTranscriptionService) {
 	r = AudioTranscriptionService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/audiotranslation.go
+++ b/audiotranslation.go
@@ -35,7 +35,7 @@ type AudioTranslationService struct {
 // options (if there is one), and before any request-specific options.
 func NewAudioTranslationService(opts ...option.RequestOption) (r AudioTranslationService) {
 	r = AudioTranslationService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/azure/azure.go
+++ b/azure/azure.go
@@ -75,6 +75,10 @@ func WithEndpoint(endpoint string, apiVersion string) option.RequestOption {
 			return errors.New("apiVersion is an empty string, but needs to be set. See https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#rest-api-versioning for details.")
 		}
 
+		if err := requestconfig.WithEndpointProvider("Azure").Apply(rc); err != nil {
+			return err
+		}
+
 		if err := withQueryAdd.Apply(rc); err != nil {
 			return err
 		}
@@ -113,6 +117,9 @@ func WithTokenCredentialScopes(scopes []string) func(*tokenCredentialConfig) err
 // [Azure Identity]: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity
 func WithTokenCredential(tokenCredential azcore.TokenCredential, options ...TokenCredentialOption) option.RequestOption {
 	return requestconfig.RequestOptionFunc(func(rc *requestconfig.RequestConfig) error {
+		if err := requestconfig.WithEndpointProvider("Azure").Apply(rc); err != nil {
+			return err
+		}
 		tc := &tokenCredentialConfig{
 			Scopes: []string{"https://cognitiveservices.azure.com/.default"},
 		}
@@ -156,6 +163,7 @@ func WithAPIKey(apiKey string) option.RequestOption {
 	// automatically injecting environment-derived client credentials.
 	return requestconfig.RequestOptionFunc(func(rc *requestconfig.RequestConfig) error {
 		return rc.Apply(
+			requestconfig.WithEndpointProvider("Azure"),
 			option.WithHeaderDel("Authorization"),
 			option.WithHeader("Api-Key", apiKey),
 		)

--- a/batch.go
+++ b/batch.go
@@ -37,7 +37,7 @@ type BatchService struct {
 // is one), and before any request-specific options.
 func NewBatchService(opts ...option.RequestOption) (r BatchService) {
 	r = BatchService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/bedrock/auth.go
+++ b/bedrock/auth.go
@@ -69,6 +69,10 @@ func newClientOptions(
 		return nil, errors.New("bedrock: nil context")
 	}
 
+	if err := requestconfig.ValidateEndpointOptions("Bedrock", userOpts...); err != nil {
+		return nil, err
+	}
+
 	resolved, err := resolveConfig(ctx, cfg, now)
 	if err != nil {
 		return nil, err
@@ -76,6 +80,7 @@ func newClientOptions(
 
 	opts := []option.RequestOption{
 		requestconfig.WithEnvironmentDefaultsDisabled(),
+		requestconfig.WithEndpointProvider("Bedrock"),
 		option.WithBaseURL(resolved.baseURL.String()),
 	}
 	opts = append(opts, userOpts...)

--- a/bedrock/data_residency_test.go
+++ b/bedrock/data_residency_test.go
@@ -1,0 +1,90 @@
+package bedrock
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/openai/openai-go/v3/internal/requestconfig"
+	"github.com/openai/openai-go/v3/option"
+)
+
+func TestDataResidencyRejectedBeforeCredentialDiscovery(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		opts    []option.RequestOption
+		message string
+	}{
+		{"valid region", []option.RequestOption{option.WithDataResidency(option.DataResidencyEU)}, "Bedrock provider"},
+		{"empty region", []option.RequestOption{option.WithDataResidency("")}, "invalid data residency"},
+		{"unknown region", []option.RequestOption{option.WithDataResidency("unknown")}, "invalid data residency"},
+		{"base URL first", []option.RequestOption{option.WithBaseURL("https://custom.example"), option.WithDataResidency(option.DataResidencyEU)}, "Bedrock provider"},
+		{"residency first", []option.RequestOption{option.WithDataResidency(option.DataResidencyEU), option.WithBaseURL("https://custom.example")}, "Bedrock provider"},
+		{"inherited region", requestconfig.InheritedOptions(option.WithDataResidency(option.DataResidencyEU)), "Bedrock provider"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			clearAWSEnvironment(t)
+			credentialCalls, callbackCalls := 0, 0
+			config := Config{
+				AWSRegion: "us-east-1",
+				AWSCredentialsProvider: aws.CredentialsProviderFunc(func(context.Context) (aws.Credentials, error) {
+					credentialCalls++
+					return aws.Credentials{AccessKeyID: "dummy-access", SecretAccessKey: "dummy-secret"}, nil
+				}),
+			}
+			callback := requestconfig.RequestOptionFunc(func(*requestconfig.RequestConfig) error { callbackCalls++; return nil })
+			opts := append([]option.RequestOption{callback}, test.opts...)
+			_, err := NewClient(context.Background(), config, opts...)
+			if err == nil || !strings.Contains(err.Error(), test.message) {
+				t.Fatalf("error = %v, want %q", err, test.message)
+			}
+			if credentialCalls != 0 || callbackCalls != 0 {
+				t.Fatalf("credential calls = %d, arbitrary callbacks = %d", credentialCalls, callbackCalls)
+			}
+		})
+	}
+}
+
+func TestEndpointPreflightDoesNotEvaluateUserCallbacks(t *testing.T) {
+	clearAWSEnvironment(t)
+	callbackCalls := 0
+	callback := requestconfig.RequestOptionFunc(func(*requestconfig.RequestConfig) error { callbackCalls++; return nil })
+	client, err := NewClient(context.Background(), Config{SkipAuth: true, BaseURL: "https://bedrock.example/openai/v1"}, callback)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if callbackCalls != 0 {
+		t.Fatalf("constructor evaluated user callback %d times", callbackCalls)
+	}
+	// Applying the stored configuration still evaluates an ordinary callback once.
+	cfg := requestconfig.RequestConfig{}
+	if err := cfg.Apply(client.Options...); err != nil {
+		t.Fatal(err)
+	}
+	if callbackCalls != 1 {
+		t.Fatalf("request setup evaluated callback %d times", callbackCalls)
+	}
+}
+
+func TestDataResidencyRequestOverrideRejected(t *testing.T) {
+	clearAWSEnvironment(t)
+	transportCalls := 0
+	client, err := NewClient(context.Background(), Config{SkipAuth: true, BaseURL: "https://bedrock.example/openai/v1"},
+		option.WithHTTPClient(&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			transportCalls++
+			return successfulResponse(req), nil
+		})}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = client.Get(context.Background(), "models", nil, nil, option.WithDataResidency(option.DataResidencyEU))
+	if err == nil || !strings.Contains(err.Error(), "Bedrock provider") {
+		t.Fatalf("expected provider error, got %v", err)
+	}
+	if transportCalls != 0 {
+		t.Fatalf("provider conflict made %d HTTP requests", transportCalls)
+	}
+}

--- a/beta.go
+++ b/beta.go
@@ -3,6 +3,7 @@
 package openai
 
 import (
+	"github.com/openai/openai-go/v3/internal/requestconfig"
 	"github.com/openai/openai-go/v3/option"
 )
 
@@ -29,7 +30,7 @@ type BetaService struct {
 // is one), and before any request-specific options.
 func NewBetaService(opts ...option.RequestOption) (r BetaService) {
 	r = BetaService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	r.Responses = NewBetaResponseService(opts...)
 	r.ChatKit = NewBetaChatKitService(opts...)
 	r.Assistants = NewBetaAssistantService(opts...)

--- a/betaassistant.go
+++ b/betaassistant.go
@@ -38,7 +38,7 @@ type BetaAssistantService struct {
 // there is one), and before any request-specific options.
 func NewBetaAssistantService(opts ...option.RequestOption) (r BetaAssistantService) {
 	r = BetaAssistantService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/betachatkit.go
+++ b/betachatkit.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 
 	"github.com/openai/openai-go/v3/internal/apijson"
+	"github.com/openai/openai-go/v3/internal/requestconfig"
 	"github.com/openai/openai-go/v3/option"
 	"github.com/openai/openai-go/v3/packages/respjson"
 )
@@ -27,7 +28,7 @@ type BetaChatKitService struct {
 // there is one), and before any request-specific options.
 func NewBetaChatKitService(opts ...option.RequestOption) (r BetaChatKitService) {
 	r = BetaChatKitService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	r.Sessions = NewBetaChatKitSessionService(opts...)
 	r.Threads = NewBetaChatKitThreadService(opts...)
 	return

--- a/betachatkitsession.go
+++ b/betachatkitsession.go
@@ -29,7 +29,7 @@ type BetaChatKitSessionService struct {
 // options (if there is one), and before any request-specific options.
 func NewBetaChatKitSessionService(opts ...option.RequestOption) (r BetaChatKitSessionService) {
 	r = BetaChatKitSessionService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/betachatkitthread.go
+++ b/betachatkitthread.go
@@ -35,7 +35,7 @@ type BetaChatKitThreadService struct {
 // options (if there is one), and before any request-specific options.
 func NewBetaChatKitThreadService(opts ...option.RequestOption) (r BetaChatKitThreadService) {
 	r = BetaChatKitThreadService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/betaresponse.go
+++ b/betaresponse.go
@@ -39,7 +39,7 @@ type BetaResponseService struct {
 // there is one), and before any request-specific options.
 func NewBetaResponseService(opts ...option.RequestOption) (r BetaResponseService) {
 	r = BetaResponseService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	r.InputItems = NewBetaResponseInputItemService(opts...)
 	r.InputTokens = NewBetaResponseInputTokenService(opts...)
 	return

--- a/betaresponseinputitem.go
+++ b/betaresponseinputitem.go
@@ -35,7 +35,7 @@ type BetaResponseInputItemService struct {
 // options (if there is one), and before any request-specific options.
 func NewBetaResponseInputItemService(opts ...option.RequestOption) (r BetaResponseInputItemService) {
 	r = BetaResponseInputItemService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/betaresponseinputtoken.go
+++ b/betaresponseinputtoken.go
@@ -31,7 +31,7 @@ type BetaResponseInputTokenService struct {
 // options (if there is one), and before any request-specific options.
 func NewBetaResponseInputTokenService(opts ...option.RequestOption) (r BetaResponseInputTokenService) {
 	r = BetaResponseInputTokenService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/betathread.go
+++ b/betathread.go
@@ -46,7 +46,7 @@ type BetaThreadService struct {
 // there is one), and before any request-specific options.
 func NewBetaThreadService(opts ...option.RequestOption) (r BetaThreadService) {
 	r = BetaThreadService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	r.Runs = NewBetaThreadRunService(opts...)
 	r.Messages = NewBetaThreadMessageService(opts...)
 	return

--- a/betathreadmessage.go
+++ b/betathreadmessage.go
@@ -40,7 +40,7 @@ type BetaThreadMessageService struct {
 // options (if there is one), and before any request-specific options.
 func NewBetaThreadMessageService(opts ...option.RequestOption) (r BetaThreadMessageService) {
 	r = BetaThreadMessageService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/betathreadrun.go
+++ b/betathreadrun.go
@@ -44,7 +44,7 @@ type BetaThreadRunService struct {
 // there is one), and before any request-specific options.
 func NewBetaThreadRunService(opts ...option.RequestOption) (r BetaThreadRunService) {
 	r = BetaThreadRunService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	r.Steps = NewBetaThreadRunStepService(opts...)
 	return
 }

--- a/betathreadrunstep.go
+++ b/betathreadrunstep.go
@@ -40,7 +40,7 @@ type BetaThreadRunStepService struct {
 // options (if there is one), and before any request-specific options.
 func NewBetaThreadRunStepService(opts ...option.RequestOption) (r BetaThreadRunStepService) {
 	r = BetaThreadRunStepService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/chat.go
+++ b/chat.go
@@ -3,6 +3,7 @@
 package openai
 
 import (
+	"github.com/openai/openai-go/v3/internal/requestconfig"
 	"github.com/openai/openai-go/v3/option"
 )
 
@@ -24,7 +25,7 @@ type ChatService struct {
 // is one), and before any request-specific options.
 func NewChatService(opts ...option.RequestOption) (r ChatService) {
 	r = ChatService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	r.Completions = NewChatCompletionService(opts...)
 	return
 }

--- a/chatcompletion.go
+++ b/chatcompletion.go
@@ -43,7 +43,7 @@ type ChatCompletionService struct {
 // there is one), and before any request-specific options.
 func NewChatCompletionService(opts ...option.RequestOption) (r ChatCompletionService) {
 	r = ChatCompletionService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	r.Messages = NewChatCompletionMessageService(opts...)
 	return
 }

--- a/chatcompletionmessage.go
+++ b/chatcompletionmessage.go
@@ -34,7 +34,7 @@ type ChatCompletionMessageService struct {
 // options (if there is one), and before any request-specific options.
 func NewChatCompletionMessageService(opts ...option.RequestOption) (r ChatCompletionMessageService) {
 	r = ChatCompletionMessageService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/client.go
+++ b/client.go
@@ -93,7 +93,7 @@ func DefaultClientOptions() []option.RequestOption {
 			}
 		}
 	}
-	return defaults
+	return requestconfig.InheritedOptions(defaults...)
 }
 
 func defaultClientOptionsWithoutEnvironment() []option.RequestOption {
@@ -108,9 +108,9 @@ func defaultClientOptionsWithoutEnvironment() []option.RequestOption {
 func NewClient(opts ...option.RequestOption) (r Client) {
 	defaults := DefaultClientOptions()
 	if requestconfig.EnvironmentDefaultsDisabled(opts...) {
-		defaults = defaultClientOptionsWithoutEnvironment()
+		defaults = requestconfig.InheritedOptions(defaultClientOptionsWithoutEnvironment()...)
 	}
-	opts = append(defaults, opts...)
+	opts = requestconfig.InheritedOptions(append(defaults, opts...)...)
 
 	r = Client{Options: opts}
 

--- a/completion.go
+++ b/completion.go
@@ -34,7 +34,7 @@ type CompletionService struct {
 // there is one), and before any request-specific options.
 func NewCompletionService(opts ...option.RequestOption) (r CompletionService) {
 	r = CompletionService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/container.go
+++ b/container.go
@@ -35,7 +35,7 @@ type ContainerService struct {
 // there is one), and before any request-specific options.
 func NewContainerService(opts ...option.RequestOption) (r ContainerService) {
 	r = ContainerService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	r.Files = NewContainerFileService(opts...)
 	return
 }

--- a/containerfile.go
+++ b/containerfile.go
@@ -39,7 +39,7 @@ type ContainerFileService struct {
 // there is one), and before any request-specific options.
 func NewContainerFileService(opts ...option.RequestOption) (r ContainerFileService) {
 	r = ContainerFileService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	r.Content = NewContainerFileContentService(opts...)
 	return
 }

--- a/containerfilecontent.go
+++ b/containerfilecontent.go
@@ -27,7 +27,7 @@ type ContainerFileContentService struct {
 // options (if there is one), and before any request-specific options.
 func NewContainerFileContentService(opts ...option.RequestOption) (r ContainerFileContentService) {
 	r = ContainerFileContentService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/contentprovenancecheck.go
+++ b/contentprovenancecheck.go
@@ -34,7 +34,7 @@ type ContentProvenanceCheckService struct {
 // options (if there is one), and before any request-specific options.
 func NewContentProvenanceCheckService(opts ...option.RequestOption) (r ContentProvenanceCheckService) {
 	r = ContentProvenanceCheckService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/conversations/conversation.go
+++ b/conversations/conversation.go
@@ -38,7 +38,7 @@ type ConversationService struct {
 // there is one), and before any request-specific options.
 func NewConversationService(opts ...option.RequestOption) (r ConversationService) {
 	r = ConversationService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	r.Items = NewItemService(opts...)
 	return
 }

--- a/conversations/item.go
+++ b/conversations/item.go
@@ -38,7 +38,7 @@ type ItemService struct {
 // is one), and before any request-specific options.
 func NewItemService(opts ...option.RequestOption) (r ItemService) {
 	r = ItemService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/data_residency_contract_test.go
+++ b/data_residency_contract_test.go
@@ -1,0 +1,158 @@
+// File generated from our OpenAPI spec by Castiron. See CONTRIBUTING.md for details.
+
+package openai_test
+
+import (
+	"context"
+	sdk "github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/internal/requestconfig"
+	"github.com/openai/openai-go/v3/option"
+	"io"
+	"net/http"
+	"net/url"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+type castironResidencyRecorder struct {
+	urls    []string
+	bodies  []string
+	headers []http.Header
+}
+
+func (r *castironResidencyRecorder) Do(req *http.Request) (*http.Response, error) {
+	body := ""
+	if req.Body != nil {
+		content, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		body = string(content)
+	}
+	r.urls = append(r.urls, req.URL.String())
+	r.bodies = append(r.bodies, body)
+	r.headers = append(r.headers, req.Header.Clone())
+	return &http.Response{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": {"application/json"}}, Body: io.NopCloser(strings.NewReader("{}")), Request: req}, nil
+}
+
+func castironResidencyOptions(t *testing.T, recorder *castironResidencyRecorder) []option.RequestOption {
+	t.Helper()
+	for _, key := range []string{"OPENAI_API_KEY", "OPENAI_ADMIN_KEY", "OPENAI_BASE_URL", "OPENAI_CUSTOM_HEADERS", "OPENAI_ORG_ID", "OPENAI_PROJECT_ID", "OPENAI_WEBHOOK_SECRET"} {
+		t.Setenv(key, "")
+	}
+	return []option.RequestOption{option.WithAPIKey("dummy-key"), option.WithHTTPClient(recorder), option.WithMaxRetries(0)}
+}
+
+func TestCastironDataResidencyMappings(t *testing.T) {
+	for _, test := range []struct {
+		region   option.DataResidency
+		endpoint string
+	}{
+		{option.DataResidencyGlobal, "https://api.openai.com/v1/"},
+		{option.DataResidencyUS, "https://us.api.openai.com/v1/"},
+		{option.DataResidencyEU, "https://eu.api.openai.com/v1/"},
+		{option.DataResidencyAE, "https://ae.api.openai.com/v1/"},
+	} {
+		t.Run(string(test.region), func(t *testing.T) {
+			endpoint, err := url.Parse(test.endpoint)
+			if err != nil {
+				t.Fatalf("invalid configured residency URL %q: %v", test.endpoint, err)
+			}
+			if (endpoint.Scheme != "http" && endpoint.Scheme != "https") || endpoint.Host == "" {
+				t.Fatalf("configured residency URL must be absolute HTTP(S): %q", test.endpoint)
+			}
+			recorder := &castironResidencyRecorder{}
+			opts := castironResidencyOptions(t, recorder)
+			client := sdk.NewClient(append(opts, option.WithDataResidency(test.region))...)
+			if err := client.Post(context.Background(), "responses", map[string]string{"input": "hello"}, nil, requestconfig.WithDefaultBaseURL("https://resource.example/v1")); err != nil {
+				t.Fatal(err)
+			}
+			if got, want := recorder.urls[0], test.endpoint+"responses"; got != want {
+				t.Fatalf("URL = %q, want %q", got, want)
+			}
+			if strings.TrimSpace(recorder.bodies[0]) != `{"input":"hello"}` {
+				t.Fatalf("unexpected wire body: %q", recorder.bodies[0])
+			}
+			for header := range recorder.headers[0] {
+				if strings.Contains(strings.ToLower(header), "residency") {
+					t.Fatalf("unexpected residency header %q", header)
+				}
+			}
+		})
+	}
+}
+
+func TestCastironDataResidencyInvalid(t *testing.T) {
+	recorder := &castironResidencyRecorder{}
+	client := sdk.NewClient(castironResidencyOptions(t, recorder)...)
+	for _, value := range []option.DataResidency{"", "UNKNOWN", "not-a-region"} {
+		err := client.Get(context.Background(), "models", nil, nil, option.WithDataResidency(value))
+		if err == nil || !strings.Contains(err.Error(), "invalid data residency") {
+			t.Fatalf("expected invalid residency, got %v", err)
+		}
+	}
+	if len(recorder.urls) != 0 {
+		t.Fatal("invalid options made an HTTP request")
+	}
+}
+
+func TestCastironDataResidencyConflicts(t *testing.T) {
+	for _, reverse := range []bool{false, true} {
+		for _, layer := range []string{"client", "request"} {
+			recorder := &castironResidencyRecorder{}
+			opts := castironResidencyOptions(t, recorder)
+			conflict := []option.RequestOption{option.WithBaseURL("https://custom.example/v1"), option.WithDataResidency(option.DataResidencyGlobal)}
+			if reverse {
+				slices.Reverse(conflict)
+			}
+			var err error
+			if layer == "client" {
+				client := sdk.NewClient(append(opts, conflict...)...)
+				err = client.Get(context.Background(), "models", nil, nil)
+			} else {
+				client := sdk.NewClient(opts...)
+				err = client.Get(context.Background(), "models", nil, nil, conflict...)
+			}
+			if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+				t.Fatalf("%s reverse=%t: expected conflict, got %v", layer, reverse, err)
+			}
+			if len(recorder.urls) != 0 {
+				t.Fatal("conflicting options made an HTTP request")
+			}
+		}
+	}
+}
+
+func TestCastironDataResidencyInheritedOverrides(t *testing.T) {
+	recorder := &castironResidencyRecorder{}
+	opts := castironResidencyOptions(t, recorder)
+	t.Setenv("OPENAI_BASE_URL", "https://environment.example/v1")
+	environment := sdk.NewClient(opts...)
+	if err := environment.Get(context.Background(), "omitted", nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	client := sdk.NewClient(append(opts, option.WithDataResidency(option.DataResidencyGlobal))...)
+	if err := client.Get(context.Background(), "original", nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.Get(context.Background(), "request", nil, nil, option.WithBaseURL("https://request.example/v1")); err != nil {
+		t.Fatal(err)
+	}
+	copy := sdk.NewClient(append(slices.Clone(client.Options), option.WithBaseURL("https://copy.example/v1"))...)
+	if err := copy.Get(context.Background(), "copy", nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	selected := sdk.NewClient(append(slices.Clone(copy.Options), option.WithDataResidency(option.DataResidencyGlobal))...)
+	if err := selected.Get(context.Background(), "selected", nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.Get(context.Background(), "unchanged", nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"https://environment.example/v1/omitted", "https://api.openai.com/v1/" + "original", "https://request.example/v1/request", "https://copy.example/v1/copy", "https://api.openai.com/v1/" + "selected", "https://api.openai.com/v1/" + "unchanged"}
+	if !reflect.DeepEqual(recorder.urls, want) {
+		t.Fatalf("URLs = %#v, want %#v", recorder.urls, want)
+	}
+}

--- a/data_residency_test.go
+++ b/data_residency_test.go
@@ -1,0 +1,187 @@
+package openai_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/azure"
+	"github.com/openai/openai-go/v3/option"
+)
+
+type residencyRecorder struct {
+	urls    []string
+	bodies  []string
+	headers []http.Header
+}
+
+func (r *residencyRecorder) Do(req *http.Request) (*http.Response, error) {
+	body := ""
+	if req.Body != nil {
+		content, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		body = string(content)
+	}
+	r.urls = append(r.urls, req.URL.String())
+	r.bodies = append(r.bodies, body)
+	r.headers = append(r.headers, req.Header.Clone())
+	return &http.Response{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": {"application/json"}}, Body: io.NopCloser(strings.NewReader(`{"id":"test","object":"model"}`)), Request: req}, nil
+}
+
+func residencyTestOptions(t *testing.T, recorder *residencyRecorder) []option.RequestOption {
+	t.Helper()
+	for _, key := range []string{"OPENAI_API_KEY", "OPENAI_ADMIN_KEY", "OPENAI_BASE_URL", "OPENAI_CUSTOM_HEADERS", "OPENAI_ORG_ID", "OPENAI_PROJECT_ID"} {
+		t.Setenv(key, "")
+	}
+	return []option.RequestOption{option.WithAPIKey("dummy-key"), option.WithHTTPClient(recorder), option.WithMaxRetries(0)}
+}
+
+func TestDataResidencyMappings(t *testing.T) {
+	for _, test := range []struct {
+		region option.DataResidency
+		host   string
+	}{
+		{option.DataResidencyGlobal, "api.openai.com"},
+		{option.DataResidencyUS, "us.api.openai.com"},
+		{option.DataResidencyEU, "eu.api.openai.com"},
+		{option.DataResidencyAE, "ae.api.openai.com"},
+	} {
+		t.Run(string(test.region), func(t *testing.T) {
+			recorder := &residencyRecorder{}
+			opts := residencyTestOptions(t, recorder)
+			client := openai.NewClient(append(opts, option.WithDataResidency(test.region))...)
+			if err := client.Post(context.Background(), "responses", map[string]string{"input": "hello"}, nil); err != nil {
+				t.Fatal(err)
+			}
+			if want := "https://" + test.host + "/v1/responses"; recorder.urls[0] != want {
+				t.Fatalf("URL = %q, want %q", recorder.urls[0], want)
+			}
+			if strings.TrimSpace(recorder.bodies[0]) != `{"input":"hello"}` {
+				t.Fatalf("unexpected wire body: %q", recorder.bodies[0])
+			}
+			for header := range recorder.headers[0] {
+				if strings.Contains(strings.ToLower(header), "residency") {
+					t.Fatalf("unexpected residency header %q", header)
+				}
+			}
+		})
+	}
+}
+
+func TestDataResidencyOptionLayers(t *testing.T) {
+	recorder := &residencyRecorder{}
+	opts := residencyTestOptions(t, recorder)
+	t.Setenv("OPENAI_BASE_URL", "https://environment.example/v1")
+	client := openai.NewClient(append(opts, option.WithDataResidency(option.DataResidencyEU))...)
+	if _, err := client.Models.Get(context.Background(), "client"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Models.Get(context.Background(), "request", option.WithBaseURL("https://request.example/v1")); err != nil {
+		t.Fatal(err)
+	}
+	service := openai.NewModelService(append(slices.Clone(client.Options), option.WithBaseURL("https://service.example/v1"))...)
+	if _, err := service.Get(context.Background(), "service"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.Get(context.Background(), "global", option.WithDataResidency(option.DataResidencyGlobal)); err != nil {
+		t.Fatal(err)
+	}
+	inherited := openai.NewClient(append(slices.Clone(client.Options), option.WithBaseURL("https://copy.example/v1"))...)
+	if err := inherited.Get(context.Background(), "copy", nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Models.Get(context.Background(), "unchanged"); err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"https://eu.api.openai.com/v1/models/client", "https://request.example/v1/models/request", "https://service.example/v1/models/service", "https://api.openai.com/v1/models/global", "https://copy.example/v1/copy", "https://eu.api.openai.com/v1/models/unchanged"}
+	if !reflect.DeepEqual(recorder.urls, want) {
+		t.Fatalf("URLs = %#v, want %#v", recorder.urls, want)
+	}
+}
+
+func TestDataResidencyConflicts(t *testing.T) {
+	for _, reverse := range []bool{false, true} {
+		for _, layer := range []string{"client", "service", "request", "inherited service"} {
+			t.Run(layer+map[bool]string{false: "/base-first", true: "/residency-first"}[reverse], func(t *testing.T) {
+				recorder := &residencyRecorder{}
+				opts := residencyTestOptions(t, recorder)
+				conflict := []option.RequestOption{option.WithBaseURL("https://custom.example/v1"), option.WithDataResidency(option.DataResidencyEU)}
+				if reverse {
+					slices.Reverse(conflict)
+				}
+				var err error
+				switch layer {
+				case "client":
+					client := openai.NewClient(append(opts, conflict...)...)
+					err = client.Get(context.Background(), "models", nil, nil)
+				case "service":
+					service := openai.NewModelService(append(opts, conflict...)...)
+					_, err = service.Get(context.Background(), "test")
+				case "request":
+					client := openai.NewClient(opts...)
+					_, err = client.Models.Get(context.Background(), "test", conflict...)
+				case "inherited service":
+					client := openai.NewClient(opts...)
+					service := openai.NewModelService(append(slices.Clone(client.Options), conflict...)...)
+					_, err = service.Get(context.Background(), "test", option.WithDataResidency(option.DataResidencyUS))
+				}
+				if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+					t.Fatalf("expected conflict, got %v", err)
+				}
+				if len(recorder.urls) != 0 {
+					t.Fatal("conflicting options made an HTTP request")
+				}
+			})
+		}
+	}
+}
+
+func TestDataResidencyInvalid(t *testing.T) {
+	recorder := &residencyRecorder{}
+	client := openai.NewClient(residencyTestOptions(t, recorder)...)
+	for _, value := range []option.DataResidency{"", "EU", "unknown"} {
+		err := client.Get(context.Background(), "models", nil, nil, option.WithDataResidency(value))
+		if err == nil || !strings.Contains(err.Error(), "invalid data residency") {
+			t.Fatalf("expected invalid residency, got %v", err)
+		}
+	}
+	if len(recorder.urls) != 0 {
+		t.Fatal("invalid options made an HTTP request")
+	}
+}
+
+func TestDataResidencyProviders(t *testing.T) {
+	for _, provider := range []struct {
+		name string
+		opt  option.RequestOption
+	}{
+		{"Azure endpoint", azure.WithEndpoint("https://azure.example", "2024-06-01")},
+		{"Azure API key", azure.WithAPIKey("dummy-azure")},
+	} {
+		for _, reverse := range []bool{false, true} {
+			t.Run(provider.name+map[bool]string{false: "/provider-first", true: "/residency-first"}[reverse], func(t *testing.T) {
+				recorder := &residencyRecorder{}
+				opts := residencyTestOptions(t, recorder)
+				conflict := []option.RequestOption{provider.opt, option.WithDataResidency(option.DataResidencyEU)}
+				if reverse {
+					slices.Reverse(conflict)
+				}
+				client := openai.NewClient(append(opts, conflict...)...)
+				err := client.Get(context.Background(), "models", nil, nil)
+				if err == nil || !strings.Contains(err.Error(), "provider") {
+					t.Fatalf("expected provider error, got %v", err)
+				}
+				if len(recorder.urls) != 0 {
+					t.Fatal("provider conflict made an HTTP request")
+				}
+			})
+		}
+	}
+}

--- a/embedding.go
+++ b/embedding.go
@@ -33,7 +33,7 @@ type EmbeddingService struct {
 // there is one), and before any request-specific options.
 func NewEmbeddingService(opts ...option.RequestOption) (r EmbeddingService) {
 	r = EmbeddingService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/file.go
+++ b/file.go
@@ -41,7 +41,7 @@ type FileService struct {
 // is one), and before any request-specific options.
 func NewFileService(opts ...option.RequestOption) (r FileService) {
 	r = FileService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/finetuning.go
+++ b/finetuning.go
@@ -3,6 +3,7 @@
 package openai
 
 import (
+	"github.com/openai/openai-go/v3/internal/requestconfig"
 	"github.com/openai/openai-go/v3/option"
 )
 
@@ -26,7 +27,7 @@ type FineTuningService struct {
 // there is one), and before any request-specific options.
 func NewFineTuningService(opts ...option.RequestOption) (r FineTuningService) {
 	r = FineTuningService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	r.Methods = NewFineTuningMethodService(opts...)
 	r.Jobs = NewFineTuningJobService(opts...)
 	r.Checkpoints = NewFineTuningCheckpointService(opts...)

--- a/finetuningalpha.go
+++ b/finetuningalpha.go
@@ -3,6 +3,7 @@
 package openai
 
 import (
+	"github.com/openai/openai-go/v3/internal/requestconfig"
 	"github.com/openai/openai-go/v3/option"
 )
 
@@ -23,7 +24,7 @@ type FineTuningAlphaService struct {
 // there is one), and before any request-specific options.
 func NewFineTuningAlphaService(opts ...option.RequestOption) (r FineTuningAlphaService) {
 	r = FineTuningAlphaService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	r.Graders = NewFineTuningAlphaGraderService(opts...)
 	return
 }

--- a/finetuningalphagrader.go
+++ b/finetuningalphagrader.go
@@ -32,7 +32,7 @@ type FineTuningAlphaGraderService struct {
 // options (if there is one), and before any request-specific options.
 func NewFineTuningAlphaGraderService(opts ...option.RequestOption) (r FineTuningAlphaGraderService) {
 	r = FineTuningAlphaGraderService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/finetuningcheckpoint.go
+++ b/finetuningcheckpoint.go
@@ -3,6 +3,7 @@
 package openai
 
 import (
+	"github.com/openai/openai-go/v3/internal/requestconfig"
 	"github.com/openai/openai-go/v3/option"
 )
 
@@ -23,7 +24,7 @@ type FineTuningCheckpointService struct {
 // options (if there is one), and before any request-specific options.
 func NewFineTuningCheckpointService(opts ...option.RequestOption) (r FineTuningCheckpointService) {
 	r = FineTuningCheckpointService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	r.Permissions = NewFineTuningCheckpointPermissionService(opts...)
 	return
 }

--- a/finetuningcheckpointpermission.go
+++ b/finetuningcheckpointpermission.go
@@ -36,7 +36,7 @@ type FineTuningCheckpointPermissionService struct {
 // client's options (if there is one), and before any request-specific options.
 func NewFineTuningCheckpointPermissionService(opts ...option.RequestOption) (r FineTuningCheckpointPermissionService) {
 	r = FineTuningCheckpointPermissionService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/finetuningjob.go
+++ b/finetuningjob.go
@@ -40,7 +40,7 @@ type FineTuningJobService struct {
 // there is one), and before any request-specific options.
 func NewFineTuningJobService(opts ...option.RequestOption) (r FineTuningJobService) {
 	r = FineTuningJobService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	r.Checkpoints = NewFineTuningJobCheckpointService(opts...)
 	return
 }

--- a/finetuningjobcheckpoint.go
+++ b/finetuningjobcheckpoint.go
@@ -36,7 +36,7 @@ type FineTuningJobCheckpointService struct {
 // options (if there is one), and before any request-specific options.
 func NewFineTuningJobCheckpointService(opts ...option.RequestOption) (r FineTuningJobCheckpointService) {
 	r = FineTuningJobCheckpointService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/finetuningmethod.go
+++ b/finetuningmethod.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 
 	"github.com/openai/openai-go/v3/internal/apijson"
+	"github.com/openai/openai-go/v3/internal/requestconfig"
 	"github.com/openai/openai-go/v3/option"
 	"github.com/openai/openai-go/v3/packages/param"
 	"github.com/openai/openai-go/v3/packages/respjson"
@@ -27,7 +28,7 @@ type FineTuningMethodService struct {
 // options (if there is one), and before any request-specific options.
 func NewFineTuningMethodService(opts ...option.RequestOption) (r FineTuningMethodService) {
 	r = FineTuningMethodService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/grader.go
+++ b/grader.go
@@ -3,6 +3,7 @@
 package openai
 
 import (
+	"github.com/openai/openai-go/v3/internal/requestconfig"
 	"github.com/openai/openai-go/v3/option"
 )
 
@@ -22,7 +23,7 @@ type GraderService struct {
 // is one), and before any request-specific options.
 func NewGraderService(opts ...option.RequestOption) (r GraderService) {
 	r = GraderService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	r.GraderModels = NewGraderGraderModelService(opts...)
 	return
 }

--- a/gradergradermodel.go
+++ b/gradergradermodel.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 
 	"github.com/openai/openai-go/v3/internal/apijson"
+	"github.com/openai/openai-go/v3/internal/requestconfig"
 	"github.com/openai/openai-go/v3/option"
 	"github.com/openai/openai-go/v3/packages/param"
 	"github.com/openai/openai-go/v3/packages/respjson"
@@ -29,7 +30,7 @@ type GraderGraderModelService struct {
 // options (if there is one), and before any request-specific options.
 func NewGraderGraderModelService(opts ...option.RequestOption) (r GraderGraderModelService) {
 	r = GraderGraderModelService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/image.go
+++ b/image.go
@@ -38,7 +38,7 @@ type ImageService struct {
 // is one), and before any request-specific options.
 func NewImageService(opts ...option.RequestOption) (r ImageService) {
 	r = ImageService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/internal/requestconfig/option_layers.go
+++ b/internal/requestconfig/option_layers.go
@@ -1,0 +1,97 @@
+package requestconfig
+
+import (
+	"fmt"
+	"net/url"
+	"slices"
+)
+
+// optionLayer preserves a configuration-call boundary after generated services
+// concatenate inherited and request options. Its contents remain immutable.
+type optionLayer []RequestOption
+
+func (opts optionLayer) Apply(cfg *RequestConfig) error {
+	previous := cfg.endpointSelector
+	cfg.endpointSelector = ""
+	defer func() { cfg.endpointSelector = previous }()
+	return cfg.Apply(opts...)
+}
+
+// InheritedOptions captures one inherited configuration layer. This is internal
+// API; generated client and service constructors use it before storing options.
+func InheritedOptions(opts ...RequestOption) []RequestOption {
+	if len(opts) == 0 {
+		return nil
+	}
+	return []RequestOption{optionLayer(slices.Clone(opts))}
+}
+
+// endpointOption carries inspectable endpoint configuration without evaluating
+// arbitrary request-option callbacks during provider construction.
+type endpointOption struct {
+	selector string
+	endpoint *url.URL
+	err      error
+}
+
+func (opt endpointOption) Apply(cfg *RequestConfig) error {
+	if opt.err != nil {
+		return opt.err
+	}
+	return cfg.SetEndpoint(opt.selector, opt.endpoint)
+}
+
+// WithEndpointSelection constructs an inspectable endpoint selector. This is
+// internal API; public endpoint options own parsing and value validation.
+func WithEndpointSelection(selector string, endpoint *url.URL, err error) RequestOption {
+	return endpointOption{selector: selector, endpoint: endpoint, err: err}
+}
+
+// ValidateEndpointOptions checks built-in selectors before a provider performs
+// credential discovery. It preserves inherited option layers and deliberately
+// does not invoke user-defined RequestOption callbacks. Normal request setup
+// still validates every option, including selectors applied by custom callbacks.
+func ValidateEndpointOptions(provider string, opts ...RequestOption) error {
+	cfg := RequestConfig{endpointProvider: provider}
+	return cfg.Apply(endpointOptionsOnly(opts)...)
+}
+
+func endpointOptionsOnly(opts []RequestOption) []RequestOption {
+	filtered := make([]RequestOption, 0, len(opts))
+	for _, opt := range opts {
+		switch opt := opt.(type) {
+		case endpointOption:
+			filtered = append(filtered, opt)
+		case optionLayer:
+			filtered = append(filtered, optionLayer(endpointOptionsOnly(opt)))
+		}
+	}
+	return filtered
+}
+
+// SetEndpoint selects an explicit endpoint within the current option layer.
+// Different selectors in one layer are an error regardless of their order.
+func (cfg *RequestConfig) SetEndpoint(selector string, endpoint *url.URL) error {
+	if selector == "data_residency" && cfg.endpointProvider != "" {
+		return fmt.Errorf("requestoption: WithDataResidency cannot be used with the %s provider", cfg.endpointProvider)
+	}
+	if cfg.endpointSelector != "" && cfg.endpointSelector != selector {
+		return fmt.Errorf("requestoption: WithDataResidency and WithBaseURL are mutually exclusive in the same configuration call")
+	}
+	cfg.endpointSelector = selector
+	cfg.dataResidencyEndpoint = selector == "data_residency"
+	cfg.BaseURL = endpoint
+	return nil
+}
+
+// WithEndpointProvider marks a third-party provider whose routing and credentials
+// cannot be combined with OpenAI data residency. This is internal API.
+func WithEndpointProvider(provider string) RequestOption {
+	return RequestOptionFunc(func(cfg *RequestConfig) error {
+		if cfg.dataResidencyEndpoint {
+			return fmt.Errorf("requestoption: WithDataResidency cannot be used with the %s provider", provider)
+		}
+		cfg.endpointProvider = provider
+		return nil
+	})
+}

--- a/internal/requestconfig/option_layers_test.go
+++ b/internal/requestconfig/option_layers_test.go
@@ -1,0 +1,60 @@
+package requestconfig
+
+import (
+	"errors"
+	"net/url"
+	"reflect"
+	"testing"
+)
+
+func TestInheritedOptionsPreservePreRequestOptions(t *testing.T) {
+	marker := errors.New("pre-request failure")
+	seen := []string{}
+	pre := func(value string) RequestOption {
+		return PreRequestOptionFunc(func(cfg *RequestConfig) error { seen = append(seen, value); cfg.WebhookSecret = value; return nil })
+	}
+	ordinary := RequestOptionFunc(func(*RequestConfig) error { t.Fatal("ordinary option executed during pre-request scan"); return nil })
+	inner := InheritedOptions(pre("inner"), ordinary, WithEnvironmentDefaultsDisabled())
+	opts := InheritedOptions(append(inner, pre("outer"))...)
+	cfg, err := PreRequestOptions(opts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.WebhookSecret != "outer" || !reflect.DeepEqual(seen, []string{"inner", "outer"}) {
+		t.Fatalf("pre-request order lost: %#v / %q", seen, cfg.WebhookSecret)
+	}
+	if !EnvironmentDefaultsDisabled(opts...) {
+		t.Fatal("nested provider marker lost")
+	}
+	_, err = PreRequestOptions(InheritedOptions(PreRequestOptionFunc(func(*RequestConfig) error { return marker }))...)
+	if !errors.Is(err, marker) {
+		t.Fatalf("pre-request error lost: %v", err)
+	}
+}
+
+func TestInheritedOptionsCaptureSlice(t *testing.T) {
+	first := RequestOptionFunc(func(cfg *RequestConfig) error { cfg.WebhookSecret = "first"; return nil })
+	second := RequestOptionFunc(func(cfg *RequestConfig) error { cfg.WebhookSecret = "second"; return nil })
+	original := []RequestOption{first}
+	captured := InheritedOptions(original...)
+	original[0] = second
+	cfg := RequestConfig{}
+	if err := cfg.Apply(captured...); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.WebhookSecret != "first" {
+		t.Fatal("inherited slice was mutated")
+	}
+}
+
+func TestInheritedOptionsRestoreOuterLayer(t *testing.T) {
+	endpoint := &url.URL{Scheme: "https", Host: "example.com"}
+	residency := RequestOptionFunc(func(cfg *RequestConfig) error { return cfg.SetEndpoint("data_residency", endpoint) })
+	base := RequestOptionFunc(func(cfg *RequestConfig) error { return cfg.SetEndpoint("base_url", endpoint) })
+	cfg := RequestConfig{}
+	opts := append([]RequestOption{base}, InheritedOptions(residency)...)
+	opts = append(opts, residency)
+	if err := cfg.Apply(opts...); err == nil {
+		t.Fatal("nested layer concealed an outer conflict")
+	}
+}

--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -173,8 +173,13 @@ func WithEnvironmentDefaultsDisabled() RequestOption {
 // provider marker returned by WithEnvironmentDefaultsDisabled.
 func EnvironmentDefaultsDisabled(opts ...RequestOption) bool {
 	for _, opt := range opts {
-		if _, ok := opt.(environmentDefaultsDisabledOption); ok {
+		switch opt := opt.(type) {
+		case environmentDefaultsDisabledOption:
 			return true
+		case optionLayer:
+			if EnvironmentDefaultsDisabled(opt...) {
+				return true
+			}
 		}
 	}
 	return false
@@ -318,11 +323,14 @@ type HTTPDoer interface {
 // Editing the variables inside RequestConfig directly is unstable api. Prefer
 // composing the RequestOption instead if possible.
 type RequestConfig struct {
-	MaxRetries     int
-	RequestTimeout time.Duration
-	Context        context.Context
-	Request        *http.Request
-	BaseURL        *url.URL
+	MaxRetries            int
+	RequestTimeout        time.Duration
+	Context               context.Context
+	Request               *http.Request
+	BaseURL               *url.URL
+	endpointSelector      string
+	endpointProvider      string
+	dataResidencyEndpoint bool
 	// DefaultBaseURL will be used if BaseURL is not explicitly overridden using
 	// WithBaseURL.
 	DefaultBaseURL     *url.URL
@@ -804,15 +812,24 @@ func (cfg *RequestConfig) Apply(opts ...RequestOption) error {
 // Only request option functions of type [PreRequestOptionFunc] are applied.
 func PreRequestOptions(opts ...RequestOption) (RequestConfig, error) {
 	cfg := RequestConfig{}
+	err := applyPreRequestOptions(&cfg, opts)
+	return cfg, err
+}
+
+func applyPreRequestOptions(cfg *RequestConfig, opts []RequestOption) error {
 	for _, opt := range opts {
-		if opt, ok := opt.(PreRequestOptionFunc); ok {
-			err := opt.Apply(&cfg)
-			if err != nil {
-				return cfg, err
+		switch opt := opt.(type) {
+		case PreRequestOptionFunc:
+			if err := opt.Apply(cfg); err != nil {
+				return err
+			}
+		case optionLayer:
+			if err := applyPreRequestOptions(cfg, opt); err != nil {
+				return err
 			}
 		}
 	}
-	return cfg, nil
+	return nil
 }
 
 // WithDefaultBaseURL returns a RequestOption that sets the client's default Base URL.

--- a/model.go
+++ b/model.go
@@ -34,7 +34,7 @@ type ModelService struct {
 // is one), and before any request-specific options.
 func NewModelService(opts ...option.RequestOption) (r ModelService) {
 	r = ModelService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/moderation.go
+++ b/moderation.go
@@ -33,7 +33,7 @@ type ModerationService struct {
 // there is one), and before any request-specific options.
 func NewModerationService(opts ...option.RequestOption) (r ModerationService) {
 	r = ModerationService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/option/data_residency.go
+++ b/option/data_residency.go
@@ -1,0 +1,43 @@
+// File generated from our OpenAPI spec by Castiron. See CONTRIBUTING.md for details.
+
+package option
+
+import (
+	"fmt"
+	"github.com/openai/openai-go/v3/internal/requestconfig"
+	"net/url"
+)
+
+// DataResidency selects an OpenAI API endpoint. Endpoint selection does not
+// grant access to a region or change project and model eligibility.
+type DataResidency string
+
+const (
+	DataResidencyGlobal DataResidency = "global"
+	DataResidencyUS     DataResidency = "us"
+	DataResidencyEU     DataResidency = "eu"
+	DataResidencyAE     DataResidency = "ae"
+)
+
+// WithDataResidency selects the OpenAI endpoint for a client, service, or request.
+// It cannot be combined with WithBaseURL in the same configuration call, but may
+// replace an inherited endpoint. It sends no additional request fields or headers
+// and never falls back to a different region. An empty or unknown value is invalid.
+func WithDataResidency(residency DataResidency) RequestOption {
+	var base string
+	switch residency {
+	case DataResidencyGlobal:
+		base = "https://api.openai.com/v1/"
+	case DataResidencyUS:
+		base = "https://us.api.openai.com/v1/"
+	case DataResidencyEU:
+		base = "https://eu.api.openai.com/v1/"
+	case DataResidencyAE:
+		base = "https://ae.api.openai.com/v1/"
+	default:
+		return requestconfig.WithEndpointSelection("data_residency", nil,
+			fmt.Errorf("requestoption: invalid data residency %q (expected global, us, eu, or ae)", residency))
+	}
+	endpoint, _ := url.Parse(base)
+	return requestconfig.WithEndpointSelection("data_residency", endpoint, nil)
+}

--- a/option/requestoption.go
+++ b/option/requestoption.go
@@ -24,6 +24,7 @@ type RequestOption = requestconfig.RequestOption
 
 // WithBaseURL returns a RequestOption that sets the BaseURL for the client.
 //
+// It cannot be combined with WithDataResidency in the same configuration call.
 // For security reasons, ensure that the base URL is trusted.
 func WithBaseURL(base string) RequestOption {
 	u, err := url.Parse(base)
@@ -31,14 +32,10 @@ func WithBaseURL(base string) RequestOption {
 		u.Path += "/"
 	}
 
-	return requestconfig.RequestOptionFunc(func(r *requestconfig.RequestConfig) error {
-		if err != nil {
-			return fmt.Errorf("requestoption: WithBaseURL failed to parse url %s", err)
-		}
-
-		r.BaseURL = u
-		return nil
-	})
+	if err != nil {
+		err = fmt.Errorf("requestoption: WithBaseURL failed to parse url %s", err)
+	}
+	return requestconfig.WithEndpointSelection("base_url", u, err)
 }
 
 // HTTPClient is primarily used to describe an [*http.Client], but also

--- a/realtime/call.go
+++ b/realtime/call.go
@@ -30,7 +30,7 @@ type CallService struct {
 // is one), and before any request-specific options.
 func NewCallService(opts ...option.RequestOption) (r CallService) {
 	r = CallService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/realtime/clientsecret.go
+++ b/realtime/clientsecret.go
@@ -32,7 +32,7 @@ type ClientSecretService struct {
 // there is one), and before any request-specific options.
 func NewClientSecretService(opts ...option.RequestOption) (r ClientSecretService) {
 	r = ClientSecretService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/realtime/realtime.go
+++ b/realtime/realtime.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 
 	"github.com/openai/openai-go/v3/internal/apijson"
+	"github.com/openai/openai-go/v3/internal/requestconfig"
 	"github.com/openai/openai-go/v3/option"
 	"github.com/openai/openai-go/v3/packages/param"
 	"github.com/openai/openai-go/v3/packages/respjson"
@@ -30,7 +31,7 @@ type RealtimeService struct {
 // there is one), and before any request-specific options.
 func NewRealtimeService(opts ...option.RequestOption) (r RealtimeService) {
 	r = RealtimeService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	r.ClientSecrets = NewClientSecretService(opts...)
 	r.Calls = NewCallService(opts...)
 	return

--- a/responses/inputitem.go
+++ b/responses/inputitem.go
@@ -34,7 +34,7 @@ type InputItemService struct {
 // there is one), and before any request-specific options.
 func NewInputItemService(opts ...option.RequestOption) (r InputItemService) {
 	r = InputItemService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/responses/inputtoken.go
+++ b/responses/inputtoken.go
@@ -31,7 +31,7 @@ type InputTokenService struct {
 // there is one), and before any request-specific options.
 func NewInputTokenService(opts ...option.RequestOption) (r InputTokenService) {
 	r = InputTokenService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/responses/response.go
+++ b/responses/response.go
@@ -40,7 +40,7 @@ type ResponseService struct {
 // there is one), and before any request-specific options.
 func NewResponseService(opts ...option.RequestOption) (r ResponseService) {
 	r = ResponseService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	r.InputItems = NewInputItemService(opts...)
 	r.InputTokens = NewInputTokenService(opts...)
 	return

--- a/skill.go
+++ b/skill.go
@@ -40,7 +40,7 @@ type SkillService struct {
 // is one), and before any request-specific options.
 func NewSkillService(opts ...option.RequestOption) (r SkillService) {
 	r = SkillService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	r.Content = NewSkillContentService(opts...)
 	r.Versions = NewSkillVersionService(opts...)
 	return

--- a/skillcontent.go
+++ b/skillcontent.go
@@ -27,7 +27,7 @@ type SkillContentService struct {
 // there is one), and before any request-specific options.
 func NewSkillContentService(opts ...option.RequestOption) (r SkillContentService) {
 	r = SkillContentService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/skillversion.go
+++ b/skillversion.go
@@ -39,7 +39,7 @@ type SkillVersionService struct {
 // there is one), and before any request-specific options.
 func NewSkillVersionService(opts ...option.RequestOption) (r SkillVersionService) {
 	r = SkillVersionService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	r.Content = NewSkillVersionContentService(opts...)
 	return
 }

--- a/skillversioncontent.go
+++ b/skillversioncontent.go
@@ -27,7 +27,7 @@ type SkillVersionContentService struct {
 // options (if there is one), and before any request-specific options.
 func NewSkillVersionContentService(opts ...option.RequestOption) (r SkillVersionContentService) {
 	r = SkillVersionContentService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/upload.go
+++ b/upload.go
@@ -35,7 +35,7 @@ type UploadService struct {
 // is one), and before any request-specific options.
 func NewUploadService(opts ...option.RequestOption) (r UploadService) {
 	r = UploadService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	r.Parts = NewUploadPartService(opts...)
 	return
 }

--- a/uploadpart.go
+++ b/uploadpart.go
@@ -36,7 +36,7 @@ type UploadPartService struct {
 // there is one), and before any request-specific options.
 func NewUploadPartService(opts ...option.RequestOption) (r UploadPartService) {
 	r = UploadPartService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/vectorstore.go
+++ b/vectorstore.go
@@ -38,7 +38,7 @@ type VectorStoreService struct {
 // there is one), and before any request-specific options.
 func NewVectorStoreService(opts ...option.RequestOption) (r VectorStoreService) {
 	r = VectorStoreService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	r.Files = NewVectorStoreFileService(opts...)
 	r.FileBatches = NewVectorStoreFileBatchService(opts...)
 	return

--- a/vectorstorefile.go
+++ b/vectorstorefile.go
@@ -35,7 +35,7 @@ type VectorStoreFileService struct {
 // there is one), and before any request-specific options.
 func NewVectorStoreFileService(opts ...option.RequestOption) (r VectorStoreFileService) {
 	r = VectorStoreFileService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/vectorstorefilebatch.go
+++ b/vectorstorefilebatch.go
@@ -35,7 +35,7 @@ type VectorStoreFileBatchService struct {
 // options (if there is one), and before any request-specific options.
 func NewVectorStoreFileBatchService(opts ...option.RequestOption) (r VectorStoreFileBatchService) {
 	r = VectorStoreFileBatchService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/video.go
+++ b/video.go
@@ -44,7 +44,7 @@ type VideoService struct {
 // 2026.
 func NewVideoService(opts ...option.RequestOption) (r VideoService) {
 	r = VideoService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/webhooks/webhook.go
+++ b/webhooks/webhook.go
@@ -37,7 +37,7 @@ type WebhookService struct {
 // is one), and before any request-specific options.
 func NewWebhookService(opts ...option.RequestOption) (r WebhookService) {
 	r = WebhookService{}
-	r.Options = opts
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 


### PR DESCRIPTION
## Summary

Let applications select an OpenAI regional endpoint by name instead of assembling base URLs themselves. `option.WithDataResidency` supports `global`, `us`, `eu`, and `ae`, with predictable precedence between inherited client settings and per-request options.

Conflicting explicit endpoints and third-party provider combinations fail locally. This changes routing only; it does not alter project eligibility or provide regional fallback. Existing streaming behavior is preserved.

## Implementation details

Preserve configuration-call boundaries in inherited option layers so selecting a regional endpoint can replace inherited routing without hiding conflicts in the same call.
