### PR TITLE
fix: track accumulator events per choice

### DIFF
--- a/streamaccumulator.go
+++ b/streamaccumulator.go
@@ -7,7 +7,7 @@ type ChatCompletionAccumulator struct {
 	// The up-to-date accumulation of model's responses
 	ChatCompletion
 	choiceChatCompletionStates []chatCompletionResponseState
-	justFinished               chatCompletionResponseState
+	justFinished               []chatCompletionResponseState
 }
 
 type FinishedChatCompletionToolCall struct {
@@ -37,7 +37,7 @@ const (
 //
 // The ChatCompletion field JSON does not get accumulated.
 func (acc *ChatCompletionAccumulator) AddChunk(chunk ChatCompletionChunk) bool {
-	acc.justFinished = chatCompletionResponseState{}
+	acc.justFinished = acc.justFinished[:0]
 	if !acc.accumulateDelta(chunk) {
 		return false
 	}
@@ -47,19 +47,27 @@ func (acc *ChatCompletionAccumulator) AddChunk(chunk ChatCompletionChunk) bool {
 		return true
 	}
 
-	chunkIndex := int(chunk.Choices[0].Index)
-	acc.choiceChatCompletionStates = expandToFit(acc.choiceChatCompletionStates, chunkIndex)
-	acc.justFinished = acc.choiceChatCompletionStates[chunkIndex].update(chunk, chunkIndex)
+	for _, choice := range chunk.Choices {
+		choiceIndex := int(choice.Index)
+		acc.choiceChatCompletionStates = expandToFit(acc.choiceChatCompletionStates, choiceIndex)
+		justFinished := acc.choiceChatCompletionStates[choiceIndex].update(choice)
+		if justFinished.state != emptyResponseState {
+			acc.justFinished = append(acc.justFinished, justFinished)
+		}
+	}
 	return true
 }
 
 // JustFinishedContent retrieves the chat completion content when it is known to have just been completed.
 // The content is "just completed" when the last added chunk no longer contains a content
 // delta. If the content is just completed, the content is returned and the boolean is true. Otherwise,
-// an empty string is returned and the boolean will be false.
+// an empty string is returned and the boolean will be false. If multiple choices finish content
+// in the same chunk, the first matching choice in the chunk is returned.
 func (acc *ChatCompletionAccumulator) JustFinishedContent() (content string, ok bool) {
-	if acc.justFinished.state == contentResponseState {
-		return acc.Choices[acc.justFinished.choiceIndex].Message.Content, true
+	for _, justFinished := range acc.justFinished {
+		if justFinished.state == contentResponseState {
+			return acc.Choices[justFinished.choiceIndex].Message.Content, true
+		}
 	}
 	return "", false
 }
@@ -67,10 +75,13 @@ func (acc *ChatCompletionAccumulator) JustFinishedContent() (content string, ok 
 // JustFinishedRefusal retrieves the chat completion refusal when it is known to have just been completed.
 // The refusal is "just completed" when the last added chunk no longer contains a refusal
 // delta. If the refusal is just completed, the refusal is returned and the boolean is true. Otherwise,
-// an empty string is returned and the boolean will be false.
+// an empty string is returned and the boolean will be false. If multiple choices finish refusals
+// in the same chunk, the first matching choice in the chunk is returned.
 func (acc *ChatCompletionAccumulator) JustFinishedRefusal() (refusal string, ok bool) {
-	if acc.justFinished.state == refusalResponseState {
-		return acc.Choices[acc.justFinished.choiceIndex].Message.Refusal, true
+	for _, justFinished := range acc.justFinished {
+		if justFinished.state == refusalResponseState {
+			return acc.Choices[justFinished.choiceIndex].Message.Refusal, true
+		}
 	}
 	return "", false
 }
@@ -79,22 +90,23 @@ func (acc *ChatCompletionAccumulator) JustFinishedRefusal() (refusal string, ok 
 // A tool call is "just completed" when the last added chunk no longer contains a tool call
 // delta or contains a delta for a different tool call. If the tool call is just completed,
 // a FinishedChatCompletionToolCall is returned and the boolean is true. Otherwise, an empty
-// tool call is returned and the boolean will be false.
+// tool call is returned and the boolean will be false. If multiple choices finish tool calls
+// in the same chunk, the first matching choice in the chunk is returned.
 //
 // You cannot rely on this with a stream that has ParallelToolCalls enabled.
 func (acc *ChatCompletionAccumulator) JustFinishedToolCall() (toolcall FinishedChatCompletionToolCall, ok bool) {
-	if acc.justFinished.state == toolResponseState {
-		choice := acc.Choices[acc.justFinished.choiceIndex]
-		f := choice.Message.ToolCalls[acc.justFinished.toolCallIndex].Function
-		id := choice.Message.ToolCalls[acc.justFinished.toolCallIndex].ID
-		return FinishedChatCompletionToolCall{
-			ID:    id,
-			Index: acc.justFinished.toolCallIndex,
-			ChatCompletionMessageFunctionToolCallFunction: ChatCompletionMessageFunctionToolCallFunction{
-				Name:      f.Name,
-				Arguments: f.Arguments,
-			},
-		}, true
+	for _, justFinished := range acc.justFinished {
+		if justFinished.state == toolResponseState {
+			toolCall := acc.Choices[justFinished.choiceIndex].Message.ToolCalls[justFinished.toolCallIndex]
+			return FinishedChatCompletionToolCall{
+				ID:    toolCall.ID,
+				Index: justFinished.toolCallIndex,
+				ChatCompletionMessageFunctionToolCallFunction: ChatCompletionMessageFunctionToolCallFunction{
+					Name:      toolCall.Function.Name,
+					Arguments: toolCall.Function.Arguments,
+				},
+			}, true
+		}
 	}
 	return FinishedChatCompletionToolCall{}, false
 }
@@ -171,9 +183,9 @@ func (cc *ChatCompletion) accumulateDelta(chunk ChatCompletionChunk) bool {
 
 // Updates the internal response state and returns the previous state if
 // the state changed. This ensures that JustFinished events only fire once.
-func (prev *chatCompletionResponseState) update(chunk ChatCompletionChunk, choiceIndex int) (justFinished chatCompletionResponseState) {
-	delta := chunk.Choices[0].Delta
-	new := chatCompletionResponseState{choiceIndex: choiceIndex}
+func (prev *chatCompletionResponseState) update(choice ChatCompletionChunkChoice) (justFinished chatCompletionResponseState) {
+	delta := choice.Delta
+	new := chatCompletionResponseState{choiceIndex: int(choice.Index)}
 	switch {
 	case len(delta.ToolCalls) > 0 && delta.Content == "":
 		new.state = toolResponseState

--- a/streamaccumulator_state_test.go
+++ b/streamaccumulator_state_test.go
@@ -64,6 +64,88 @@ func TestAccumulatorEmptyAndNullToolCallStateTransitions(t *testing.T) {
 	}
 }
 
+func TestAccumulatorJustFinishedContentUsesChoiceIndex(t *testing.T) {
+	var acc openai.ChatCompletionAccumulator
+
+	pr688AddChunk(t, &acc, `{"id":"test","choices":[{"index":0,"delta":{"content":"choice zero"}},{"index":1,"delta":{"content":"choice one"}}]}`)
+	pr688AddChunk(t, &acc, `{"id":"test","choices":[{"index":0,"delta":{"content":" continues"}},{"index":1,"delta":{},"finish_reason":"stop"}]}`)
+
+	content, ok := acc.JustFinishedContent()
+	if !ok {
+		t.Fatal("JustFinishedContent did not return the completed content")
+	}
+	if content != "choice one" {
+		t.Fatalf("content: expected %q, got %q", "choice one", content)
+	}
+}
+
+func TestAccumulatorJustFinishedContentReturnsFirstMatchingChoice(t *testing.T) {
+	var acc openai.ChatCompletionAccumulator
+
+	pr688AddChunk(t, &acc, `{"id":"test","choices":[{"index":2,"delta":{"content":"choice two"}},{"index":1,"delta":{"content":"choice one"}}]}`)
+	pr688AddChunk(t, &acc, `{"id":"test","choices":[{"index":2,"delta":{},"finish_reason":"stop"},{"index":1,"delta":{},"finish_reason":"stop"}]}`)
+
+	content, ok := acc.JustFinishedContent()
+	if !ok {
+		t.Fatal("JustFinishedContent did not return the completed content")
+	}
+	if content != "choice two" {
+		t.Fatalf("content: expected %q, got %q", "choice two", content)
+	}
+}
+
+func TestAccumulatorPreservesFinishedEventsFromMultipleChoices(t *testing.T) {
+	var acc openai.ChatCompletionAccumulator
+
+	pr688AddChunk(t, &acc, `{"id":"test","choices":[{"index":0,"delta":{"content":"choice zero"}},{"index":1,"delta":{"refusal":"choice one refusal"}},{"index":2,"delta":{"tool_calls":[{"index":1,"id":"call_choice_two","type":"function","function":{"name":"choice_two_tool","arguments":"{\"value\":2}"}}]}}]}`)
+	pr688AddChunk(t, &acc, `{"id":"test","choices":[{"index":0,"delta":{"content":" continues"}},{"index":1,"delta":{},"finish_reason":"stop"},{"index":2,"delta":{},"finish_reason":"tool_calls"}]}`)
+
+	if content, ok := acc.JustFinishedContent(); ok {
+		t.Fatalf("JustFinishedContent returned unexpected content: %q", content)
+	}
+
+	refusal, ok := acc.JustFinishedRefusal()
+	if !ok {
+		t.Fatal("JustFinishedRefusal did not return the completed refusal")
+	}
+	if refusal != "choice one refusal" {
+		t.Fatalf("refusal: expected %q, got %q", "choice one refusal", refusal)
+	}
+
+	toolCall, ok := acc.JustFinishedToolCall()
+	if !ok {
+		t.Fatal("JustFinishedToolCall did not return the completed tool call")
+	}
+	if toolCall.Index != 1 {
+		t.Fatalf("tool call index: expected 1, got %d", toolCall.Index)
+	}
+	if toolCall.ID != "call_choice_two" {
+		t.Fatalf("tool call ID: expected %q, got %q", "call_choice_two", toolCall.ID)
+	}
+	if toolCall.Name != "choice_two_tool" {
+		t.Fatalf("tool call name: expected %q, got %q", "choice_two_tool", toolCall.Name)
+	}
+	if toolCall.Arguments != `{"value":2}` {
+		t.Fatalf("tool call arguments: expected %q, got %q", `{"value":2}`, toolCall.Arguments)
+	}
+
+	pr688AddChunk(t, &acc, `{"id":"test","choices":[{"index":0,"delta":{},"finish_reason":"stop"},{"index":1,"delta":{},"finish_reason":"stop"},{"index":2,"delta":{},"finish_reason":"tool_calls"}]}`)
+
+	content, ok := acc.JustFinishedContent()
+	if !ok {
+		t.Fatal("JustFinishedContent did not return the completed content")
+	}
+	if content != "choice zero continues" {
+		t.Fatalf("content: expected %q, got %q", "choice zero continues", content)
+	}
+	if refusal, ok := acc.JustFinishedRefusal(); ok {
+		t.Fatalf("JustFinishedRefusal returned repeated refusal: %q", refusal)
+	}
+	if toolCall, ok := acc.JustFinishedToolCall(); ok {
+		t.Fatalf("JustFinishedToolCall returned repeated tool call: %+v", toolCall)
+	}
+}
+
 func pr688AddChunk(t *testing.T, acc *openai.ChatCompletionAccumulator, raw string) {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

- Track streaming accumulator response state for every choice in each chunk instead of only `choices[0]`.
- Keep finish events associated with their originating choice so content, refusal, and tool-call helpers return the correct accumulated data.
- Preserve multiple finish-event types from the same chunk instead of allowing a later choice to overwrite an earlier event.
- Keep the exported SDK API unchanged. If multiple choices finish the same response type in one chunk, the existing singular helper returns the first matching choice in chunk order.

## Root cause

`ChatCompletionChunk.Choices` can contain multiple choices when `n > 1`, and accumulation already stores each choice by its wire index. The finish-state machine only inspected `chunk.Choices[0]`, then the helpers read from a single tracked event. A nonzero choice could therefore be missed or return data from the wrong accumulated choice; finish transitions from different choices in one chunk could also overwrite one another.

This keeps the adjacent empty-content tool-call behavior from #757 while making that state machine choice-aware.

## Validation

- `go test . -run '^TestAccumulator' -count=1`
- `go test -race . -run '^TestAccumulator' -count=1`
- `./scripts/test` (all package tests reported `ok`; the wrapper cleanup trap subsequently reported an already-exited mock PID)
- `go test ./...` in `examples`
- `go test -mod=readonly ./...` in `internal/testdata/consumer`
- `go mod tidy -diff` in root, `examples`, `internal/testdata/consumer`, and `tools`
- Configured `golangci-lint` for root, examples, consumer, and the Windows-only example target: 0 issues
