### PR TITLE
fix: preserve request options across pagination

### DIFF
--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -740,25 +740,13 @@ func (cfg *RequestConfig) Clone(ctx context.Context) *RequestConfig {
 	if err != nil {
 		return nil
 	}
-	new := &RequestConfig{
-		MaxRetries:         cfg.MaxRetries,
-		RequestTimeout:     cfg.RequestTimeout,
-		Context:            ctx,
-		Request:            req,
-		BaseURL:            cfg.BaseURL,
-		HTTPClient:         cfg.HTTPClient,
-		Middlewares:        cfg.Middlewares,
-		APIKey:             cfg.APIKey,
-		AdminAPIKey:        cfg.AdminAPIKey,
-		Organization:       cfg.Organization,
-		Project:            cfg.Project,
-		WebhookSecret:      cfg.WebhookSecret,
-		finalizers:         append([]requestFinalizer(nil), cfg.finalizers...),
-		authHeaderOverride: cfg.authHeaderOverride,
-		authPreference:     cfg.authPreference,
-	}
+	clone := *cfg
+	clone.Context = ctx
+	clone.Request = req
+	clone.Middlewares = append([]middleware(nil), cfg.Middlewares...)
+	clone.finalizers = append([]requestFinalizer(nil), cfg.finalizers...)
 
-	return new
+	return &clone
 }
 
 func (cfg *RequestConfig) SetHeader(key, value string) {

--- a/internal/requestconfig/requestconfig_test.go
+++ b/internal/requestconfig/requestconfig_test.go
@@ -157,6 +157,24 @@ func TestRequestFinalizerComposesThroughApply(t *testing.T) {
 	}
 }
 
+func TestCloneDoesNotAliasMiddlewareSlice(t *testing.T) {
+	cfg, err := NewRequestConfig(context.Background(), http.MethodGet, "/models", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.Middlewares = []middleware{func(*http.Request, middlewareNext) (*http.Response, error) {
+		return nil, nil
+	}}
+
+	clone := cfg.Clone(context.Background())
+	if clone == nil {
+		t.Fatal("Clone() = nil")
+	}
+	if &clone.Middlewares[0] == &cfg.Middlewares[0] {
+		t.Fatal("clone middleware aliases the original configuration")
+	}
+}
+
 func TestExecuteClosesAttemptBodyOnHandlerError(t *testing.T) {
 	t.Run("no retry", func(t *testing.T) {
 		body := newTrackedFileBody(t)

--- a/pagination_transport_test.go
+++ b/pagination_transport_test.go
@@ -1,0 +1,82 @@
+package openai_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+)
+
+type paginationHTTPDoerFunc func(*http.Request) (*http.Response, error)
+
+func (f paginationHTTPDoerFunc) Do(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type paginationRoundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f paginationRoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestPaginationPreservesCustomHTTPClient(t *testing.T) {
+	customCalls := 0
+	customClient := paginationHTTPDoerFunc(func(req *http.Request) (*http.Response, error) {
+		customCalls++
+		var body string
+		switch req.URL.Query().Get("after") {
+		case "":
+			body = `{"data":[{"id":"job-1"}],"has_more":true}`
+		case "job-1":
+			body = `{"data":[{"id":"job-2"}],"has_more":false}`
+		default:
+			return nil, errors.New("unexpected pagination cursor")
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": {"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    req,
+		}, nil
+	})
+
+	fallbackCalls := 0
+	fallbackClient := &http.Client{Transport: paginationRoundTripperFunc(func(*http.Request) (*http.Response, error) {
+		fallbackCalls++
+		return nil, errors.New("fallback HTTP client called")
+	})}
+
+	client := openai.NewClient(
+		option.WithBaseURL("https://example.com/v1"),
+		option.WithAPIKey("test-key"),
+		option.WithMaxRetries(0),
+		// Install a deterministic native fallback before the bespoke doer. Every
+		// page must continue through the latter.
+		option.WithHTTPClient(fallbackClient),
+		option.WithHTTPClient(customClient),
+	)
+	pager := client.FineTuning.Jobs.ListAutoPaging(context.Background(), openai.FineTuningJobListParams{})
+
+	var jobIDs []string
+	for pager.Next() {
+		jobIDs = append(jobIDs, pager.Current().ID)
+	}
+	if err := pager.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"job-1", "job-2"}; !reflect.DeepEqual(jobIDs, want) {
+		t.Fatalf("job IDs = %v, want %v", jobIDs, want)
+	}
+	if customCalls != 2 {
+		t.Fatalf("custom HTTP client calls = %d, want 2", customCalls)
+	}
+	if fallbackCalls != 0 {
+		t.Fatalf("fallback HTTP client calls = %d, want 0", fallbackCalls)
+	}
+}


### PR DESCRIPTION
## Summary

- preserve complete request configuration for paginated follow-up calls
- isolate mutable middleware and finalizer slice state when cloning
- add public custom-client pagination regression coverage

## Testing

- `go test ./...` (with the pinned Steady mock server)
- `go test ./...` in `examples`
- `go test -mod=readonly ./...` in `internal/testdata/consumer`
- `./scripts/check-go-mod`
- `GOFLAGS=-buildvcs=false ./scripts/lint`
- focused tests under `-race`