### PR TITLE
fix: make debug logging metadata-only

### DIFF
--- a/debuglog_test.go
+++ b/debuglog_test.go
@@ -200,3 +200,35 @@ func TestWithDebugLogOmitsResponseStatusText(t *testing.T) {
 		t.Fatalf("debug log missing numeric status code: %s", logOutput)
 	}
 }
+
+func TestWithDebugLogRedactsUnrecognizedMethod(t *testing.T) {
+	const requestMethod = "CUSTOM-METHOD-SECRET"
+
+	receivedMethod := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedMethod <- r.Method
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	var output bytes.Buffer
+	client := openai.NewClient(
+		option.WithBaseURL(server.URL),
+		option.WithAPIKey("api-key-secret"),
+		option.WithDebugLog(log.New(&output, "", 0)),
+	)
+	if err := client.Execute(context.Background(), requestMethod, "debug", nil, nil); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := <-receivedMethod; got != requestMethod {
+		t.Fatalf("request method = %q, want %q", got, requestMethod)
+	}
+
+	logOutput := output.String()
+	if strings.Contains(logOutput, requestMethod) {
+		t.Fatalf("debug log contains unrecognized request method: %s", logOutput)
+	}
+	if !strings.Contains(logOutput, `"method":"***"`) {
+		t.Fatalf("debug log missing method placeholder: %s", logOutput)
+	}
+}

--- a/debuglog_test.go
+++ b/debuglog_test.go
@@ -1,0 +1,130 @@
+package openai_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+)
+
+func TestWithDebugLogEmitsOnlyRedactedMetadata(t *testing.T) {
+	const requestBody = "request-body-secret"
+	const responseBody = "response-body-secret"
+
+	type receivedRequest struct {
+		body               string
+		proxyAuthorization []string
+		rawQuery           string
+		err                error
+	}
+	received := make(chan receivedRequest, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, readErr := io.ReadAll(r.Body)
+		received <- receivedRequest{
+			body:               string(body),
+			proxyAuthorization: r.Header.Values("Proxy-Authorization"),
+			rawQuery:           r.URL.RawQuery,
+			err:                readErr,
+		}
+		w.Header().Add("Set-Cookie", "first=response-secret")
+		w.Header().Add("Set-Cookie", "second=response-secret")
+		w.Header().Set("X-Request-ID", "request-id-value")
+		_, _ = io.WriteString(w, responseBody)
+	}))
+	t.Cleanup(server.Close)
+
+	baseURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	baseURL.User = url.UserPassword("url-user", "url-password")
+
+	var output bytes.Buffer
+	var response []byte
+	var rawResponse *http.Response
+	client := openai.NewClient(
+		option.WithBaseURL(baseURL.String()),
+		option.WithAPIKey("api-key-secret"),
+		option.WithHeaderAdd("Proxy-Authorization", "first-proxy-secret"),
+		option.WithHeaderAdd("Proxy-Authorization", "second-proxy-secret"),
+		option.WithHeader("X-Custom-Secret", "custom-header-secret"),
+		option.WithDebugLog(log.New(&output, "", 0)),
+	)
+	err = client.Post(
+		context.Background(),
+		"debug?api_key=query-secret&access_token=access-token-secret&sig=signature-secret",
+		[]byte(requestBody),
+		&response,
+		option.WithResponseInto(&rawResponse),
+	)
+	if err != nil {
+		t.Fatalf("Post() error = %v", err)
+	}
+
+	gotRequest := <-received
+	if gotRequest.err != nil {
+		t.Fatalf("read request body: %v", gotRequest.err)
+	}
+	if gotRequest.body != requestBody {
+		t.Fatalf("request body = %q, want %q", gotRequest.body, requestBody)
+	}
+	const wantRawQuery = "api_key=query-secret&access_token=access-token-secret&sig=signature-secret"
+	if gotRequest.rawQuery != wantRawQuery {
+		t.Fatalf("request query = %q, want %q", gotRequest.rawQuery, wantRawQuery)
+	}
+	wantProxyAuthorization := []string{"first-proxy-secret", "second-proxy-secret"}
+	if !reflect.DeepEqual(gotRequest.proxyAuthorization, wantProxyAuthorization) {
+		t.Fatalf("Proxy-Authorization = %#v, want %#v", gotRequest.proxyAuthorization, wantProxyAuthorization)
+	}
+	if got := string(response); got != responseBody {
+		t.Fatalf("response body = %q, want %q", got, responseBody)
+	}
+	if got := rawResponse.Header.Values("Set-Cookie"); !reflect.DeepEqual(got, []string{"first=response-secret", "second=response-secret"}) {
+		t.Fatalf("Set-Cookie = %#v", got)
+	}
+
+	logOutput := output.String()
+	for _, secret := range []string{
+		"url-user",
+		"url-password",
+		"api_key",
+		"query-secret",
+		"access_token",
+		"access-token-secret",
+		"signature-secret",
+		"api-key-secret",
+		"first-proxy-secret",
+		"second-proxy-secret",
+		"custom-header-secret",
+		requestBody,
+		responseBody,
+		"first=response-secret",
+		"second=response-secret",
+	} {
+		if strings.Contains(logOutput, secret) {
+			t.Errorf("debug log contains sensitive value %q: %s", secret, logOutput)
+		}
+	}
+	for _, metadata := range []string{
+		`"method":"POST"`,
+		`"url":"` + server.URL + `/debug"`,
+		`"Authorization":["***"]`,
+		`"Proxy-Authorization":["***","***"]`,
+		`"status_code":200`,
+		`"Set-Cookie":["***","***"]`,
+		`"X-Request-Id":["request-id-value"]`,
+	} {
+		if !strings.Contains(logOutput, metadata) {
+			t.Errorf("debug log missing %q: %s", metadata, logOutput)
+		}
+	}
+}

--- a/debuglog_test.go
+++ b/debuglog_test.go
@@ -22,6 +22,7 @@ func TestWithDebugLogEmitsOnlyRedactedMetadata(t *testing.T) {
 
 	type receivedRequest struct {
 		body               string
+		escapedPath        string
 		proxyAuthorization []string
 		rawQuery           string
 		err                error
@@ -31,6 +32,7 @@ func TestWithDebugLogEmitsOnlyRedactedMetadata(t *testing.T) {
 		body, readErr := io.ReadAll(r.Body)
 		received <- receivedRequest{
 			body:               string(body),
+			escapedPath:        r.URL.EscapedPath(),
 			proxyAuthorization: r.Header.Values("Proxy-Authorization"),
 			rawQuery:           r.URL.RawQuery,
 			err:                readErr,
@@ -61,7 +63,7 @@ func TestWithDebugLogEmitsOnlyRedactedMetadata(t *testing.T) {
 	)
 	err = client.Post(
 		context.Background(),
-		"debug?api_key=query-secret&access_token=access-token-secret&sig=signature-secret",
+		"debug/path-token-secret?api_key=query-secret&access_token=access-token-secret&sig=signature-secret",
 		[]byte(requestBody),
 		&response,
 		option.WithResponseInto(&rawResponse),
@@ -76,6 +78,9 @@ func TestWithDebugLogEmitsOnlyRedactedMetadata(t *testing.T) {
 	}
 	if gotRequest.body != requestBody {
 		t.Fatalf("request body = %q, want %q", gotRequest.body, requestBody)
+	}
+	if got, want := gotRequest.escapedPath, "/debug/path-token-secret"; got != want {
+		t.Fatalf("request path = %q, want %q", got, want)
 	}
 	const wantRawQuery = "api_key=query-secret&access_token=access-token-secret&sig=signature-secret"
 	if gotRequest.rawQuery != wantRawQuery {
@@ -96,6 +101,7 @@ func TestWithDebugLogEmitsOnlyRedactedMetadata(t *testing.T) {
 	for _, secret := range []string{
 		"url-user",
 		"url-password",
+		"path-token-secret",
 		"api_key",
 		"query-secret",
 		"access_token",
@@ -109,6 +115,7 @@ func TestWithDebugLogEmitsOnlyRedactedMetadata(t *testing.T) {
 		responseBody,
 		"first=response-secret",
 		"second=response-secret",
+		"request-id-value",
 	} {
 		if strings.Contains(logOutput, secret) {
 			t.Errorf("debug log contains sensitive value %q: %s", secret, logOutput)
@@ -116,15 +123,60 @@ func TestWithDebugLogEmitsOnlyRedactedMetadata(t *testing.T) {
 	}
 	for _, metadata := range []string{
 		`"method":"POST"`,
-		`"url":"` + server.URL + `/debug"`,
+		`"url":"` + server.URL + `"`,
 		`"Authorization":["***"]`,
 		`"Proxy-Authorization":["***","***"]`,
 		`"status_code":200`,
 		`"Set-Cookie":["***","***"]`,
-		`"X-Request-Id":["request-id-value"]`,
 	} {
 		if !strings.Contains(logOutput, metadata) {
 			t.Errorf("debug log missing %q: %s", metadata, logOutput)
 		}
+	}
+}
+
+func TestWithDebugLogOmitsResponseStatusText(t *testing.T) {
+	const responseStatus = "200 response-status-secret"
+
+	var output bytes.Buffer
+	client := openai.NewClient(
+		option.WithAPIKey("api-key-secret"),
+		option.WithHTTPClient(&http.Client{
+			Transport: &closureTransport{
+				fn: func(req *http.Request) (*http.Response, error) {
+					return &http.Response{
+						Status:     responseStatus,
+						StatusCode: http.StatusOK,
+						Header:     make(http.Header),
+						Body:       io.NopCloser(strings.NewReader("response-body-secret")),
+						Request:    req,
+					}, nil
+				},
+			},
+		}),
+		option.WithDebugLog(log.New(&output, "", 0)),
+	)
+
+	var response []byte
+	var rawResponse *http.Response
+	if err := client.Get(
+		context.Background(),
+		"debug",
+		nil,
+		&response,
+		option.WithResponseInto(&rawResponse),
+	); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if rawResponse.Status != responseStatus {
+		t.Fatalf("response status = %q, want %q", rawResponse.Status, responseStatus)
+	}
+
+	logOutput := output.String()
+	if strings.Contains(logOutput, responseStatus) {
+		t.Fatalf("debug log contains response status text: %s", logOutput)
+	}
+	if !strings.Contains(logOutput, `"status_code":200`) {
+		t.Fatalf("debug log missing numeric status code: %s", logOutput)
 	}
 }

--- a/debuglog_test.go
+++ b/debuglog_test.go
@@ -17,7 +17,26 @@ import (
 	"github.com/openai/openai-go/v3/option"
 )
 
+func clearOpenAIEnvironment(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{
+		"OPENAI_API_KEY",
+		"OPENAI_ADMIN_KEY",
+		"OPENAI_BASE_URL",
+		"OPENAI_CUSTOM_HEADERS",
+		"OPENAI_ORG_ID",
+		"OPENAI_PROJECT_ID",
+		"OPENAI_WEBHOOK_SECRET",
+	} {
+		t.Setenv(key, "")
+	}
+}
+
 func TestWithDebugLogEmitsOnlyRedactedMetadata(t *testing.T) {
+	// Prove this public-path regression does not inherit supported ambient headers.
+	t.Setenv("OPENAI_CUSTOM_HEADERS", "Proxy-Authorization: ambient-proxy-secret")
+	clearOpenAIEnvironment(t)
+
 	const requestBody = "request-body-secret"
 	const responseBody = "response-body-secret"
 
@@ -83,7 +102,7 @@ func TestWithDebugLogEmitsOnlyRedactedMetadata(t *testing.T) {
 		option.WithResponseInto(&rawResponse),
 	)
 	if err != nil {
-		t.Fatalf("Post() error = %v", err)
+		t.Fatal("Post() returned an error")
 	}
 
 	gotRequest := <-received
@@ -91,31 +110,31 @@ func TestWithDebugLogEmitsOnlyRedactedMetadata(t *testing.T) {
 		t.Fatalf("read request body: %v", gotRequest.err)
 	}
 	if gotRequest.body != requestBody {
-		t.Fatalf("request body = %q, want %q", gotRequest.body, requestBody)
+		t.Fatal("request body did not reach the server unchanged")
 	}
 	if got, want := gotRequest.escapedPath, "/debug/path-token-secret"; got != want {
-		t.Fatalf("request path = %q, want %q", got, want)
+		t.Fatal("request path did not reach the server unchanged")
 	}
 	if got, want := gotRequest.host, baseURL.Host; got != want {
-		t.Fatalf("request host = %q, want %q", got, want)
+		t.Fatal("request host did not reach the server unchanged")
 	}
 	const wantRawQuery = "api_key=query-secret&access_token=access-token-secret&sig=signature-secret"
 	if gotRequest.rawQuery != wantRawQuery {
-		t.Fatalf("request query = %q, want %q", gotRequest.rawQuery, wantRawQuery)
+		t.Fatal("request query did not reach the server unchanged")
 	}
 	wantProxyAuthorization := []string{"first-proxy-secret", "second-proxy-secret"}
 	if !reflect.DeepEqual(gotRequest.proxyAuthorization, wantProxyAuthorization) {
-		t.Fatalf("Proxy-Authorization = %#v, want %#v", gotRequest.proxyAuthorization, wantProxyAuthorization)
+		t.Fatal("Proxy-Authorization headers did not match the isolated fixture")
 	}
 	if got := string(response); got != responseBody {
-		t.Fatalf("response body = %q, want %q", got, responseBody)
+		t.Fatal("response body did not reach the caller unchanged")
 	}
 	if got := rawResponse.Header.Values("Set-Cookie"); !reflect.DeepEqual(got, []string{"first=response-secret", "second=response-secret"}) {
-		t.Fatalf("Set-Cookie = %#v", got)
+		t.Fatal("Set-Cookie headers did not reach the caller unchanged")
 	}
 
 	logOutput := output.String()
-	for _, secret := range []string{
+	for index, secret := range []string{
 		credentialBearingHostname,
 		"url-user",
 		"url-password",
@@ -136,7 +155,7 @@ func TestWithDebugLogEmitsOnlyRedactedMetadata(t *testing.T) {
 		"request-id-value",
 	} {
 		if strings.Contains(logOutput, secret) {
-			t.Errorf("debug log contains sensitive value %q: %s", secret, logOutput)
+			t.Errorf("debug log contains synthetic sensitive marker %d", index)
 		}
 	}
 	for _, metadata := range []string{
@@ -147,15 +166,17 @@ func TestWithDebugLogEmitsOnlyRedactedMetadata(t *testing.T) {
 		`"Set-Cookie":["***","***"]`,
 	} {
 		if !strings.Contains(logOutput, metadata) {
-			t.Errorf("debug log missing %q: %s", metadata, logOutput)
+			t.Errorf("debug log missing %q", metadata)
 		}
 	}
 	if strings.Contains(logOutput, `"url":`) {
-		t.Errorf("debug log contains URL metadata: %s", logOutput)
+		t.Error("debug log contains URL metadata")
 	}
 }
 
 func TestWithDebugLogOmitsResponseStatusText(t *testing.T) {
+	clearOpenAIEnvironment(t)
+
 	const responseStatus = "200 response-status-secret"
 
 	var output bytes.Buffer
@@ -186,22 +207,24 @@ func TestWithDebugLogOmitsResponseStatusText(t *testing.T) {
 		&response,
 		option.WithResponseInto(&rawResponse),
 	); err != nil {
-		t.Fatalf("Get() error = %v", err)
+		t.Fatal("Get() returned an error")
 	}
 	if rawResponse.Status != responseStatus {
-		t.Fatalf("response status = %q, want %q", rawResponse.Status, responseStatus)
+		t.Fatal("response status did not reach the caller unchanged")
 	}
 
 	logOutput := output.String()
 	if strings.Contains(logOutput, responseStatus) {
-		t.Fatalf("debug log contains response status text: %s", logOutput)
+		t.Fatal("debug log contains response status text")
 	}
 	if !strings.Contains(logOutput, `"status_code":200`) {
-		t.Fatalf("debug log missing numeric status code: %s", logOutput)
+		t.Fatal("debug log missing numeric status code")
 	}
 }
 
 func TestWithDebugLogRedactsUnrecognizedMethod(t *testing.T) {
+	clearOpenAIEnvironment(t)
+
 	const requestMethod = "CUSTOM-METHOD-SECRET"
 
 	receivedMethod := make(chan string, 1)
@@ -218,17 +241,17 @@ func TestWithDebugLogRedactsUnrecognizedMethod(t *testing.T) {
 		option.WithDebugLog(log.New(&output, "", 0)),
 	)
 	if err := client.Execute(context.Background(), requestMethod, "debug", nil, nil); err != nil {
-		t.Fatalf("Execute() error = %v", err)
+		t.Fatal("Execute() returned an error")
 	}
 	if got := <-receivedMethod; got != requestMethod {
-		t.Fatalf("request method = %q, want %q", got, requestMethod)
+		t.Fatal("request method did not reach the server unchanged")
 	}
 
 	logOutput := output.String()
 	if strings.Contains(logOutput, requestMethod) {
-		t.Fatalf("debug log contains unrecognized request method: %s", logOutput)
+		t.Fatal("debug log contains unrecognized request method")
 	}
 	if !strings.Contains(logOutput, `"method":"***"`) {
-		t.Fatalf("debug log missing method placeholder: %s", logOutput)
+		t.Fatal("debug log missing method placeholder")
 	}
 }

--- a/debuglog_test.go
+++ b/debuglog_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -23,6 +24,7 @@ func TestWithDebugLogEmitsOnlyRedactedMetadata(t *testing.T) {
 	type receivedRequest struct {
 		body               string
 		escapedPath        string
+		host               string
 		proxyAuthorization []string
 		rawQuery           string
 		err                error
@@ -33,6 +35,7 @@ func TestWithDebugLogEmitsOnlyRedactedMetadata(t *testing.T) {
 		received <- receivedRequest{
 			body:               string(body),
 			escapedPath:        r.URL.EscapedPath(),
+			host:               r.Host,
 			proxyAuthorization: r.Header.Values("Proxy-Authorization"),
 			rawQuery:           r.URL.RawQuery,
 			err:                readErr,
@@ -48,7 +51,17 @@ func TestWithDebugLogEmitsOnlyRedactedMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse server URL: %v", err)
 	}
+	const credentialBearingHostname = "customer-credential-host-secret.example.test"
+	baseURL.Host = net.JoinHostPort(credentialBearingHostname, baseURL.Port())
 	baseURL.User = url.UserPassword("url-user", "url-password")
+
+	dialer := &net.Dialer{}
+	transport := &http.Transport{
+		DialContext: func(ctx context.Context, network string, _ string) (net.Conn, error) {
+			return dialer.DialContext(ctx, network, server.Listener.Addr().String())
+		},
+	}
+	t.Cleanup(transport.CloseIdleConnections)
 
 	var output bytes.Buffer
 	var response []byte
@@ -56,6 +69,7 @@ func TestWithDebugLogEmitsOnlyRedactedMetadata(t *testing.T) {
 	client := openai.NewClient(
 		option.WithBaseURL(baseURL.String()),
 		option.WithAPIKey("api-key-secret"),
+		option.WithHTTPClient(&http.Client{Transport: transport}),
 		option.WithHeaderAdd("Proxy-Authorization", "first-proxy-secret"),
 		option.WithHeaderAdd("Proxy-Authorization", "second-proxy-secret"),
 		option.WithHeader("X-Custom-Secret", "custom-header-secret"),
@@ -82,6 +96,9 @@ func TestWithDebugLogEmitsOnlyRedactedMetadata(t *testing.T) {
 	if got, want := gotRequest.escapedPath, "/debug/path-token-secret"; got != want {
 		t.Fatalf("request path = %q, want %q", got, want)
 	}
+	if got, want := gotRequest.host, baseURL.Host; got != want {
+		t.Fatalf("request host = %q, want %q", got, want)
+	}
 	const wantRawQuery = "api_key=query-secret&access_token=access-token-secret&sig=signature-secret"
 	if gotRequest.rawQuery != wantRawQuery {
 		t.Fatalf("request query = %q, want %q", gotRequest.rawQuery, wantRawQuery)
@@ -99,6 +116,7 @@ func TestWithDebugLogEmitsOnlyRedactedMetadata(t *testing.T) {
 
 	logOutput := output.String()
 	for _, secret := range []string{
+		credentialBearingHostname,
 		"url-user",
 		"url-password",
 		"path-token-secret",
@@ -123,7 +141,6 @@ func TestWithDebugLogEmitsOnlyRedactedMetadata(t *testing.T) {
 	}
 	for _, metadata := range []string{
 		`"method":"POST"`,
-		`"url":"` + server.URL + `"`,
 		`"Authorization":["***"]`,
 		`"Proxy-Authorization":["***","***"]`,
 		`"status_code":200`,
@@ -132,6 +149,9 @@ func TestWithDebugLogEmitsOnlyRedactedMetadata(t *testing.T) {
 		if !strings.Contains(logOutput, metadata) {
 			t.Errorf("debug log missing %q: %s", metadata, logOutput)
 		}
+	}
+	if strings.Contains(logOutput, `"url":`) {
+		t.Errorf("debug log contains URL metadata: %s", logOutput)
 	}
 }
 

--- a/option/middleware.go
+++ b/option/middleware.go
@@ -16,7 +16,6 @@ type debugRequestMetadata struct {
 }
 
 type debugResponseMetadata struct {
-	Status        string      `json:"status"`
 	StatusCode    int         `json:"status_code"`
 	ContentLength int64       `json:"content_length"`
 	Headers       http.Header `json:"headers"`
@@ -25,9 +24,10 @@ type debugResponseMetadata struct {
 // WithDebugLog logs allowlisted HTTP request and response metadata.
 // If the logger parameter is nil, it uses the default logger.
 //
-// Request and response bodies, URL user information and query strings, and
-// headers outside the allowlist are omitted. Credential-bearing headers are
-// represented by a placeholder for each original value.
+// Request and response bodies, URL path, user information, query strings and
+// fragments, and all original header values are omitted. Recognized
+// credential-bearing header names are represented by a placeholder for each
+// original value.
 //
 // WithDebugLog is for debugging and development purposes only.
 // It should not be used in production code. The behavior and interface
@@ -55,7 +55,6 @@ func WithDebugLog(logger *log.Logger) RequestOption {
 
 		if resp != nil {
 			responseMetadata, responseMarshalErr := json.Marshal(debugResponseMetadata{
-				Status:        resp.Status,
 				StatusCode:    resp.StatusCode,
 				ContentLength: resp.ContentLength,
 				Headers:       debugLogHeaders(resp.Header),
@@ -74,26 +73,35 @@ func debugLogURL(original *url.URL) string {
 		return ""
 	}
 	return (&url.URL{
-		Scheme:  original.Scheme,
-		Host:    original.Host,
-		Path:    original.Path,
-		RawPath: original.RawPath,
+		Scheme: original.Scheme,
+		Host:   original.Host,
 	}).String()
 }
 
 func debugLogHeaders(headers http.Header) http.Header {
 	result := make(http.Header)
 	for name, values := range headers {
-		canonicalName := http.CanonicalHeaderKey(name)
+		var redactedName string
 		switch strings.ToLower(name) {
-		case "authorization", "proxy-authorization", "api-key", "x-api-key", "x-amz-security-token", "cookie", "set-cookie":
-			for range values {
-				result.Add(canonicalName, "***")
-			}
-		case "accept", "content-length", "content-type", "openai-processing-ms", "openai-version", "request-id", "retry-after", "user-agent", "x-request-id", "x-stainless-retry-count", "x-stainless-timeout":
-			for _, value := range values {
-				result.Add(canonicalName, value)
-			}
+		case "authorization":
+			redactedName = "Authorization"
+		case "proxy-authorization":
+			redactedName = "Proxy-Authorization"
+		case "api-key":
+			redactedName = "Api-Key"
+		case "x-api-key":
+			redactedName = "X-Api-Key"
+		case "x-amz-security-token":
+			redactedName = "X-Amz-Security-Token"
+		case "cookie":
+			redactedName = "Cookie"
+		case "set-cookie":
+			redactedName = "Set-Cookie"
+		default:
+			continue
+		}
+		for range values {
+			result.Add(redactedName, "***")
 		}
 	}
 	return result

--- a/option/middleware.go
+++ b/option/middleware.go
@@ -4,13 +4,11 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
-	"net/url"
 	"strings"
 )
 
 type debugRequestMetadata struct {
 	Method        string      `json:"method"`
-	URL           string      `json:"url"`
 	ContentLength int64       `json:"content_length"`
 	Headers       http.Header `json:"headers"`
 }
@@ -24,10 +22,9 @@ type debugResponseMetadata struct {
 // WithDebugLog logs allowlisted HTTP request and response metadata.
 // If the logger parameter is nil, it uses the default logger.
 //
-// Request and response bodies, URL path, user information, query strings and
-// fragments, and all original header values are omitted. Recognized
-// credential-bearing header names are represented by a placeholder for each
-// original value.
+// Request and response bodies, URLs, free-form response status text, and all
+// original header values are omitted. Recognized credential-bearing header
+// names are represented by a placeholder for each original value.
 //
 // WithDebugLog is for debugging and development purposes only.
 // It should not be used in production code. The behavior and interface
@@ -40,7 +37,6 @@ func WithDebugLog(logger *log.Logger) RequestOption {
 	return WithMiddleware(func(req *http.Request, nxt MiddlewareNext) (*http.Response, error) {
 		requestMetadata, marshalErr := json.Marshal(debugRequestMetadata{
 			Method:        req.Method,
-			URL:           debugLogURL(req.URL),
 			ContentLength: req.ContentLength,
 			Headers:       debugLogHeaders(req.Header),
 		})
@@ -66,16 +62,6 @@ func WithDebugLog(logger *log.Logger) RequestOption {
 
 		return resp, err
 	})
-}
-
-func debugLogURL(original *url.URL) string {
-	if original == nil {
-		return ""
-	}
-	return (&url.URL{
-		Scheme: original.Scheme,
-		Host:   original.Host,
-	}).String()
 }
 
 func debugLogHeaders(headers http.Header) http.Header {

--- a/option/middleware.go
+++ b/option/middleware.go
@@ -1,36 +1,51 @@
 package option
 
 import (
+	"encoding/json"
 	"log"
 	"net/http"
-	"net/http/httputil"
+	"net/url"
+	"strings"
 )
 
-// sensitiveLogHeaders are redacted before request and response content is
-// written to the debug logger.
-var sensitiveLogHeaders = []string{
-	"authorization",
-	"api-key",
-	"x-api-key",
-	"x-amz-security-token",
-	"cookie",
-	"set-cookie",
+type debugRequestMetadata struct {
+	Method        string      `json:"method"`
+	URL           string      `json:"url"`
+	ContentLength int64       `json:"content_length"`
+	Headers       http.Header `json:"headers"`
 }
 
-// WithDebugLog logs the HTTP request and response content.
+type debugResponseMetadata struct {
+	Status        string      `json:"status"`
+	StatusCode    int         `json:"status_code"`
+	ContentLength int64       `json:"content_length"`
+	Headers       http.Header `json:"headers"`
+}
+
+// WithDebugLog logs allowlisted HTTP request and response metadata.
 // If the logger parameter is nil, it uses the default logger.
+//
+// Request and response bodies, URL user information and query strings, and
+// headers outside the allowlist are omitted. Credential-bearing headers are
+// represented by a placeholder for each original value.
 //
 // WithDebugLog is for debugging and development purposes only.
 // It should not be used in production code. The behavior and interface
 // of WithDebugLog is not guaranteed to be stable.
 func WithDebugLog(logger *log.Logger) RequestOption {
-	return WithMiddleware(func(req *http.Request, nxt MiddlewareNext) (*http.Response, error) {
-		if logger == nil {
-			logger = log.Default()
-		}
+	if logger == nil {
+		logger = log.Default()
+	}
 
-		if reqBytes, err := dumpRedactedRequest(req); err == nil {
-			logger.Printf("Request Content:\n%s\n", reqBytes)
+	return WithMiddleware(func(req *http.Request, nxt MiddlewareNext) (*http.Response, error) {
+		requestMetadata, marshalErr := json.Marshal(debugRequestMetadata{
+			Method:        req.Method,
+			URL:           debugLogURL(req.URL),
+			ContentLength: req.ContentLength,
+			Headers:       debugLogHeaders(req.Header),
+		})
+		if marshalErr == nil {
+			logger.Printf("Request Metadata: %s\n", requestMetadata)
 		}
 
 		resp, err := nxt(req)
@@ -38,48 +53,48 @@ func WithDebugLog(logger *log.Logger) RequestOption {
 			return resp, err
 		}
 
-		if respBytes, dumpErr := dumpRedactedResponse(resp); dumpErr == nil {
-			logger.Printf("Response Content:\n%s\n", respBytes)
+		if resp != nil {
+			responseMetadata, responseMarshalErr := json.Marshal(debugResponseMetadata{
+				Status:        resp.Status,
+				StatusCode:    resp.StatusCode,
+				ContentLength: resp.ContentLength,
+				Headers:       debugLogHeaders(resp.Header),
+			})
+			if responseMarshalErr == nil {
+				logger.Printf("Response Metadata: %s\n", responseMetadata)
+			}
 		}
 
 		return resp, err
 	})
 }
 
-// dumpRedactedRequest dumps req with sensitive headers replaced. The
-// original headers are restored via defer so a panic in DumpRequest cannot
-// leak the placeholder map into the live request sent downstream.
-func dumpRedactedRequest(req *http.Request) ([]byte, error) {
-	origHeaders := req.Header
-	req.Header = redactDebugHeaders(origHeaders)
-	defer func() { req.Header = origHeaders }()
-	return httputil.DumpRequest(req, true)
+func debugLogURL(original *url.URL) string {
+	if original == nil {
+		return ""
+	}
+	return (&url.URL{
+		Scheme:  original.Scheme,
+		Host:    original.Host,
+		Path:    original.Path,
+		RawPath: original.RawPath,
+	}).String()
 }
 
-func dumpRedactedResponse(resp *http.Response) ([]byte, error) {
-	origHeaders := resp.Header
-	resp.Header = redactDebugHeaders(origHeaders)
-	defer func() { resp.Header = origHeaders }()
-	return httputil.DumpResponse(resp, true)
-}
-
-func redactDebugHeaders(headers http.Header) http.Header {
-	var redacted http.Header
-	for _, name := range sensitiveLogHeaders {
-		values := headers.Values(name)
-		if len(values) == 0 {
-			continue
-		}
-		if redacted == nil {
-			redacted = headers.Clone()
-		}
-		redacted.Del(name)
-		for range values {
-			redacted.Add(name, "***")
+func debugLogHeaders(headers http.Header) http.Header {
+	result := make(http.Header)
+	for name, values := range headers {
+		canonicalName := http.CanonicalHeaderKey(name)
+		switch strings.ToLower(name) {
+		case "authorization", "proxy-authorization", "api-key", "x-api-key", "x-amz-security-token", "cookie", "set-cookie":
+			for range values {
+				result.Add(canonicalName, "***")
+			}
+		case "accept", "content-length", "content-type", "openai-processing-ms", "openai-version", "request-id", "retry-after", "user-agent", "x-request-id", "x-stainless-retry-count", "x-stainless-timeout":
+			for _, value := range values {
+				result.Add(canonicalName, value)
+			}
 		}
 	}
-	if redacted == nil {
-		return headers
-	}
-	return redacted
+	return result
 }

--- a/option/middleware.go
+++ b/option/middleware.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 )
 
+const debugLogRedacted = "***"
+
 type debugRequestMetadata struct {
 	Method        string      `json:"method"`
 	ContentLength int64       `json:"content_length"`
@@ -23,8 +25,9 @@ type debugResponseMetadata struct {
 // If the logger parameter is nil, it uses the default logger.
 //
 // Request and response bodies, URLs, free-form response status text, and all
-// original header values are omitted. Recognized credential-bearing header
-// names are represented by a placeholder for each original value.
+// original header values are omitted. Unrecognized request methods and values
+// for recognized credential-bearing header names are represented by a
+// placeholder.
 //
 // WithDebugLog is for debugging and development purposes only.
 // It should not be used in production code. The behavior and interface
@@ -36,7 +39,7 @@ func WithDebugLog(logger *log.Logger) RequestOption {
 
 	return WithMiddleware(func(req *http.Request, nxt MiddlewareNext) (*http.Response, error) {
 		requestMetadata, marshalErr := json.Marshal(debugRequestMetadata{
-			Method:        req.Method,
+			Method:        debugLogMethod(req.Method),
 			ContentLength: req.ContentLength,
 			Headers:       debugLogHeaders(req.Header),
 		})
@@ -64,6 +67,23 @@ func WithDebugLog(logger *log.Logger) RequestOption {
 	})
 }
 
+func debugLogMethod(method string) string {
+	switch method {
+	case http.MethodConnect,
+		http.MethodDelete,
+		http.MethodGet,
+		http.MethodHead,
+		http.MethodOptions,
+		http.MethodPatch,
+		http.MethodPost,
+		http.MethodPut,
+		http.MethodTrace:
+		return method
+	default:
+		return debugLogRedacted
+	}
+}
+
 func debugLogHeaders(headers http.Header) http.Header {
 	result := make(http.Header)
 	for name, values := range headers {
@@ -87,7 +107,7 @@ func debugLogHeaders(headers http.Header) http.Header {
 			continue
 		}
 		for range values {
-			result.Add(redactedName, "***")
+			result.Add(redactedName, debugLogRedacted)
 		}
 	}
 	return result

--- a/option/middleware_test.go
+++ b/option/middleware_test.go
@@ -15,7 +15,6 @@ func TestDebugLogHeaders(t *testing.T) {
 		"X-Custom-Secret":      {"custom-secret"},
 	}
 	want := http.Header{
-		"Content-Type":         {"application/json"},
 		"Proxy-Authorization":  {"***", "***"},
 		"X-Amz-Security-Token": {"***"},
 	}
@@ -39,7 +38,7 @@ func TestDebugLogURL(t *testing.T) {
 		Opaque:   "opaque-secret",
 	}
 
-	if got, want := debugLogURL(u), "https://example.com/v1/responses"; got != want {
+	if got, want := debugLogURL(u), "https://example.com"; got != want {
 		t.Fatalf("debugLogURL() = %q, want %q", got, want)
 	}
 }

--- a/option/middleware_test.go
+++ b/option/middleware_test.go
@@ -2,7 +2,6 @@ package option
 
 import (
 	"net/http"
-	"net/url"
 	"reflect"
 	"testing"
 )
@@ -24,21 +23,5 @@ func TestDebugLogHeaders(t *testing.T) {
 	}
 	if got := headers.Values("Proxy-Authorization"); !reflect.DeepEqual(got, []string{"first-secret", "second-secret"}) {
 		t.Fatalf("original headers were modified: %#v", got)
-	}
-}
-
-func TestDebugLogURL(t *testing.T) {
-	u := &url.URL{
-		Scheme:   "https",
-		User:     url.UserPassword("url-user", "url-password"),
-		Host:     "example.com",
-		Path:     "/v1/responses",
-		RawQuery: "api_key=query-secret&access_token=token-secret",
-		Fragment: "fragment-secret",
-		Opaque:   "opaque-secret",
-	}
-
-	if got, want := debugLogURL(u), "https://example.com"; got != want {
-		t.Fatalf("debugLogURL() = %q, want %q", got, want)
 	}
 }

--- a/option/middleware_test.go
+++ b/option/middleware_test.go
@@ -6,6 +6,28 @@ import (
 	"testing"
 )
 
+func TestDebugLogMethod(t *testing.T) {
+	for _, method := range []string{
+		http.MethodConnect,
+		http.MethodDelete,
+		http.MethodGet,
+		http.MethodHead,
+		http.MethodOptions,
+		http.MethodPatch,
+		http.MethodPost,
+		http.MethodPut,
+		http.MethodTrace,
+	} {
+		if got := debugLogMethod(method); got != method {
+			t.Errorf("debugLogMethod(%q) = %q, want unchanged", method, got)
+		}
+	}
+
+	if got := debugLogMethod("CUSTOM-METHOD-SECRET"); got != debugLogRedacted {
+		t.Errorf("debugLogMethod() = %q, want %q", got, debugLogRedacted)
+	}
+}
+
 func TestDebugLogHeaders(t *testing.T) {
 	headers := http.Header{
 		"Content-Type":         {"application/json"},

--- a/option/middleware_test.go
+++ b/option/middleware_test.go
@@ -2,22 +2,44 @@ package option
 
 import (
 	"net/http"
+	"net/url"
+	"reflect"
 	"testing"
 )
 
-func TestRedactDebugHeadersRedactsAWSSessionToken(t *testing.T) {
+func TestDebugLogHeaders(t *testing.T) {
 	headers := http.Header{
-		"X-Amz-Security-Token": {"secret-session-token"},
-		"X-Amz-Date":           {"20250102T030405Z"},
+		"Content-Type":         {"application/json"},
+		"Proxy-Authorization":  {"first-secret", "second-secret"},
+		"X-Amz-Security-Token": {"session-secret"},
+		"X-Custom-Secret":      {"custom-secret"},
 	}
-	redacted := redactDebugHeaders(headers)
-	if got := redacted.Get("X-Amz-Security-Token"); got != "***" {
-		t.Fatalf("X-Amz-Security-Token = %q", got)
+	want := http.Header{
+		"Content-Type":         {"application/json"},
+		"Proxy-Authorization":  {"***", "***"},
+		"X-Amz-Security-Token": {"***"},
 	}
-	if got := redacted.Get("X-Amz-Date"); got != "20250102T030405Z" {
-		t.Fatalf("X-Amz-Date = %q", got)
+
+	if got := debugLogHeaders(headers); !reflect.DeepEqual(got, want) {
+		t.Fatalf("debugLogHeaders() = %#v, want %#v", got, want)
 	}
-	if got := headers.Get("X-Amz-Security-Token"); got != "secret-session-token" {
-		t.Fatalf("original header was modified: %q", got)
+	if got := headers.Values("Proxy-Authorization"); !reflect.DeepEqual(got, []string{"first-secret", "second-secret"}) {
+		t.Fatalf("original headers were modified: %#v", got)
+	}
+}
+
+func TestDebugLogURL(t *testing.T) {
+	u := &url.URL{
+		Scheme:   "https",
+		User:     url.UserPassword("url-user", "url-password"),
+		Host:     "example.com",
+		Path:     "/v1/responses",
+		RawQuery: "api_key=query-secret&access_token=token-secret",
+		Fragment: "fragment-secret",
+		Opaque:   "opaque-secret",
+	}
+
+	if got, want := debugLogURL(u), "https://example.com/v1/responses"; got != want {
+		t.Fatalf("debugLogURL() = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
## Summary

- make `WithDebugLog` emit a fixed structured request and response metadata schema
- omit bodies, the entire URL, free-form status text, and all original header values
- preserve recognized standard methods while representing unrecognized methods and duplicate credential-header values with fixed placeholders, without mutating live traffic
- add focused helper and public-client regressions isolated from ambient OpenAI environment defaults, with value-free failure diagnostics

## Rationale

This makes the opt-in development diagnostic safer by default while retaining recognized standard request methods, numeric response status, and content-length metadata.

There is no exported API signature change. The option already documents its diagnostic output as unstable.

## Validation

- focused request/response regression tests
- focused race tests
- repository lint and module checks
- complete repository test script
- examples module and read-only external-consumer tests
- exhaustive openai-go review
- thermo-nuclear code-quality review
- exact-commit Codex Security diff scan
