### PR TITLE
docs: improve webhook request handling examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -738,20 +738,29 @@ For most use cases, you will likely want to verify the webhook and parse the pay
 
 Note that the `body` parameter should be the raw JSON bytes sent from the server (do not parse it first). The `Unwrap()` method will parse this JSON for you into an event object after verifying the webhook was sent from OpenAI.
 
+Webhook payloads are unauthenticated until signature verification succeeds. The
+example below limits each request to 1 MiB before buffering it and configures
+server read timeouts. Enforce the same or a smaller limit at your reverse proxy
+as defense in depth.
+
 ```go
 package main
 
 import (
+	"errors"
 	"io"
 	"log"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/option"
 	"github.com/openai/openai-go/v3/webhooks"
 )
+
+const maxWebhookBodySize = 1 << 20 // 1 MiB
 
 func main() {
 	client := openai.NewClient(
@@ -761,12 +770,19 @@ func main() {
 	r := gin.Default()
 
 	r.POST("/webhook", func(c *gin.Context) {
+		c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxWebhookBodySize)
+		defer func() { _ = c.Request.Body.Close() }()
+
 		body, err := io.ReadAll(c.Request.Body)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Error reading request body"})
+			var maxBytesError *http.MaxBytesError
+			if errors.As(err, &maxBytesError) {
+				c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "request body too large"})
+				return
+			}
+			c.JSON(http.StatusBadRequest, gin.H{"error": "error reading request body"})
 			return
 		}
-		defer c.Request.Body.Close()
 
 		webhookEvent, err := client.Webhooks.Unwrap(body, c.Request.Header)
 		if err != nil {
@@ -787,7 +803,15 @@ func main() {
 		c.JSON(http.StatusOK, gin.H{"message": "ok"})
 	})
 
-	r.Run(":8000")
+	server := &http.Server{
+		Addr:              ":8000",
+		Handler:           r,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      10 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
+	log.Fatal(server.ListenAndServe())
 }
 ```
 
@@ -797,20 +821,26 @@ In some cases, you may want to verify the webhook separately from parsing the pa
 
 Note that the `body` parameter should be the raw JSON bytes sent from the server (do not parse it first). You will then need to parse the body after verifying the signature.
 
+As above, bound the unauthenticated request body before reading it and configure
+server read timeouts. This example also uses a 1 MiB maximum.
+
 ```go
 package main
 
 import (
-	"encoding/json"
+	"errors"
 	"io"
 	"log"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/option"
 )
+
+const maxWebhookBodySize = 1 << 20 // 1 MiB
 
 func main() {
 	client := openai.NewClient(
@@ -820,12 +850,19 @@ func main() {
 	r := gin.Default()
 
 	r.POST("/webhook", func(c *gin.Context) {
+		c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxWebhookBodySize)
+		defer func() { _ = c.Request.Body.Close() }()
+
 		body, err := io.ReadAll(c.Request.Body)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Error reading request body"})
+			var maxBytesError *http.MaxBytesError
+			if errors.As(err, &maxBytesError) {
+				c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "request body too large"})
+				return
+			}
+			c.JSON(http.StatusBadRequest, gin.H{"error": "error reading request body"})
 			return
 		}
-		defer c.Request.Body.Close()
 
 		err = client.Webhooks.VerifySignature(body, c.Request.Header)
 		if err != nil {
@@ -837,7 +874,15 @@ func main() {
 		c.JSON(http.StatusOK, gin.H{"message": "ok"})
 	})
 
-	r.Run(":8000")
+	server := &http.Server{
+		Addr:              ":8000",
+		Handler:           r,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      10 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
+	log.Fatal(server.ListenAndServe())
 }
 ```
 

--- a/webhooks/readme_example_test.go
+++ b/webhooks/readme_example_test.go
@@ -1,0 +1,114 @@
+package webhooks_test
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+)
+
+const (
+	readmeWebhookBodyLimit int64 = 1 << 20
+	readmeWebhookSecret          = "readme-test-secret"
+	readmeWebhookID              = "wh_readme_test"
+)
+
+func readmeWebhookHandler(client openai.Client) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, readmeWebhookBodyLimit)
+		defer func() { _ = r.Body.Close() }()
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			var maxBytesError *http.MaxBytesError
+			if errors.As(err, &maxBytesError) {
+				http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+				return
+			}
+			http.Error(w, "error reading request body", http.StatusBadRequest)
+			return
+		}
+
+		if err := client.Webhooks.VerifySignature(body, r.Header); err != nil {
+			http.Error(w, "invalid signature", http.StatusBadRequest)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func signReadmeWebhook(body []byte, timestamp string) string {
+	signedPayload := readmeWebhookID + "." + timestamp + "." + string(body)
+	mac := hmac.New(sha256.New, []byte(readmeWebhookSecret))
+	_, _ = mac.Write([]byte(signedPayload))
+	return "v1," + base64.StdEncoding.EncodeToString(mac.Sum(nil))
+}
+
+func TestREADMEWebhookHandlerRejectsOversizedBodyBeforeVerification(t *testing.T) {
+	client := openai.NewClient(option.WithWebhookSecret(readmeWebhookSecret))
+	body := bytes.Repeat([]byte("x"), int(readmeWebhookBodyLimit)+1)
+	req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(body))
+	recorder := httptest.NewRecorder()
+
+	readmeWebhookHandler(client).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected status %d, got %d", http.StatusRequestEntityTooLarge, recorder.Code)
+	}
+}
+
+func TestREADMEWebhookHandlerAcceptsSignedBodyAtLimit(t *testing.T) {
+	client := openai.NewClient(option.WithWebhookSecret(readmeWebhookSecret))
+	body := bytes.Repeat([]byte("x"), int(readmeWebhookBodyLimit))
+	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
+	req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(body))
+	req.Header.Set("webhook-id", readmeWebhookID)
+	req.Header.Set("webhook-timestamp", timestamp)
+	req.Header.Set("webhook-signature", signReadmeWebhook(body, timestamp))
+	recorder := httptest.NewRecorder()
+
+	readmeWebhookHandler(client).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestREADMEWebhookExamplesEnforceRequestLimits(t *testing.T) {
+	contents, err := os.ReadFile("../README.md")
+	if err != nil {
+		t.Fatalf("read README: %v", err)
+	}
+
+	_, webhookSection, found := strings.Cut(string(contents), "## Webhook Verification")
+	if !found {
+		t.Fatal("README does not contain the webhook verification section")
+	}
+	webhookSection, _, _ = strings.Cut(webhookSection, "### Retries")
+
+	checks := map[string]int{
+		"const maxWebhookBodySize = 1 << 20": 2,
+		"http.MaxBytesReader":                2,
+		"http.StatusRequestEntityTooLarge":   2,
+		"ReadHeaderTimeout:":                 2,
+		"ReadTimeout:":                       2,
+	}
+	for snippet, want := range checks {
+		if got := strings.Count(webhookSection, snippet); got != want {
+			t.Errorf("README webhook examples contain %q %d times, want %d", snippet, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- add a concrete request size limit and clear oversized-request response to both webhook examples
- configure explicit HTTP server timeouts in the copyable handlers
- add focused regression coverage for request-boundary behavior and documentation safeguards

## Test plan

- `go test ./webhooks -count=1`
- `GOFLAGS=-buildvcs=false ./scripts/lint`
- `go -C examples test ./...`
- `go -C internal/testdata/consumer test -mod=readonly ./...`

SDK CODEOWNER review is required because this updates webhook integration guidance.