### PR TITLE
fix: track stream accumulator events for every choice

### DIFF
--- a/streamaccumulator.go
+++ b/streamaccumulator.go
@@ -7,7 +7,7 @@ type ChatCompletionAccumulator struct {
 	// The up-to-date accumulation of model's responses
 	ChatCompletion
 	choiceChatCompletionStates []chatCompletionResponseState
-	justFinished               chatCompletionResponseState
+	justFinished               []chatCompletionResponseState
 }
 
 type FinishedChatCompletionToolCall struct {
@@ -37,29 +37,32 @@ const (
 //
 // The ChatCompletion field JSON does not get accumulated.
 func (acc *ChatCompletionAccumulator) AddChunk(chunk ChatCompletionChunk) bool {
-	acc.justFinished = chatCompletionResponseState{}
+	acc.justFinished = acc.justFinished[:0]
 	if !acc.accumulateDelta(chunk) {
 		return false
 	}
 
-	// only chunks with choices can cause finished events
-	if len(chunk.Choices) == 0 {
-		return true
+	for _, choice := range chunk.Choices {
+		choiceIndex := int(choice.Index)
+		acc.choiceChatCompletionStates = expandToFit(acc.choiceChatCompletionStates, choiceIndex)
+		justFinished := acc.choiceChatCompletionStates[choiceIndex].update(choice)
+		if justFinished.state != emptyResponseState {
+			acc.justFinished = append(acc.justFinished, justFinished)
+		}
 	}
-
-	chunkIndex := int(chunk.Choices[0].Index)
-	acc.choiceChatCompletionStates = expandToFit(acc.choiceChatCompletionStates, chunkIndex)
-	acc.justFinished = acc.choiceChatCompletionStates[chunkIndex].update(chunk, chunkIndex)
 	return true
 }
 
 // JustFinishedContent retrieves the chat completion content when it is known to have just been completed.
 // The content is "just completed" when the last added chunk no longer contains a content
 // delta. If the content is just completed, the content is returned and the boolean is true. Otherwise,
-// an empty string is returned and the boolean will be false.
+// an empty string is returned and the boolean will be false. If multiple choices finish content
+// in the same chunk, the first matching choice in the chunk is returned.
 func (acc *ChatCompletionAccumulator) JustFinishedContent() (content string, ok bool) {
-	if acc.justFinished.state == contentResponseState {
-		return acc.Choices[acc.justFinished.choiceIndex].Message.Content, true
+	for _, justFinished := range acc.justFinished {
+		if justFinished.state == contentResponseState {
+			return acc.Choices[justFinished.choiceIndex].Message.Content, true
+		}
 	}
 	return "", false
 }
@@ -67,10 +70,13 @@ func (acc *ChatCompletionAccumulator) JustFinishedContent() (content string, ok 
 // JustFinishedRefusal retrieves the chat completion refusal when it is known to have just been completed.
 // The refusal is "just completed" when the last added chunk no longer contains a refusal
 // delta. If the refusal is just completed, the refusal is returned and the boolean is true. Otherwise,
-// an empty string is returned and the boolean will be false.
+// an empty string is returned and the boolean will be false. If multiple choices finish refusals
+// in the same chunk, the first matching choice in the chunk is returned.
 func (acc *ChatCompletionAccumulator) JustFinishedRefusal() (refusal string, ok bool) {
-	if acc.justFinished.state == refusalResponseState {
-		return acc.Choices[acc.justFinished.choiceIndex].Message.Refusal, true
+	for _, justFinished := range acc.justFinished {
+		if justFinished.state == refusalResponseState {
+			return acc.Choices[justFinished.choiceIndex].Message.Refusal, true
+		}
 	}
 	return "", false
 }
@@ -79,22 +85,23 @@ func (acc *ChatCompletionAccumulator) JustFinishedRefusal() (refusal string, ok 
 // A tool call is "just completed" when the last added chunk no longer contains a tool call
 // delta or contains a delta for a different tool call. If the tool call is just completed,
 // a FinishedChatCompletionToolCall is returned and the boolean is true. Otherwise, an empty
-// tool call is returned and the boolean will be false.
+// tool call is returned and the boolean will be false. If multiple choices finish tool calls
+// in the same chunk, the first matching choice in the chunk is returned.
 //
 // You cannot rely on this with a stream that has ParallelToolCalls enabled.
 func (acc *ChatCompletionAccumulator) JustFinishedToolCall() (toolcall FinishedChatCompletionToolCall, ok bool) {
-	if acc.justFinished.state == toolResponseState {
-		choice := acc.Choices[acc.justFinished.choiceIndex]
-		f := choice.Message.ToolCalls[acc.justFinished.toolCallIndex].Function
-		id := choice.Message.ToolCalls[acc.justFinished.toolCallIndex].ID
-		return FinishedChatCompletionToolCall{
-			ID:    id,
-			Index: acc.justFinished.toolCallIndex,
-			ChatCompletionMessageFunctionToolCallFunction: ChatCompletionMessageFunctionToolCallFunction{
-				Name:      f.Name,
-				Arguments: f.Arguments,
-			},
-		}, true
+	for _, justFinished := range acc.justFinished {
+		if justFinished.state == toolResponseState {
+			toolCall := acc.Choices[justFinished.choiceIndex].Message.ToolCalls[justFinished.toolCallIndex]
+			return FinishedChatCompletionToolCall{
+				ID:    toolCall.ID,
+				Index: justFinished.toolCallIndex,
+				ChatCompletionMessageFunctionToolCallFunction: ChatCompletionMessageFunctionToolCallFunction{
+					Name:      toolCall.Function.Name,
+					Arguments: toolCall.Function.Arguments,
+				},
+			}, true
+		}
 	}
 	return FinishedChatCompletionToolCall{}, false
 }
@@ -171,9 +178,9 @@ func (cc *ChatCompletion) accumulateDelta(chunk ChatCompletionChunk) bool {
 
 // Updates the internal response state and returns the previous state if
 // the state changed. This ensures that JustFinished events only fire once.
-func (prev *chatCompletionResponseState) update(chunk ChatCompletionChunk, choiceIndex int) (justFinished chatCompletionResponseState) {
-	delta := chunk.Choices[0].Delta
-	new := chatCompletionResponseState{choiceIndex: choiceIndex}
+func (prev *chatCompletionResponseState) update(choice ChatCompletionChunkChoice) (justFinished chatCompletionResponseState) {
+	delta := choice.Delta
+	new := chatCompletionResponseState{choiceIndex: int(choice.Index)}
 	switch {
 	case len(delta.ToolCalls) > 0 && delta.Content == "":
 		new.state = toolResponseState

--- a/streamaccumulator.go
+++ b/streamaccumulator.go
@@ -7,7 +7,8 @@ type ChatCompletionAccumulator struct {
 	// The up-to-date accumulation of model's responses
 	ChatCompletion
 	choiceChatCompletionStates []chatCompletionResponseState
-	justFinished               []chatCompletionResponseState
+	justFinished               chatCompletionResponseState
+	justFinishedByChoice       []chatCompletionResponseState
 }
 
 type FinishedChatCompletionToolCall struct {
@@ -37,17 +38,21 @@ const (
 //
 // The ChatCompletion field JSON does not get accumulated.
 func (acc *ChatCompletionAccumulator) AddChunk(chunk ChatCompletionChunk) bool {
-	acc.justFinished = acc.justFinished[:0]
+	acc.justFinished = chatCompletionResponseState{}
+	acc.justFinishedByChoice = acc.justFinishedByChoice[:0]
 	if !acc.accumulateDelta(chunk) {
 		return false
 	}
 
-	for _, choice := range chunk.Choices {
+	for i, choice := range chunk.Choices {
 		choiceIndex := int(choice.Index)
 		acc.choiceChatCompletionStates = expandToFit(acc.choiceChatCompletionStates, choiceIndex)
 		justFinished := acc.choiceChatCompletionStates[choiceIndex].update(choice)
+		if i == 0 {
+			acc.justFinished = justFinished
+		}
 		if justFinished.state != emptyResponseState {
-			acc.justFinished = append(acc.justFinished, justFinished)
+			acc.justFinishedByChoice = append(acc.justFinishedByChoice, justFinished)
 		}
 	}
 	return true
@@ -56,11 +61,22 @@ func (acc *ChatCompletionAccumulator) AddChunk(chunk ChatCompletionChunk) bool {
 // JustFinishedContent retrieves the chat completion content when it is known to have just been completed.
 // The content is "just completed" when the last added chunk no longer contains a content
 // delta. If the content is just completed, the content is returned and the boolean is true. Otherwise,
-// an empty string is returned and the boolean will be false. If multiple choices finish content
-// in the same chunk, the first matching choice in the chunk is returned.
+// an empty string is returned and the boolean will be false.
+//
+// This method preserves the legacy behavior of reporting events only for the first choice in the
+// most recently added chunk. Use [ChatCompletionAccumulator.JustFinishedContentForChoice] to inspect
+// another choice.
 func (acc *ChatCompletionAccumulator) JustFinishedContent() (content string, ok bool) {
-	for _, justFinished := range acc.justFinished {
-		if justFinished.state == contentResponseState {
+	if acc.justFinished.state == contentResponseState {
+		return acc.Choices[acc.justFinished.choiceIndex].Message.Content, true
+	}
+	return "", false
+}
+
+// JustFinishedContentForChoice retrieves content that was just completed for the given choice.
+func (acc *ChatCompletionAccumulator) JustFinishedContentForChoice(choiceIndex int) (content string, ok bool) {
+	for _, justFinished := range acc.justFinishedByChoice {
+		if justFinished.choiceIndex == choiceIndex && justFinished.state == contentResponseState {
 			return acc.Choices[justFinished.choiceIndex].Message.Content, true
 		}
 	}
@@ -70,11 +86,22 @@ func (acc *ChatCompletionAccumulator) JustFinishedContent() (content string, ok 
 // JustFinishedRefusal retrieves the chat completion refusal when it is known to have just been completed.
 // The refusal is "just completed" when the last added chunk no longer contains a refusal
 // delta. If the refusal is just completed, the refusal is returned and the boolean is true. Otherwise,
-// an empty string is returned and the boolean will be false. If multiple choices finish refusals
-// in the same chunk, the first matching choice in the chunk is returned.
+// an empty string is returned and the boolean will be false.
+//
+// This method preserves the legacy behavior of reporting events only for the first choice in the
+// most recently added chunk. Use [ChatCompletionAccumulator.JustFinishedRefusalForChoice] to inspect
+// another choice.
 func (acc *ChatCompletionAccumulator) JustFinishedRefusal() (refusal string, ok bool) {
-	for _, justFinished := range acc.justFinished {
-		if justFinished.state == refusalResponseState {
+	if acc.justFinished.state == refusalResponseState {
+		return acc.Choices[acc.justFinished.choiceIndex].Message.Refusal, true
+	}
+	return "", false
+}
+
+// JustFinishedRefusalForChoice retrieves a refusal that was just completed for the given choice.
+func (acc *ChatCompletionAccumulator) JustFinishedRefusalForChoice(choiceIndex int) (refusal string, ok bool) {
+	for _, justFinished := range acc.justFinishedByChoice {
+		if justFinished.choiceIndex == choiceIndex && justFinished.state == refusalResponseState {
 			return acc.Choices[justFinished.choiceIndex].Message.Refusal, true
 		}
 	}
@@ -85,25 +112,42 @@ func (acc *ChatCompletionAccumulator) JustFinishedRefusal() (refusal string, ok 
 // A tool call is "just completed" when the last added chunk no longer contains a tool call
 // delta or contains a delta for a different tool call. If the tool call is just completed,
 // a FinishedChatCompletionToolCall is returned and the boolean is true. Otherwise, an empty
-// tool call is returned and the boolean will be false. If multiple choices finish tool calls
-// in the same chunk, the first matching choice in the chunk is returned.
+// tool call is returned and the boolean will be false.
 //
 // You cannot rely on this with a stream that has ParallelToolCalls enabled.
+//
+// This method preserves the legacy behavior of reporting events only for the first choice in the
+// most recently added chunk. Use [ChatCompletionAccumulator.JustFinishedToolCallForChoice] to inspect
+// another choice.
 func (acc *ChatCompletionAccumulator) JustFinishedToolCall() (toolcall FinishedChatCompletionToolCall, ok bool) {
-	for _, justFinished := range acc.justFinished {
-		if justFinished.state == toolResponseState {
-			toolCall := acc.Choices[justFinished.choiceIndex].Message.ToolCalls[justFinished.toolCallIndex]
-			return FinishedChatCompletionToolCall{
-				ID:    toolCall.ID,
-				Index: justFinished.toolCallIndex,
-				ChatCompletionMessageFunctionToolCallFunction: ChatCompletionMessageFunctionToolCallFunction{
-					Name:      toolCall.Function.Name,
-					Arguments: toolCall.Function.Arguments,
-				},
-			}, true
+	if acc.justFinished.state != toolResponseState {
+		return FinishedChatCompletionToolCall{}, false
+	}
+	return acc.finishedToolCall(acc.justFinished), true
+}
+
+// JustFinishedToolCallForChoice retrieves a tool call that was just completed for the given choice.
+//
+// You cannot rely on this with a stream that has ParallelToolCalls enabled.
+func (acc *ChatCompletionAccumulator) JustFinishedToolCallForChoice(choiceIndex int) (toolcall FinishedChatCompletionToolCall, ok bool) {
+	for _, justFinished := range acc.justFinishedByChoice {
+		if justFinished.choiceIndex == choiceIndex && justFinished.state == toolResponseState {
+			return acc.finishedToolCall(justFinished), true
 		}
 	}
 	return FinishedChatCompletionToolCall{}, false
+}
+
+func (acc *ChatCompletionAccumulator) finishedToolCall(justFinished chatCompletionResponseState) FinishedChatCompletionToolCall {
+	toolCall := acc.Choices[justFinished.choiceIndex].Message.ToolCalls[justFinished.toolCallIndex]
+	return FinishedChatCompletionToolCall{
+		ID:    toolCall.ID,
+		Index: justFinished.toolCallIndex,
+		ChatCompletionMessageFunctionToolCallFunction: ChatCompletionMessageFunctionToolCallFunction{
+			Name:      toolCall.Function.Name,
+			Arguments: toolCall.Function.Arguments,
+		},
+	}
 }
 
 // Concatenates a ChatCompletionChunk onto a ChatCompletion. Returns false and

--- a/streamaccumulator.go
+++ b/streamaccumulator.go
@@ -6,9 +6,10 @@ import "github.com/openai/openai-go/v3/shared/constant"
 type ChatCompletionAccumulator struct {
 	// The up-to-date accumulation of model's responses
 	ChatCompletion
-	choiceChatCompletionStates []chatCompletionResponseState
-	justFinished               chatCompletionResponseState
-	justFinishedByChoice       []chatCompletionResponseState
+	choiceChatCompletionStates       []chatCompletionResponseState
+	legacyChoiceChatCompletionStates []chatCompletionResponseState
+	justFinished                     chatCompletionResponseState
+	justFinishedByChoice             []chatCompletionResponseState
 }
 
 type FinishedChatCompletionToolCall struct {
@@ -44,13 +45,17 @@ func (acc *ChatCompletionAccumulator) AddChunk(chunk ChatCompletionChunk) bool {
 		return false
 	}
 
-	for i, choice := range chunk.Choices {
+	if len(chunk.Choices) > 0 {
+		firstChoice := chunk.Choices[0]
+		choiceIndex := int(firstChoice.Index)
+		acc.legacyChoiceChatCompletionStates = expandToFit(acc.legacyChoiceChatCompletionStates, choiceIndex)
+		acc.justFinished = acc.legacyChoiceChatCompletionStates[choiceIndex].update(firstChoice)
+	}
+
+	for _, choice := range chunk.Choices {
 		choiceIndex := int(choice.Index)
 		acc.choiceChatCompletionStates = expandToFit(acc.choiceChatCompletionStates, choiceIndex)
 		justFinished := acc.choiceChatCompletionStates[choiceIndex].update(choice)
-		if i == 0 {
-			acc.justFinished = justFinished
-		}
 		if justFinished.state != emptyResponseState {
 			acc.justFinishedByChoice = append(acc.justFinishedByChoice, justFinished)
 		}

--- a/streamaccumulator_state_test.go
+++ b/streamaccumulator_state_test.go
@@ -161,6 +161,64 @@ func TestAccumulatorSingularFinishedEventsUseFirstWireChoice(t *testing.T) {
 	}
 }
 
+func TestAccumulatorSingularToolCallIgnoresAlternateChoiceWhenFirstChoiceIsOmitted(t *testing.T) {
+	var acc openai.ChatCompletionAccumulator
+
+	pr688AddChunk(t, &acc, `{"id":"test","choices":[{"index":0,"delta":{"content":"selected"}},{"index":1,"delta":{"tool_calls":[{"index":0,"id":"alternate_call","type":"function","function":{"name":"lookup","arguments":"{\"id\":\"example\"}"}}]}}]}`)
+	pr688AssertNoFinishedToolCall(t, &acc)
+
+	finishAlternate := `{"id":"test","choices":[{"index":1,"delta":{},"finish_reason":"tool_calls"}]}`
+	pr688AddChunk(t, &acc, finishAlternate)
+	pr688AssertNoFinishedToolCall(t, &acc)
+
+	toolCall, ok := acc.JustFinishedToolCallForChoice(1)
+	if !ok {
+		t.Fatal("JustFinishedToolCallForChoice did not return the alternate choice tool call")
+	}
+	if toolCall.ID != "alternate_call" || toolCall.Name != "lookup" {
+		t.Fatalf("alternate choice tool call: got ID %q and name %q", toolCall.ID, toolCall.Name)
+	}
+
+	pr688AddChunk(t, &acc, finishAlternate)
+	pr688AssertNoFinishedToolCall(t, &acc)
+	if toolCall, ok := acc.JustFinishedToolCallForChoice(1); ok {
+		t.Fatalf("JustFinishedToolCallForChoice returned repeated tool call: %+v", toolCall)
+	}
+}
+
+func TestAccumulatorSingularToolCallKeepsIndependentLegacyChoiceState(t *testing.T) {
+	var acc openai.ChatCompletionAccumulator
+
+	pr688AddChunk(t, &acc, `{"id":"test","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"selected_call","type":"function","function":{"name":"selected_tool","arguments":"{}"}}]}},{"index":1,"delta":{"content":"other"}}]}`)
+	pr688AssertNoFinishedToolCall(t, &acc)
+
+	pr688AddChunk(t, &acc, `{"id":"test","choices":[{"index":1,"delta":{"content":" continues"}},{"index":0,"delta":{"tool_calls":null}}]}`)
+	pr688AssertNoFinishedToolCall(t, &acc)
+	choiceToolCall, ok := acc.JustFinishedToolCallForChoice(0)
+	if !ok {
+		t.Fatal("JustFinishedToolCallForChoice did not return the selected choice tool call")
+	}
+	if choiceToolCall.ID != "selected_call" || choiceToolCall.Name != "selected_tool" {
+		t.Fatalf("choice-aware tool call: got ID %q and name %q", choiceToolCall.ID, choiceToolCall.Name)
+	}
+
+	finishSelected := `{"id":"test","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`
+	pr688AddChunk(t, &acc, finishSelected)
+	legacyToolCall, ok := acc.JustFinishedToolCall()
+	if !ok {
+		t.Fatal("JustFinishedToolCall did not return the selected choice tool call")
+	}
+	if legacyToolCall.ID != "selected_call" || legacyToolCall.Name != "selected_tool" {
+		t.Fatalf("legacy tool call: got ID %q and name %q", legacyToolCall.ID, legacyToolCall.Name)
+	}
+	if toolCall, ok := acc.JustFinishedToolCallForChoice(0); ok {
+		t.Fatalf("JustFinishedToolCallForChoice returned repeated tool call: %+v", toolCall)
+	}
+
+	pr688AddChunk(t, &acc, finishSelected)
+	pr688AssertNoFinishedToolCall(t, &acc)
+}
+
 func TestAccumulatorSingularContentUsesFirstWireChoice(t *testing.T) {
 	var acc openai.ChatCompletionAccumulator
 

--- a/streamaccumulator_state_test.go
+++ b/streamaccumulator_state_test.go
@@ -64,6 +64,73 @@ func TestAccumulatorEmptyAndNullToolCallStateTransitions(t *testing.T) {
 	}
 }
 
+func TestAccumulatorTracksFinishedEventsForEveryChoice(t *testing.T) {
+	var acc openai.ChatCompletionAccumulator
+
+	pr688AddChunk(t, &acc, `{"id":"test","choices":[{"index":0,"delta":{"content":"choice zero"}},{"index":1,"delta":{"refusal":"choice one refusal"}},{"index":2,"delta":{"tool_calls":[{"index":1,"id":"call_choice_two","type":"function","function":{"name":"choice_two_tool","arguments":"{\"value\":2}"}}]}}]}`)
+	pr688AddChunk(t, &acc, `{"id":"test","choices":[{"index":0,"delta":{"content":" continues"}},{"index":1,"delta":{},"finish_reason":"stop"},{"index":2,"delta":{},"finish_reason":"tool_calls"}]}`)
+
+	if content, ok := acc.JustFinishedContent(); ok {
+		t.Fatalf("JustFinishedContent returned unexpected content: %q", content)
+	}
+
+	refusal, ok := acc.JustFinishedRefusal()
+	if !ok {
+		t.Fatal("JustFinishedRefusal did not return the completed refusal")
+	}
+	if refusal != "choice one refusal" {
+		t.Fatalf("refusal: expected %q, got %q", "choice one refusal", refusal)
+	}
+
+	toolCall, ok := acc.JustFinishedToolCall()
+	if !ok {
+		t.Fatal("JustFinishedToolCall did not return the completed tool call")
+	}
+	if toolCall.Index != 1 {
+		t.Fatalf("tool call index: expected 1, got %d", toolCall.Index)
+	}
+	if toolCall.ID != "call_choice_two" {
+		t.Fatalf("tool call ID: expected %q, got %q", "call_choice_two", toolCall.ID)
+	}
+	if toolCall.Name != "choice_two_tool" {
+		t.Fatalf("tool call name: expected %q, got %q", "choice_two_tool", toolCall.Name)
+	}
+	if toolCall.Arguments != `{"value":2}` {
+		t.Fatalf("tool call arguments: expected %q, got %q", `{"value":2}`, toolCall.Arguments)
+	}
+
+	pr688AddChunk(t, &acc, `{"id":"test","choices":[{"index":0,"delta":{},"finish_reason":"stop"},{"index":1,"delta":{},"finish_reason":"stop"},{"index":2,"delta":{},"finish_reason":"tool_calls"}]}`)
+
+	content, ok := acc.JustFinishedContent()
+	if !ok {
+		t.Fatal("JustFinishedContent did not return the completed content")
+	}
+	if content != "choice zero continues" {
+		t.Fatalf("content: expected %q, got %q", "choice zero continues", content)
+	}
+	if refusal, ok := acc.JustFinishedRefusal(); ok {
+		t.Fatalf("JustFinishedRefusal returned repeated refusal: %q", refusal)
+	}
+	if toolCall, ok := acc.JustFinishedToolCall(); ok {
+		t.Fatalf("JustFinishedToolCall returned repeated tool call: %+v", toolCall)
+	}
+}
+
+func TestAccumulatorReturnsFirstMatchingFinishedChoice(t *testing.T) {
+	var acc openai.ChatCompletionAccumulator
+
+	pr688AddChunk(t, &acc, `{"id":"test","choices":[{"index":2,"delta":{"content":"choice two"}},{"index":1,"delta":{"content":"choice one"}}]}`)
+	pr688AddChunk(t, &acc, `{"id":"test","choices":[{"index":2,"delta":{},"finish_reason":"stop"},{"index":1,"delta":{},"finish_reason":"stop"}]}`)
+
+	content, ok := acc.JustFinishedContent()
+	if !ok {
+		t.Fatal("JustFinishedContent did not return completed content")
+	}
+	if content != "choice two" {
+		t.Fatalf("content: expected %q, got %q", "choice two", content)
+	}
+}
+
 func pr688AddChunk(t *testing.T, acc *openai.ChatCompletionAccumulator, raw string) {
 	t.Helper()
 

--- a/streamaccumulator_state_test.go
+++ b/streamaccumulator_state_test.go
@@ -74,7 +74,10 @@ func TestAccumulatorTracksFinishedEventsForEveryChoice(t *testing.T) {
 		t.Fatalf("JustFinishedContent returned unexpected content: %q", content)
 	}
 
-	refusal, ok := acc.JustFinishedRefusal()
+	if refusal, ok := acc.JustFinishedRefusal(); ok {
+		t.Fatalf("JustFinishedRefusal returned alternate choice refusal: %q", refusal)
+	}
+	refusal, ok := acc.JustFinishedRefusalForChoice(1)
 	if !ok {
 		t.Fatal("JustFinishedRefusal did not return the completed refusal")
 	}
@@ -82,7 +85,10 @@ func TestAccumulatorTracksFinishedEventsForEveryChoice(t *testing.T) {
 		t.Fatalf("refusal: expected %q, got %q", "choice one refusal", refusal)
 	}
 
-	toolCall, ok := acc.JustFinishedToolCall()
+	if toolCall, toolCallOK := acc.JustFinishedToolCall(); toolCallOK {
+		t.Fatalf("JustFinishedToolCall returned alternate choice tool call: %+v", toolCall)
+	}
+	toolCall, ok := acc.JustFinishedToolCallForChoice(2)
 	if !ok {
 		t.Fatal("JustFinishedToolCall did not return the completed tool call")
 	}
@@ -108,15 +114,54 @@ func TestAccumulatorTracksFinishedEventsForEveryChoice(t *testing.T) {
 	if content != "choice zero continues" {
 		t.Fatalf("content: expected %q, got %q", "choice zero continues", content)
 	}
-	if refusal, ok := acc.JustFinishedRefusal(); ok {
+	if refusal, ok := acc.JustFinishedRefusalForChoice(1); ok {
 		t.Fatalf("JustFinishedRefusal returned repeated refusal: %q", refusal)
 	}
-	if toolCall, ok := acc.JustFinishedToolCall(); ok {
+	if toolCall, ok := acc.JustFinishedToolCallForChoice(2); ok {
 		t.Fatalf("JustFinishedToolCall returned repeated tool call: %+v", toolCall)
 	}
 }
 
-func TestAccumulatorReturnsFirstMatchingFinishedChoice(t *testing.T) {
+func TestAccumulatorSingularFinishedEventsUseFirstWireChoice(t *testing.T) {
+	var acc openai.ChatCompletionAccumulator
+
+	pr688AddChunk(t, &acc, `{"id":"test","choices":[{"index":0,"delta":{"content":"selected"}},{"index":1,"delta":{"tool_calls":[{"index":0,"id":"alternate_tool","type":"function","function":{"name":"mutate","arguments":"{}"}}]}},{"index":2,"delta":{"refusal":"alternate refusal"}}]}`)
+	pr688AddChunk(t, &acc, `{"id":"test","choices":[{"index":0,"delta":{"content":" response"}},{"index":1,"delta":{},"finish_reason":"tool_calls"},{"index":2,"delta":{},"finish_reason":"stop"}]}`)
+
+	if toolCall, ok := acc.JustFinishedToolCall(); ok {
+		t.Errorf("JustFinishedToolCall returned alternate choice tool call: %+v", toolCall)
+	}
+	if refusal, ok := acc.JustFinishedRefusal(); ok {
+		t.Errorf("JustFinishedRefusal returned alternate choice refusal: %q", refusal)
+	}
+	if content, ok := acc.JustFinishedContent(); ok {
+		t.Errorf("JustFinishedContent returned unfinished first choice content: %q", content)
+	}
+
+	finish := `{"id":"test","choices":[{"index":0,"delta":{},"finish_reason":"stop"},{"index":1,"delta":{},"finish_reason":"tool_calls"},{"index":2,"delta":{},"finish_reason":"stop"}]}`
+	pr688AddChunk(t, &acc, finish)
+
+	content, ok := acc.JustFinishedContent()
+	if !ok {
+		t.Fatal("JustFinishedContent did not return completed first choice content")
+	}
+	if content != "selected response" {
+		t.Fatalf("content: expected %q, got %q", "selected response", content)
+	}
+	if toolCall, ok := acc.JustFinishedToolCall(); ok {
+		t.Errorf("JustFinishedToolCall repeated alternate choice tool call: %+v", toolCall)
+	}
+	if refusal, ok := acc.JustFinishedRefusal(); ok {
+		t.Errorf("JustFinishedRefusal repeated alternate choice refusal: %q", refusal)
+	}
+
+	pr688AddChunk(t, &acc, finish)
+	if content, ok := acc.JustFinishedContent(); ok {
+		t.Errorf("JustFinishedContent repeated completed first choice content: %q", content)
+	}
+}
+
+func TestAccumulatorSingularContentUsesFirstWireChoice(t *testing.T) {
 	var acc openai.ChatCompletionAccumulator
 
 	pr688AddChunk(t, &acc, `{"id":"test","choices":[{"index":2,"delta":{"content":"choice two"}},{"index":1,"delta":{"content":"choice one"}}]}`)
@@ -128,6 +173,14 @@ func TestAccumulatorReturnsFirstMatchingFinishedChoice(t *testing.T) {
 	}
 	if content != "choice two" {
 		t.Fatalf("content: expected %q, got %q", "choice two", content)
+	}
+
+	content, ok = acc.JustFinishedContentForChoice(1)
+	if !ok {
+		t.Fatal("JustFinishedContentForChoice did not return second choice content")
+	}
+	if content != "choice one" {
+		t.Fatalf("choice 1 content: expected %q, got %q", "choice one", content)
 	}
 }
 


### PR DESCRIPTION
Fixes #428.

## Summary

- process every choice in a streamed chat-completion chunk when updating accumulator state
- retain each finished state transition from the most recently added chunk so content, refusal, and tool-call helpers do not suppress one another
- preserve the existing singular helper APIs and return the first matching choice in chunk order when multiple choices finish the same response type
- add focused multi-choice and exactly-once regression coverage

## Root cause

`accumulateDelta` already accumulated every element in `chunk.Choices`, but `AddChunk` and the state transition helper only inspected `chunk.Choices[0]`. As a result, later choices were present in the accumulated response while their finished content, refusal, or tool-call events could be missed.

## Compatibility

This is local handwritten accumulator logic. It does not change exported types, method signatures, request serialization, response wire shapes, or generated SDK source. Single-choice behavior is unchanged. For multiple same-type completions in one chunk, the existing singular helpers return the first matching choice in wire order.

## Validation

- `GOTOOLCHAIN=local go test . -run '^(TestAccumulatorTracksFinishedEventsForEveryChoice|TestAccumulatorReturnsFirstMatchingFinishedChoice|TestAccumulatorEmptyAndNullToolCallStateTransitions|TestAccumulatorToolCallWithEmptyContentAtNonzeroChoice|TestAccumulatorToolCallWithEmptyContent)$' -count=1 -v`
- all Go packages passed under `GOTOOLCHAIN=local ./scripts/test`; after the tests passed, the local wrapper reported that its mock-server PID had already exited during cleanup
- `GOFLAGS=-buildvcs=false GOTOOLCHAIN=local ./scripts/lint` (0 issues; VCS stamping disabled for the detached worktree environment)
- `git diff --check`