### PR TITLE
fix(azure): require secure credential transport

### DIFF
--- a/azure/azure.go
+++ b/azure/azure.go
@@ -115,7 +115,8 @@ type azureCredentialOrigin struct {
 // WithUnsafeAllowHTTP permits Azure credentials to be sent over plaintext HTTP
 // only when the final request destination is localhost or a loopback IP address.
 // This option is intended exclusively for local development and testing. It
-// should never be used in production.
+// should never be used in production. Plaintext loopback requests always use
+// a direct connection and bypass configured proxies and custom RoundTrippers.
 func WithUnsafeAllowHTTP() option.RequestOption {
 	return option.WithMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
 		ctx := context.WithValue(req.Context(), unsafeAllowHTTPContextKey{}, true)
@@ -290,7 +291,7 @@ func withAzureCredentialMiddleware(authenticate option.Middleware) option.Reques
 		if transport == nil {
 			transport = http.DefaultTransport
 		}
-		client.Transport = azureCredentialTransport{base: transport}
+		client.Transport = newAzureCredentialTransport(transport)
 		rc.HTTPClient = &client
 
 		return option.WithMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
@@ -309,14 +310,47 @@ type azureCredentialTransport struct {
 	base http.RoundTripper
 }
 
+func newAzureCredentialTransport(base http.RoundTripper) azureCredentialTransport {
+	if transport, ok := base.(azureCredentialTransport); ok {
+		return transport
+	}
+	return azureCredentialTransport{base: base}
+}
+
+var azureDirectLoopbackHTTPTransport = &http.Transport{DialContext: dialAzureLoopback}
+
+func dialAzureLoopback(ctx context.Context, network string, address string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, fmt.Errorf("azure: invalid loopback address %q: %w", address, err)
+	}
+	if host == "localhost" {
+		host = "127.0.0.1"
+	}
+	ip := net.ParseIP(host)
+	if ip == nil || !ip.IsLoopback() {
+		return nil, fmt.Errorf("azure: refusing non-loopback plaintext connection to %q", address)
+	}
+	return (&net.Dialer{}).DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+}
+
 func (t azureCredentialTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if err := validateAzureCredentialTransport(req); err != nil {
-		if req.Body != nil {
-			_ = req.Body.Close()
-		}
-		return nil, err
+		return rejectAzureCredentialTransport(req, err)
 	}
-	return t.base.RoundTrip(req)
+
+	transport := t.base
+	if azureCredentialHTTPAllowed(req) {
+		transport = azureDirectLoopbackHTTPTransport
+	}
+	return transport.RoundTrip(req)
+}
+
+func rejectAzureCredentialTransport(req *http.Request, err error) (*http.Response, error) {
+	if req.Body != nil {
+		_ = req.Body.Close()
+	}
+	return nil, err
 }
 
 func validateAzureCredentialTransport(req *http.Request) error {
@@ -336,6 +370,12 @@ func validateAzureCredentialTransport(req *http.Request) error {
 	}
 
 	if destination == origin {
+		return nil
+	}
+	// An explicitly unsafe loopback HTTP origin may upgrade to a loopback TLS
+	// server without weakening the origin rules for ordinary HTTPS endpoints.
+	if origin.scheme == "http" && azureCredentialUnsafeHTTPConfigured(req) &&
+		azureCredentialOriginIsLoopback(origin) && azureCredentialOriginIsLoopback(destination) {
 		return nil
 	}
 	return requestconfig.WithNoRetryError(&azureCredentialOriginError{})
@@ -389,8 +429,7 @@ func azureCredentialHTTPAllowed(req *http.Request) bool {
 	if !strings.EqualFold(req.URL.Scheme, "http") {
 		return false
 	}
-	allowed, _ := req.Context().Value(unsafeAllowHTTPContextKey{}).(bool)
-	if !allowed {
+	if !azureCredentialUnsafeHTTPConfigured(req) {
 		return false
 	}
 
@@ -402,6 +441,11 @@ func azureCredentialHTTPAllowed(req *http.Request) bool {
 	}
 	ip := net.ParseIP(host)
 	return ip != nil && ip.IsLoopback()
+}
+
+func azureCredentialUnsafeHTTPConfigured(req *http.Request) bool {
+	allowed, _ := req.Context().Value(unsafeAllowHTTPContextKey{}).(bool)
+	return allowed
 }
 
 // jsonRoutes have JSON payloads - we'll deserialize looking for a .model field in there

--- a/azure/azure.go
+++ b/azure/azure.go
@@ -104,6 +104,14 @@ func WithEndpoint(endpoint string, apiVersion string) option.RequestOption {
 
 type unsafeAllowHTTPContextKey struct{}
 
+type azureCredentialOriginContextKey struct{}
+
+type azureCredentialOrigin struct {
+	scheme string
+	host   string
+	port   string
+}
+
 // WithUnsafeAllowHTTP permits Azure credentials to be sent over plaintext HTTP
 // only when the final request destination is localhost or a loopback IP address.
 // This option is intended exclusively for local development and testing. It
@@ -286,6 +294,9 @@ func withAzureCredentialMiddleware(authenticate option.Middleware) option.Reques
 		rc.HTTPClient = &client
 
 		return option.WithMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+			origin := azureCredentialOriginFromURL(req.URL)
+			ctx := context.WithValue(req.Context(), azureCredentialOriginContextKey{}, origin)
+			req = req.WithContext(ctx)
 			if err := validateAzureCredentialTransport(req); err != nil {
 				return nil, err
 			}
@@ -306,10 +317,51 @@ func (t azureCredentialTransport) RoundTrip(req *http.Request) (*http.Response, 
 }
 
 func validateAzureCredentialTransport(req *http.Request) error {
-	if strings.EqualFold(req.URL.Scheme, "https") || azureCredentialHTTPAllowed(req) {
+	origin, ok := req.Context().Value(azureCredentialOriginContextKey{}).(azureCredentialOrigin)
+	if !ok {
+		return requestconfig.WithNoRetryError(&azureCredentialOriginError{})
+	}
+
+	destination := azureCredentialOriginFromURL(req.URL)
+	if destination.scheme != "https" {
+		// Unsafe mode may redirect between local development servers, but it
+		// must never expand a remote credential origin to a loopback target.
+		if azureCredentialOriginIsLoopback(origin) && azureCredentialHTTPAllowed(req) {
+			return nil
+		}
+		return requestconfig.WithNoRetryError(&azureCredentialTransportError{})
+	}
+
+	if destination == origin {
 		return nil
 	}
-	return requestconfig.WithNoRetryError(&azureCredentialTransportError{})
+	return requestconfig.WithNoRetryError(&azureCredentialOriginError{})
+}
+
+func azureCredentialOriginFromURL(u *url.URL) azureCredentialOrigin {
+	scheme := strings.ToLower(u.Scheme)
+	host := strings.ToLower(u.Hostname())
+	if ip := net.ParseIP(host); ip != nil {
+		host = ip.String()
+	}
+	port := u.Port()
+	if port == "" {
+		switch scheme {
+		case "http":
+			port = "80"
+		case "https":
+			port = "443"
+		}
+	}
+	return azureCredentialOrigin{scheme: scheme, host: host, port: port}
+}
+
+func azureCredentialOriginIsLoopback(origin azureCredentialOrigin) bool {
+	if origin.host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(origin.host)
+	return ip != nil && ip.IsLoopback()
 }
 
 type azureCredentialTransportError struct{}
@@ -321,6 +373,14 @@ func (*azureCredentialTransportError) Error() string {
 // NonRetriable implements the marker understood by the Azure pipeline's retry
 // policy. The outer requestconfig marker independently stops SDK retries.
 func (*azureCredentialTransportError) NonRetriable() {}
+
+type azureCredentialOriginError struct{}
+
+func (*azureCredentialOriginError) Error() string {
+	return "azure: authenticated redirects must remain on the original origin"
+}
+
+func (*azureCredentialOriginError) NonRetriable() {}
 
 func azureCredentialHTTPAllowed(req *http.Request) bool {
 	if !strings.EqualFold(req.URL.Scheme, "http") {

--- a/azure/azure.go
+++ b/azure/azure.go
@@ -52,6 +52,8 @@ const (
 //
 // Authenticated endpoints must use HTTPS unless [WithUnsafeAllowHTTP] is also
 // configured for a loopback-only local development endpoint.
+// Azure authentication also requires custom networking to use an [*http.Client]
+// with a custom [http.RoundTripper] so every redirect destination can be checked.
 //
 // This function should be paired with a call to authenticate, like [azure.WithAPIKey] or [azure.WithTokenCredential], similar to this:
 //
@@ -268,18 +270,20 @@ func nonEmptyHeaderValues(header http.Header, name string) int {
 
 func withAzureCredentialMiddleware(authenticate option.Middleware) option.RequestOption {
 	return requestconfig.WithRequestFinalizer(func(rc *requestconfig.RequestConfig) error {
+		if rc.CustomHTTPDoer != nil {
+			return errors.New("azure: custom HTTP clients must use *http.Client with a custom RoundTripper so redirects can be validated")
+		}
+
 		// Redirects run inside http.Client.Do and don't re-enter SDK middleware.
 		// Clone the selected client so every redirect reaches this guard without
 		// mutating the caller's client or replacing its CheckRedirect policy.
-		if rc.CustomHTTPDoer == nil {
-			client := *rc.HTTPClient
-			transport := client.Transport
-			if transport == nil {
-				transport = http.DefaultTransport
-			}
-			client.Transport = azureCredentialTransport{base: transport}
-			rc.HTTPClient = &client
+		client := *rc.HTTPClient
+		transport := client.Transport
+		if transport == nil {
+			transport = http.DefaultTransport
 		}
+		client.Transport = azureCredentialTransport{base: transport}
+		rc.HTTPClient = &client
 
 		return option.WithMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
 			if err := validateAzureCredentialTransport(req); err != nil {

--- a/azure/azure.go
+++ b/azure/azure.go
@@ -311,6 +311,9 @@ type azureCredentialTransport struct {
 
 func (t azureCredentialTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if err := validateAzureCredentialTransport(req); err != nil {
+		if req.Body != nil {
+			_ = req.Body.Close()
+		}
 		return nil, err
 	}
 	return t.base.RoundTrip(req)

--- a/azure/azure.go
+++ b/azure/azure.go
@@ -268,14 +268,55 @@ func nonEmptyHeaderValues(header http.Header, name string) int {
 
 func withAzureCredentialMiddleware(authenticate option.Middleware) option.RequestOption {
 	return requestconfig.WithRequestFinalizer(func(rc *requestconfig.RequestConfig) error {
+		// Redirects run inside http.Client.Do and don't re-enter SDK middleware.
+		// Clone the selected client so every redirect reaches this guard without
+		// mutating the caller's client or replacing its CheckRedirect policy.
+		if rc.CustomHTTPDoer == nil {
+			client := *rc.HTTPClient
+			transport := client.Transport
+			if transport == nil {
+				transport = http.DefaultTransport
+			}
+			client.Transport = azureCredentialTransport{base: transport}
+			rc.HTTPClient = &client
+		}
+
 		return option.WithMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
-			if !strings.EqualFold(req.URL.Scheme, "https") && !azureCredentialHTTPAllowed(req) {
-				return nil, requestconfig.WithNoRetryError(errors.New("azure: authenticated requests require HTTPS; WithUnsafeAllowHTTP permits HTTP only for local development on loopback endpoints"))
+			if err := validateAzureCredentialTransport(req); err != nil {
+				return nil, err
 			}
 			return authenticate(req, next)
 		}).Apply(rc)
 	})
 }
+
+type azureCredentialTransport struct {
+	base http.RoundTripper
+}
+
+func (t azureCredentialTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if err := validateAzureCredentialTransport(req); err != nil {
+		return nil, err
+	}
+	return t.base.RoundTrip(req)
+}
+
+func validateAzureCredentialTransport(req *http.Request) error {
+	if strings.EqualFold(req.URL.Scheme, "https") || azureCredentialHTTPAllowed(req) {
+		return nil
+	}
+	return requestconfig.WithNoRetryError(&azureCredentialTransportError{})
+}
+
+type azureCredentialTransportError struct{}
+
+func (*azureCredentialTransportError) Error() string {
+	return "azure: authenticated requests require HTTPS; WithUnsafeAllowHTTP permits HTTP only for local development on loopback endpoints"
+}
+
+// NonRetriable implements the marker understood by the Azure pipeline's retry
+// policy. The outer requestconfig marker independently stops SDK retries.
+func (*azureCredentialTransportError) NonRetriable() {}
 
 func azureCredentialHTTPAllowed(req *http.Request) bool {
 	if !strings.EqualFold(req.URL.Scheme, "http") {

--- a/azure/azure.go
+++ b/azure/azure.go
@@ -311,8 +311,8 @@ func withAzureCredentialMiddleware(authenticate option.Middleware, directTranspo
 }
 
 type azureCredentialTransport struct {
-	base               http.RoundTripper
-	directLoopbackHTTP http.RoundTripper
+	base             http.RoundTripper
+	directTransports *azureDirectLoopbackTransportCache
 }
 
 func newAzureCredentialTransport(base http.RoundTripper, directTransports *azureDirectLoopbackTransportCache) azureCredentialTransport {
@@ -320,15 +320,15 @@ func newAzureCredentialTransport(base http.RoundTripper, directTransports *azure
 		return transport
 	}
 	return azureCredentialTransport{
-		base:               base,
-		directLoopbackHTTP: directTransports.get(base),
+		base:             base,
+		directTransports: directTransports,
 	}
 }
 
-// azureDirectLoopbackTransportCache gives each configured HTTP transport one
-// direct loopback pool for the lifetime of the Azure credential option. Azure
-// finalizers run per request, so constructing the direct transport there would
-// defeat keep-alive reuse and per-transport connection limits across SDK calls.
+// azureDirectLoopbackTransportCache lazily gives each HTTP transport used for
+// unsafe loopback HTTP one direct pool for the lifetime of the Azure credential
+// option. Azure finalizers run per request, so constructing the direct transport
+// there would defeat keep-alive reuse and retain ordinary HTTPS overrides.
 type azureDirectLoopbackTransportCache struct {
 	transports sync.Map // map[*http.Transport]*http.Transport
 	fallback   sync.Once
@@ -403,7 +403,7 @@ func (t azureCredentialTransport) RoundTrip(req *http.Request) (*http.Response, 
 
 	transport := t.base
 	if azureCredentialHTTPAllowed(req) {
-		transport = t.directLoopbackHTTP
+		transport = t.directTransports.get(t.base)
 	}
 	return transport.RoundTrip(req)
 }

--- a/azure/azure.go
+++ b/azure/azure.go
@@ -19,12 +19,14 @@ package azure
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"mime"
 	"mime/multipart"
+	"net"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -47,6 +49,9 @@ const (
 //
 //   - endpoint - the Azure OpenAI endpoint to connect to. Ex: https://<azure-openai-resource>.openai.azure.com
 //   - apiVersion - the Azure OpenAI API version to target (ex: 2024-06-01). See [Azure OpenAI apiversions] for current API versions. This value cannot be empty.
+//
+// Authenticated endpoints must use HTTPS unless [WithUnsafeAllowHTTP] is also
+// configured for a loopback-only local development endpoint.
 //
 // This function should be paired with a call to authenticate, like [azure.WithAPIKey] or [azure.WithTokenCredential], similar to this:
 //
@@ -95,6 +100,19 @@ func WithEndpoint(endpoint string, apiVersion string) option.RequestOption {
 	return requestconfig.WithEnvironmentDefaultsDisabled(endpointOption)
 }
 
+type unsafeAllowHTTPContextKey struct{}
+
+// WithUnsafeAllowHTTP permits Azure credentials to be sent over plaintext HTTP
+// only when the final request destination is localhost or a loopback IP address.
+// This option is intended exclusively for local development and testing. It
+// should never be used in production.
+func WithUnsafeAllowHTTP() option.RequestOption {
+	return option.WithMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+		ctx := context.WithValue(req.Context(), unsafeAllowHTTPContextKey{}, true)
+		return next(req.WithContext(ctx))
+	})
+}
+
 type tokenCredentialConfig struct {
 	Scopes []string
 }
@@ -136,17 +154,23 @@ func WithTokenCredential(tokenCredential azcore.TokenCredential, options ...Toke
 		}
 
 		bearerTokenPolicy := runtime.NewBearerTokenPolicy(tokenCredential, tc.Scopes, nil)
+		unsafeBearerTokenPolicy := runtime.NewBearerTokenPolicy(tokenCredential, tc.Scopes, &policy.BearerTokenOptions{
+			InsecureAllowCredentialWithHTTP: true,
+		})
 
 		// add in a middleware that uses the bearer token generated from the token credential
-		middlewareOption := option.WithMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+		middlewareOption := withAzureCredentialMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
 			if !auth.Selected(rc) {
 				return next(req)
 			}
 
+			tokenPolicy := bearerTokenPolicy
+			if azureCredentialHTTPAllowed(req) {
+				tokenPolicy = unsafeBearerTokenPolicy
+			}
 			pipeline := runtime.NewPipeline("azopenai-extensions", version, runtime.PipelineOptions{}, &policy.ClientOptions{
-				InsecureAllowCredentialWithHTTP: true, // allow for plain HTTP proxies, etc..
 				PerRetryPolicies: []policy.Policy{
-					bearerTokenPolicy,
+					tokenPolicy,
 					policyAdapter(next),
 				},
 			})
@@ -194,6 +218,9 @@ func WithAPIKey(apiKey string) option.RequestOption {
 		return rc.Apply(
 			option.WithHeader("Api-Key", apiKey),
 			requestconfig.WithRequestFinalizer(finalizeAzureProvider),
+			withAzureCredentialMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+				return next(req)
+			}),
 		)
 	})
 }
@@ -237,6 +264,34 @@ func nonEmptyHeaderValues(header http.Header, name string) int {
 		}
 	}
 	return count
+}
+
+func withAzureCredentialMiddleware(authenticate option.Middleware) option.RequestOption {
+	return requestconfig.WithRequestFinalizer(func(rc *requestconfig.RequestConfig) error {
+		return option.WithMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+			if !strings.EqualFold(req.URL.Scheme, "https") && !azureCredentialHTTPAllowed(req) {
+				return nil, requestconfig.WithNoRetryError(errors.New("azure: authenticated requests require HTTPS; WithUnsafeAllowHTTP permits HTTP only for local development on loopback endpoints"))
+			}
+			return authenticate(req, next)
+		}).Apply(rc)
+	})
+}
+
+func azureCredentialHTTPAllowed(req *http.Request) bool {
+	if !strings.EqualFold(req.URL.Scheme, "http") {
+		return false
+	}
+	allowed, _ := req.Context().Value(unsafeAllowHTTPContextKey{}).(bool)
+	if !allowed {
+		return false
+	}
+
+	host := strings.TrimSuffix(req.URL.Hostname(), ".")
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 // jsonRoutes have JSON payloads - we'll deserialize looking for a .model field in there

--- a/azure/azure.go
+++ b/azure/azure.go
@@ -31,6 +31,7 @@ import (
 	"net/url"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -307,17 +308,49 @@ func withAzureCredentialMiddleware(authenticate option.Middleware) option.Reques
 }
 
 type azureCredentialTransport struct {
-	base http.RoundTripper
+	base               http.RoundTripper
+	directLoopbackHTTP http.RoundTripper
 }
 
 func newAzureCredentialTransport(base http.RoundTripper) azureCredentialTransport {
 	if transport, ok := base.(azureCredentialTransport); ok {
 		return transport
 	}
-	return azureCredentialTransport{base: base}
+	return azureCredentialTransport{
+		base:               base,
+		directLoopbackHTTP: newAzureDirectLoopbackHTTPTransport(base),
+	}
 }
 
-var azureDirectLoopbackHTTPTransport = &http.Transport{DialContext: dialAzureLoopback}
+const (
+	azureDirectResponseHeaderTimeout = 10 * time.Minute
+	azureDirectIdleConnTimeout       = 90 * time.Second
+)
+
+var azureLoopbackDialer = net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}
+
+func newAzureDirectLoopbackHTTPTransport(base http.RoundTripper) *http.Transport {
+	var transport *http.Transport
+	if baseTransport, ok := base.(*http.Transport); ok {
+		transport = baseTransport.Clone()
+	} else {
+		transport = &http.Transport{}
+	}
+
+	transport.Proxy = nil
+	transport.DialContext = dialAzureLoopback
+	if transport.ResponseHeaderTimeout <= 0 {
+		// Match the root SDK client's default bound for silent servers.
+		transport.ResponseHeaderTimeout = azureDirectResponseHeaderTimeout
+	}
+	if transport.IdleConnTimeout <= 0 {
+		transport.IdleConnTimeout = azureDirectIdleConnTimeout
+	}
+	if transport.ExpectContinueTimeout <= 0 {
+		transport.ExpectContinueTimeout = time.Second
+	}
+	return transport
+}
 
 func dialAzureLoopback(ctx context.Context, network string, address string) (net.Conn, error) {
 	host, port, err := net.SplitHostPort(address)
@@ -331,7 +364,7 @@ func dialAzureLoopback(ctx context.Context, network string, address string) (net
 	if ip == nil || !ip.IsLoopback() {
 		return nil, fmt.Errorf("azure: refusing non-loopback plaintext connection to %q", address)
 	}
-	return (&net.Dialer{}).DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+	return azureLoopbackDialer.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
 }
 
 func (t azureCredentialTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -341,7 +374,7 @@ func (t azureCredentialTransport) RoundTrip(req *http.Request) (*http.Response, 
 
 	transport := t.base
 	if azureCredentialHTTPAllowed(req) {
-		transport = azureDirectLoopbackHTTPTransport
+		transport = t.directLoopbackHTTP
 	}
 	return transport.RoundTrip(req)
 }
@@ -364,7 +397,10 @@ func validateAzureCredentialTransport(req *http.Request) error {
 		// Unsafe mode may redirect between local development servers, but it
 		// must never expand a remote credential origin to a loopback target.
 		if azureCredentialOriginIsLoopback(origin) && azureCredentialHTTPAllowed(req) {
-			return nil
+			if origin.host == destination.host {
+				return nil
+			}
+			return requestconfig.WithNoRetryError(&azureCredentialOriginError{})
 		}
 		return requestconfig.WithNoRetryError(&azureCredentialTransportError{})
 	}
@@ -374,7 +410,7 @@ func validateAzureCredentialTransport(req *http.Request) error {
 	}
 	// An explicitly unsafe loopback HTTP origin may upgrade to a loopback TLS
 	// server without weakening the origin rules for ordinary HTTPS endpoints.
-	if origin.scheme == "http" && azureCredentialUnsafeHTTPConfigured(req) &&
+	if origin.scheme == "http" && origin.host == destination.host && azureCredentialUnsafeHTTPConfigured(req) &&
 		azureCredentialOriginIsLoopback(origin) && azureCredentialOriginIsLoopback(destination) {
 		return nil
 	}

--- a/azure/azure.go
+++ b/azure/azure.go
@@ -327,8 +327,10 @@ func azureCredentialHTTPAllowed(req *http.Request) bool {
 		return false
 	}
 
-	host := strings.TrimSuffix(req.URL.Hostname(), ".")
-	if strings.EqualFold(host, "localhost") {
+	// Keep this allowlist aligned with net/http's ProxyFromEnvironment bypass.
+	// Other localhost spellings can resolve to loopback but still reach HTTP_PROXY.
+	host := req.URL.Hostname()
+	if host == "localhost" {
 		return true
 	}
 	ip := net.ParseIP(host)

--- a/azure/azure.go
+++ b/azure/azure.go
@@ -387,13 +387,50 @@ func dialAzureLoopback(ctx context.Context, network string, address string) (net
 		return nil, fmt.Errorf("azure: invalid loopback address %q: %w", address, err)
 	}
 	if host == "localhost" {
-		host = "127.0.0.1"
+		return dialAzureLocalhost(ctx, network, address, port)
 	}
 	ip := net.ParseIP(host)
 	if ip == nil || !ip.IsLoopback() {
 		return nil, fmt.Errorf("azure: refusing non-loopback plaintext connection to %q", address)
 	}
 	return azureLoopbackDialer.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+}
+
+func dialAzureLocalhost(ctx context.Context, network string, address string, port string) (net.Conn, error) {
+	type dialResult struct {
+		conn net.Conn
+		err  error
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Avoid DNS and try only fixed loopback addresses. Concurrent attempts keep
+	// localhost usable when either IP family is unavailable or filtered locally.
+	results := make(chan dialResult, 2)
+	for _, host := range []string{"127.0.0.1", "::1"} {
+		go func() {
+			conn, err := azureLoopbackDialer.DialContext(ctx, network, net.JoinHostPort(host, port))
+			results <- dialResult{conn: conn, err: err}
+		}()
+	}
+
+	errs := make([]error, 0, 2)
+	for attempt := range 2 {
+		result := <-results
+		if result.err == nil {
+			cancel()
+			for remaining := attempt + 1; remaining < 2; remaining++ {
+				loser := <-results
+				if loser.conn != nil {
+					_ = loser.conn.Close()
+				}
+			}
+			return result.conn, nil
+		}
+		errs = append(errs, result.err)
+	}
+	return nil, fmt.Errorf("azure: could not connect to loopback address %q: %w", address, errors.Join(errs...))
 }
 
 func (t azureCredentialTransport) RoundTrip(req *http.Request) (*http.Response, error) {

--- a/azure/azure.go
+++ b/azure/azure.go
@@ -31,6 +31,7 @@ import (
 	"net/url"
 	"reflect"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -146,6 +147,7 @@ func WithTokenCredentialScopes(scopes []string) func(*tokenCredentialConfig) err
 //
 // [Azure Identity]: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity
 func WithTokenCredential(tokenCredential azcore.TokenCredential, options ...TokenCredentialOption) option.RequestOption {
+	directTransports := &azureDirectLoopbackTransportCache{}
 	return requestconfig.RequestOptionFunc(func(rc *requestconfig.RequestConfig) error {
 		if isNilTokenCredential(tokenCredential) {
 			return errors.New("azure: token credential must not be nil")
@@ -194,7 +196,7 @@ func WithTokenCredential(tokenCredential azcore.TokenCredential, options ...Toke
 			}
 
 			return pipeline.Do(req2)
-		})
+		}, directTransports)
 
 		return rc.Apply(
 			middlewareOption,
@@ -221,6 +223,7 @@ func isNilTokenCredential(tokenCredential azcore.TokenCredential) bool {
 func WithAPIKey(apiKey string) option.RequestOption {
 	// NOTE: option.WithAPIKey() uses the Authorization header. Azure expects
 	// Api-Key instead.
+	directTransports := &azureDirectLoopbackTransportCache{}
 	return requestconfig.RequestOptionFunc(func(rc *requestconfig.RequestConfig) error {
 		auth := requestconfig.NewProviderAuthOption(azureProvider, azureAPIKeyAuth)
 		if err := rc.Apply(requestconfig.WithEndpointProvider(azureProvider), auth); err != nil {
@@ -232,7 +235,7 @@ func WithAPIKey(apiKey string) option.RequestOption {
 			requestconfig.WithRequestFinalizer(finalizeAzureProvider),
 			withAzureCredentialMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
 				return next(req)
-			}),
+			}, directTransports),
 		)
 	})
 }
@@ -278,7 +281,7 @@ func nonEmptyHeaderValues(header http.Header, name string) int {
 	return count
 }
 
-func withAzureCredentialMiddleware(authenticate option.Middleware) option.RequestOption {
+func withAzureCredentialMiddleware(authenticate option.Middleware, directTransports *azureDirectLoopbackTransportCache) option.RequestOption {
 	return requestconfig.WithRequestFinalizer(func(rc *requestconfig.RequestConfig) error {
 		if rc.CustomHTTPDoer != nil {
 			return errors.New("azure: custom HTTP clients must use *http.Client with a custom RoundTripper so redirects can be validated")
@@ -292,7 +295,7 @@ func withAzureCredentialMiddleware(authenticate option.Middleware) option.Reques
 		if transport == nil {
 			transport = http.DefaultTransport
 		}
-		client.Transport = newAzureCredentialTransport(transport)
+		client.Transport = newAzureCredentialTransport(transport, directTransports)
 		rc.HTTPClient = &client
 
 		return option.WithMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
@@ -312,14 +315,40 @@ type azureCredentialTransport struct {
 	directLoopbackHTTP http.RoundTripper
 }
 
-func newAzureCredentialTransport(base http.RoundTripper) azureCredentialTransport {
+func newAzureCredentialTransport(base http.RoundTripper, directTransports *azureDirectLoopbackTransportCache) azureCredentialTransport {
 	if transport, ok := base.(azureCredentialTransport); ok {
 		return transport
 	}
 	return azureCredentialTransport{
 		base:               base,
-		directLoopbackHTTP: newAzureDirectLoopbackHTTPTransport(base),
+		directLoopbackHTTP: directTransports.get(base),
 	}
+}
+
+// azureDirectLoopbackTransportCache gives each configured HTTP transport one
+// direct loopback pool for the lifetime of the Azure credential option. Azure
+// finalizers run per request, so constructing the direct transport there would
+// defeat keep-alive reuse and per-transport connection limits across SDK calls.
+type azureDirectLoopbackTransportCache struct {
+	transports sync.Map // map[*http.Transport]*http.Transport
+	fallback   sync.Once
+	direct     *http.Transport
+}
+
+func (c *azureDirectLoopbackTransportCache) get(base http.RoundTripper) *http.Transport {
+	if baseTransport, ok := base.(*http.Transport); ok {
+		if cached, ok := c.transports.Load(baseTransport); ok {
+			return cached.(*http.Transport)
+		}
+		direct := newAzureDirectLoopbackHTTPTransport(baseTransport)
+		cached, _ := c.transports.LoadOrStore(baseTransport, direct)
+		return cached.(*http.Transport)
+	}
+
+	c.fallback.Do(func() {
+		c.direct = newAzureDirectLoopbackHTTPTransport(base)
+	})
+	return c.direct
 }
 
 const (

--- a/azure/azure_test.go
+++ b/azure/azure_test.go
@@ -12,7 +12,9 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
 	"github.com/openai/openai-go/v3"
@@ -401,10 +403,10 @@ func TestAzureCredentialTransportSecurity(t *testing.T) {
 	for authName, auth := range authOptions {
 		for testName, test := range tests {
 			t.Run(authName+"/"+testName, func(t *testing.T) {
-				var captured *http.Request
+				var captured atomic.Pointer[http.Request]
 				endpoint := test.endpoint
 				transport := http.RoundTripper(roundTripFunc(func(req *http.Request) (*http.Response, error) {
-					captured = req
+					captured.Store(req)
 					return &http.Response{
 						StatusCode: http.StatusOK,
 						Header:     http.Header{"Content-Type": []string{"application/json"}},
@@ -424,7 +426,7 @@ func TestAzureCredentialTransportSecurity(t *testing.T) {
 						listenAddress = "[::1]:0"
 					}
 					origin := newLoopbackHTTPServer(t, network, listenAddress, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-						captured = req
+						captured.Store(req)
 						w.Header().Set("Content-Type", "application/json")
 						_, _ = w.Write([]byte(`{"ok":true}`))
 					}))
@@ -465,10 +467,11 @@ func TestAzureCredentialTransportSecurity(t *testing.T) {
 					if err != nil {
 						t.Fatalf("request failed: %v", err)
 					}
-					if captured == nil {
+					request := captured.Load()
+					if request == nil {
 						t.Fatal("request did not reach the transport")
 					}
-					if got := captured.Header.Get(auth.header); got != auth.headerValue {
+					if got := request.Header.Get(auth.header); got != auth.headerValue {
 						t.Fatalf("%s header = %q, want %q", auth.header, got, auth.headerValue)
 					}
 					return
@@ -477,7 +480,7 @@ func TestAzureCredentialTransportSecurity(t *testing.T) {
 				if err == nil || !strings.Contains(err.Error(), "azure: authenticated requests require HTTPS") {
 					t.Fatalf("expected HTTPS requirement error, got %v", err)
 				}
-				if captured != nil {
+				if captured.Load() != nil {
 					t.Fatal("insecure credential transport reached the network")
 				}
 			})
@@ -508,17 +511,17 @@ func TestAzureCredentialTransportSecurityRedirects(t *testing.T) {
 
 	for authName, auth := range authOptions {
 		t.Run(authName+"/rejects opaque custom doer", func(t *testing.T) {
-			redirectedCredential := ""
+			var redirectedCredential atomicString
 			insecureTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-				redirectedCredential = req.Header.Get(auth.header)
+				redirectedCredential.Store(req.Header.Get(auth.header))
 				w.Header().Set("Content-Type", "application/json")
 				_, _ = w.Write([]byte(`{"ok":true}`))
 			}))
 			t.Cleanup(insecureTarget.Close)
 
-			sourceRequests := 0
+			var sourceRequests atomic.Int32
 			secureSource := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-				sourceRequests++
+				sourceRequests.Add(1)
 				http.Redirect(w, req, insecureTarget.URL+"/final", http.StatusTemporaryRedirect)
 			}))
 			t.Cleanup(secureSource.Close)
@@ -535,26 +538,26 @@ func TestAzureCredentialTransportSecurityRedirects(t *testing.T) {
 			if err == nil || !strings.Contains(err.Error(), "custom HTTP clients") {
 				t.Errorf("expected custom HTTP client error, got %v", err)
 			}
-			if sourceRequests != 0 {
-				t.Errorf("custom HTTP client reached redirect source %d times", sourceRequests)
+			if got := sourceRequests.Load(); got != 0 {
+				t.Errorf("custom HTTP client reached redirect source %d times", got)
 			}
-			if redirectedCredential != "" {
-				t.Errorf("credential reached insecure redirect target: %q", redirectedCredential)
+			if got := redirectedCredential.Load(); got != "" {
+				t.Errorf("credential reached insecure redirect target: %q", got)
 			}
 		})
 
 		t.Run(authName+"/rejects HTTPS downgrade", func(t *testing.T) {
-			redirectedCredential := ""
+			var redirectedCredential atomicString
 			insecureTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-				redirectedCredential = req.Header.Get(auth.header)
+				redirectedCredential.Store(req.Header.Get(auth.header))
 				w.Header().Set("Content-Type", "application/json")
 				_, _ = w.Write([]byte(`{"ok":true}`))
 			}))
 			t.Cleanup(insecureTarget.Close)
 
-			sourceRequests := 0
+			var sourceRequests atomic.Int32
 			secureSource := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-				sourceRequests++
+				sourceRequests.Add(1)
 				if req.URL.Path != "/hop" {
 					http.Redirect(w, req, "/hop", http.StatusTemporaryRedirect)
 					return
@@ -575,11 +578,11 @@ func TestAzureCredentialTransportSecurityRedirects(t *testing.T) {
 			if err == nil || !strings.Contains(err.Error(), "azure: authenticated requests require HTTPS") {
 				t.Fatalf("expected HTTPS requirement error, got %v", err)
 			}
-			if redirectedCredential != "" {
-				t.Fatalf("credential reached insecure redirect target: %q", redirectedCredential)
+			if got := redirectedCredential.Load(); got != "" {
+				t.Fatalf("credential reached insecure redirect target: %q", got)
 			}
-			if sourceRequests != 2 {
-				t.Fatalf("secure source requests = %d, want 2", sourceRequests)
+			if got := sourceRequests.Load(); got != 2 {
+				t.Fatalf("secure source requests = %d, want 2", got)
 			}
 		})
 
@@ -592,17 +595,17 @@ func TestAzureCredentialTransportSecurityRedirects(t *testing.T) {
 		for targetName, redirectTarget := range crossOriginTargets {
 			t.Run(authName+"/rejects HTTPS cross-origin redirect/"+targetName, func(t *testing.T) {
 				redirectBodyClosed := make(chan struct{}, 1)
-				redirectedCredential := ""
+				var redirectedCredential atomicString
 				target := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-					redirectedCredential = req.Header.Get(auth.header)
+					redirectedCredential.Store(req.Header.Get(auth.header))
 					w.Header().Set("Content-Type", "application/json")
 					_, _ = w.Write([]byte(`{"ok":true}`))
 				}))
 				t.Cleanup(target.Close)
 
-				sourceRequests := 0
+				var sourceRequests atomic.Int32
 				source := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-					sourceRequests++
+					sourceRequests.Add(1)
 					http.Redirect(w, req, redirectTarget(target.URL)+"/final", http.StatusTemporaryRedirect)
 				}))
 				t.Cleanup(source.Close)
@@ -628,11 +631,11 @@ func TestAzureCredentialTransportSecurityRedirects(t *testing.T) {
 				if err == nil || !strings.Contains(err.Error(), "authenticated redirects must remain on the original origin") {
 					t.Fatalf("expected origin restriction error, got %v", err)
 				}
-				if sourceRequests != 1 {
-					t.Fatalf("secure source requests = %d, want 1", sourceRequests)
+				if got := sourceRequests.Load(); got != 1 {
+					t.Fatalf("secure source requests = %d, want 1", got)
 				}
-				if redirectedCredential != "" {
-					t.Fatalf("credential reached cross-origin redirect target: %q", redirectedCredential)
+				if got := redirectedCredential.Load(); got != "" {
+					t.Fatalf("credential reached cross-origin redirect target: %q", got)
 				}
 				// The token policy rebuilds the request body; the direct API-key path
 				// exposes the close-tracking replay body to this transport wrapper.
@@ -647,9 +650,9 @@ func TestAzureCredentialTransportSecurityRedirects(t *testing.T) {
 		}
 
 		t.Run(authName+"/unsafe remote HTTPS cannot redirect to loopback HTTP", func(t *testing.T) {
-			targetReached := false
+			var targetReached atomic.Bool
 			target := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
-				targetReached = true
+				targetReached.Store(true)
 			}))
 			t.Cleanup(target.Close)
 
@@ -680,19 +683,19 @@ func TestAzureCredentialTransportSecurityRedirects(t *testing.T) {
 			if requestErr == nil || !strings.Contains(requestErr.Error(), "azure: authenticated requests require HTTPS") {
 				t.Fatalf("expected HTTPS requirement error, got %v", requestErr)
 			}
-			if targetReached {
+			if targetReached.Load() {
 				t.Fatal("credential request reached loopback redirect target")
 			}
 		})
 
 		t.Run(authName+"/preserves HTTPS redirect", func(t *testing.T) {
-			redirectedCredential := ""
+			var redirectedCredential atomicString
 			secureServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 				if req.URL.Path != "/final" {
 					http.Redirect(w, req, "/final", http.StatusTemporaryRedirect)
 					return
 				}
-				redirectedCredential = req.Header.Get(auth.header)
+				redirectedCredential.Store(req.Header.Get(auth.header))
 				w.Header().Set("Content-Type", "application/json")
 				_, _ = w.Write([]byte(`{"ok":true}`))
 			}))
@@ -709,15 +712,15 @@ func TestAzureCredentialTransportSecurityRedirects(t *testing.T) {
 			if err := client.Execute(context.Background(), http.MethodGet, "models", nil, &res); err != nil {
 				t.Fatalf("request failed: %v", err)
 			}
-			if redirectedCredential != auth.headerValue {
-				t.Fatalf("redirected credential = %q, want %q", redirectedCredential, auth.headerValue)
+			if got := redirectedCredential.Load(); got != auth.headerValue {
+				t.Fatalf("redirected credential = %q, want %q", got, auth.headerValue)
 			}
 		})
 
 		t.Run(authName+"/preserves unsafe loopback redirect", func(t *testing.T) {
-			redirectedCredential := ""
+			var redirectedCredential atomicString
 			target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-				redirectedCredential = req.Header.Get(auth.header)
+				redirectedCredential.Store(req.Header.Get(auth.header))
 				w.Header().Set("Content-Type", "application/json")
 				_, _ = w.Write([]byte(`{"ok":true}`))
 			}))
@@ -740,23 +743,65 @@ func TestAzureCredentialTransportSecurityRedirects(t *testing.T) {
 			if err := client.Execute(context.Background(), http.MethodGet, "models", nil, &res); err != nil {
 				t.Fatalf("request failed: %v", err)
 			}
-			if redirectedCredential != auth.headerValue {
-				t.Fatalf("redirected credential = %q, want %q", redirectedCredential, auth.headerValue)
+			if got := redirectedCredential.Load(); got != auth.headerValue {
+				t.Fatalf("redirected credential = %q, want %q", got, auth.headerValue)
 			}
 		})
 
+		for _, targetScheme := range []string{"HTTP", "HTTPS"} {
+			t.Run(authName+"/rejects unsafe cross-host loopback "+targetScheme+" redirect", func(t *testing.T) {
+				targetReached := make(chan struct{}, 1)
+				target := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					targetReached <- struct{}{}
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{"ok":true}`))
+				}))
+				if targetScheme == "HTTPS" {
+					target.StartTLS()
+				} else {
+					target.Start()
+				}
+				t.Cleanup(target.Close)
+
+				source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+					http.Redirect(w, req, target.URL+"/final", http.StatusTemporaryRedirect)
+				}))
+				t.Cleanup(source.Close)
+				sourceEndpoint := strings.Replace(source.URL, "127.0.0.1", "localhost", 1)
+
+				client := openai.NewClient(
+					WithEndpoint(sourceEndpoint, "2024-10-21"),
+					auth.option(),
+					WithUnsafeAllowHTTP(),
+					option.WithMaxRetries(0),
+					option.WithHTTPClient(target.Client()),
+				)
+
+				var res map[string]any
+				err := client.Execute(context.Background(), http.MethodGet, "models", nil, &res)
+				if err == nil || !strings.Contains(err.Error(), "authenticated redirects must remain on the original origin") {
+					t.Fatalf("expected origin restriction error, got %v", err)
+				}
+				select {
+				case <-targetReached:
+					t.Fatal("cross-host loopback redirect reached target")
+				default:
+				}
+			})
+		}
+
 		t.Run(authName+"/preserves unsafe loopback HTTPS upgrade", func(t *testing.T) {
-			redirectedCredential := ""
+			var redirectedCredential atomicString
 			target := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-				redirectedCredential = req.Header.Get(auth.header)
+				redirectedCredential.Store(req.Header.Get(auth.header))
 				w.Header().Set("Content-Type", "application/json")
 				_, _ = w.Write([]byte(`{"ok":true}`))
 			}))
 			t.Cleanup(target.Close)
 
-			sourceRequests := 0
+			var sourceRequests atomic.Int32
 			source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-				sourceRequests++
+				sourceRequests.Add(1)
 				http.Redirect(w, req, target.URL+"/final", http.StatusTemporaryRedirect)
 			}))
 			t.Cleanup(source.Close)
@@ -775,29 +820,29 @@ func TestAzureCredentialTransportSecurityRedirects(t *testing.T) {
 			if err := client.Execute(context.Background(), http.MethodGet, "models", nil, &res); err != nil {
 				t.Fatalf("request failed: %v", err)
 			}
-			if sourceRequests != 1 {
-				t.Fatalf("source requests = %d, want 1", sourceRequests)
+			if got := sourceRequests.Load(); got != 1 {
+				t.Fatalf("source requests = %d, want 1", got)
 			}
-			if redirectedCredential != auth.headerValue {
-				t.Fatalf("redirected credential = %q, want %q", redirectedCredential, auth.headerValue)
+			if got := redirectedCredential.Load(); got != auth.headerValue {
+				t.Fatalf("redirected credential = %q, want %q", got, auth.headerValue)
 			}
 		})
 
 		t.Run(authName+"/preserves caller redirect policy", func(t *testing.T) {
-			finalReached := false
+			var finalReached atomic.Bool
 			secureServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 				if req.URL.Path != "/final" {
 					http.Redirect(w, req, "/final", http.StatusTemporaryRedirect)
 					return
 				}
-				finalReached = true
+				finalReached.Store(true)
 			}))
 			t.Cleanup(secureServer.Close)
 
-			redirectPolicyCalled := false
+			var redirectPolicyCalled atomic.Bool
 			httpClient := secureServer.Client()
 			httpClient.CheckRedirect = func(*http.Request, []*http.Request) error {
-				redirectPolicyCalled = true
+				redirectPolicyCalled.Store(true)
 				return http.ErrUseLastResponse
 			}
 			client := openai.NewClient(
@@ -811,10 +856,10 @@ func TestAzureCredentialTransportSecurityRedirects(t *testing.T) {
 			if err := client.Execute(context.Background(), http.MethodGet, "models", nil, &res); err == nil {
 				t.Fatal("expected redirect response error")
 			}
-			if !redirectPolicyCalled {
+			if !redirectPolicyCalled.Load() {
 				t.Fatal("caller redirect policy was not invoked")
 			}
-			if finalReached {
+			if finalReached.Load() {
 				t.Fatal("redirect target was reached despite caller policy")
 			}
 		})
@@ -1041,9 +1086,9 @@ func TestAzureUnsafeHTTPBypassesOpaqueRoundTripper(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "")
 	t.Setenv("OPENAI_ADMIN_KEY", "")
 
-	originReached := false
+	var originReached atomic.Bool
 	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		originReached = true
+		originReached.Store(true)
 		if got := req.Header.Get("Api-Key"); got != "azure-api-key" {
 			t.Errorf("Api-Key header = %q, want %q", got, "azure-api-key")
 		}
@@ -1075,8 +1120,45 @@ func TestAzureUnsafeHTTPBypassesOpaqueRoundTripper(t *testing.T) {
 	if transportCalled {
 		t.Fatal("opaque transport received unsafe loopback request")
 	}
-	if !originReached {
+	if !originReached.Load() {
 		t.Fatal("direct loopback origin did not receive request")
+	}
+}
+
+func TestAzureUnsafeHTTPPreservesResponseHeaderTimeout(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("OPENAI_ADMIN_KEY", "")
+
+	origin := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+		<-req.Context().Done()
+	}))
+	t.Cleanup(origin.Close)
+	originURL, err := url.Parse(origin.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const responseHeaderTimeout = 50 * time.Millisecond
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.ResponseHeaderTimeout = responseHeaderTimeout
+	client := openai.NewClient(
+		WithEndpoint("http://localhost:"+originURL.Port(), "2024-10-21"),
+		WithAPIKey("azure-api-key"),
+		WithUnsafeAllowHTTP(),
+		option.WithMaxRetries(0),
+		option.WithHTTPClient(&http.Client{Transport: transport}),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	started := time.Now()
+	var res map[string]any
+	err = client.Execute(ctx, http.MethodGet, "models", nil, &res)
+	if err == nil || !strings.Contains(err.Error(), "timeout awaiting response headers") {
+		t.Fatalf("expected response header timeout, got %v", err)
+	}
+	if elapsed := time.Since(started); elapsed >= time.Second {
+		t.Fatalf("response header timeout took %v, want less than 1s", elapsed)
 	}
 }
 
@@ -1358,6 +1440,19 @@ func (b *closeTrackingBody) Close() error {
 	default:
 	}
 	return nil
+}
+
+type atomicString struct {
+	value atomic.Value
+}
+
+func (s *atomicString) Load() string {
+	value, _ := s.value.Load().(string)
+	return value
+}
+
+func (s *atomicString) Store(value string) {
+	s.value.Store(value)
 }
 
 const azureVectorStoreResponse = `{

--- a/azure/azure_test.go
+++ b/azure/azure_test.go
@@ -622,7 +622,9 @@ func TestAzureCredentialTransportSecurityRedirects(t *testing.T) {
 						}
 						return next(req)
 					}),
-					option.WithMaxRetries(0),
+					// Keep the normal retry count so the source-request assertion
+					// proves deterministic redirect failures skip outer retries.
+					option.WithMaxRetryDelay(time.Millisecond),
 					option.WithHTTPClient(source.Client()),
 				)
 
@@ -1198,6 +1200,45 @@ func TestAzureUnsafeHTTPReusesDirectTransport(t *testing.T) {
 	}
 	if got := connections.Load(); got != 1 {
 		t.Fatalf("loopback connections = %d, want 1 shared connection", got)
+	}
+}
+
+func TestAzureHTTPSDoesNotCacheDirectTransports(t *testing.T) {
+	origin := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(origin.Close)
+	originURL, err := url.Parse(origin.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	directTransports := &azureDirectLoopbackTransportCache{}
+	for range 10 {
+		base := origin.Client().Transport.(*http.Transport).Clone()
+		transport := newAzureCredentialTransport(base, directTransports)
+		req, err := http.NewRequest(http.MethodGet, origin.URL, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx := context.WithValue(req.Context(), azureCredentialOriginContextKey{}, azureCredentialOriginFromURL(originURL))
+		res, err := transport.RoundTrip(req.WithContext(ctx))
+		if err != nil {
+			t.Fatalf("HTTPS request failed: %v", err)
+		}
+		_, _ = io.Copy(io.Discard, res.Body)
+		_ = res.Body.Close()
+		base.CloseIdleConnections()
+	}
+
+	cached := 0
+	directTransports.transports.Range(func(_, _ any) bool {
+		cached++
+		return true
+	})
+	if cached != 0 {
+		t.Fatalf("cached direct transports after HTTPS requests = %d, want 0", cached)
 	}
 }
 

--- a/azure/azure_test.go
+++ b/azure/azure_test.go
@@ -568,6 +568,7 @@ func TestAzureCredentialTransportSecurityRedirects(t *testing.T) {
 		}
 		for targetName, redirectTarget := range crossOriginTargets {
 			t.Run(authName+"/rejects HTTPS cross-origin redirect/"+targetName, func(t *testing.T) {
+				redirectBodyClosed := make(chan struct{}, 1)
 				redirectedCredential := ""
 				target := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 					redirectedCredential = req.Header.Get(auth.header)
@@ -586,12 +587,21 @@ func TestAzureCredentialTransportSecurityRedirects(t *testing.T) {
 				client := openai.NewClient(
 					WithEndpoint(source.URL, "2024-10-21"),
 					auth.option(),
+					option.WithMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+						req.GetBody = func() (io.ReadCloser, error) {
+							return &closeTrackingBody{
+								Reader: strings.NewReader(`{"model":"test"}`),
+								closed: redirectBodyClosed,
+							}, nil
+						}
+						return next(req)
+					}),
 					option.WithMaxRetries(0),
 					option.WithHTTPClient(source.Client()),
 				)
 
 				var res map[string]any
-				err := client.Execute(context.Background(), http.MethodGet, "models", nil, &res)
+				err := client.Execute(context.Background(), http.MethodPost, "models", []byte(`{"model":"test"}`), &res)
 				if err == nil || !strings.Contains(err.Error(), "authenticated redirects must remain on the original origin") {
 					t.Fatalf("expected origin restriction error, got %v", err)
 				}
@@ -600,6 +610,15 @@ func TestAzureCredentialTransportSecurityRedirects(t *testing.T) {
 				}
 				if redirectedCredential != "" {
 					t.Fatalf("credential reached cross-origin redirect target: %q", redirectedCredential)
+				}
+				// The token policy rebuilds the request body; the direct API-key path
+				// exposes the close-tracking replay body to this transport wrapper.
+				if authName == "API key" {
+					select {
+					case <-redirectBodyClosed:
+					default:
+						t.Fatal("rejected redirect body was not closed")
+					}
 				}
 			})
 		}
@@ -1129,6 +1148,19 @@ type delegatingHTTPDoer struct {
 
 func (d delegatingHTTPDoer) Do(req *http.Request) (*http.Response, error) {
 	return d.client.Do(req)
+}
+
+type closeTrackingBody struct {
+	io.Reader
+	closed chan<- struct{}
+}
+
+func (b *closeTrackingBody) Close() error {
+	select {
+	case b.closed <- struct{}{}:
+	default:
+	}
+	return nil
 }
 
 const azureVectorStoreResponse = `{

--- a/azure/azure_test.go
+++ b/azure/azure_test.go
@@ -361,7 +361,7 @@ func TestAzureCredentialTransportSecurity(t *testing.T) {
 			wantRequest: true,
 		},
 		"unsafe IPv4 loopback HTTP": {
-			endpoint:    "http://127.0.0.2:8080",
+			endpoint:    "http://127.0.0.1:8080",
 			unsafe:      true,
 			wantRequest: true,
 		},
@@ -402,8 +402,41 @@ func TestAzureCredentialTransportSecurity(t *testing.T) {
 		for testName, test := range tests {
 			t.Run(authName+"/"+testName, func(t *testing.T) {
 				var captured *http.Request
+				endpoint := test.endpoint
+				transport := http.RoundTripper(roundTripFunc(func(req *http.Request) (*http.Response, error) {
+					captured = req
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Header:     http.Header{"Content-Type": []string{"application/json"}},
+						Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+						Request:    req,
+					}, nil
+				}))
+				if test.unsafe && test.wantRequest {
+					endpointURL, err := url.Parse(endpoint)
+					if err != nil {
+						t.Fatal(err)
+					}
+					network := "tcp4"
+					listenAddress := "127.0.0.1:0"
+					if ip := net.ParseIP(endpointURL.Hostname()); ip != nil && ip.To4() == nil {
+						network = "tcp6"
+						listenAddress = "[::1]:0"
+					}
+					origin := newLoopbackHTTPServer(t, network, listenAddress, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+						captured = req
+						w.Header().Set("Content-Type", "application/json")
+						_, _ = w.Write([]byte(`{"ok":true}`))
+					}))
+					originURL, err := url.Parse(origin.URL)
+					if err != nil {
+						t.Fatal(err)
+					}
+					endpointURL.Host = net.JoinHostPort(endpointURL.Hostname(), originURL.Port())
+					endpoint = endpointURL.String()
+				}
 				opts := []option.RequestOption{
-					WithEndpoint(test.endpoint, "2024-10-21"),
+					WithEndpoint(endpoint, "2024-10-21"),
 					auth.option(),
 				}
 				if test.unsafe {
@@ -418,17 +451,7 @@ func TestAzureCredentialTransportSecurity(t *testing.T) {
 				}
 				opts = append(opts,
 					option.WithMaxRetries(0),
-					option.WithHTTPClient(&http.Client{
-						Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-							captured = req
-							return &http.Response{
-								StatusCode: http.StatusOK,
-								Header:     http.Header{"Content-Type": []string{"application/json"}},
-								Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
-								Request:    req,
-							}, nil
-						}),
-					}),
+					option.WithHTTPClient(&http.Client{Transport: transport}),
 				)
 				client := openai.NewClient(opts...)
 
@@ -722,6 +745,44 @@ func TestAzureCredentialTransportSecurityRedirects(t *testing.T) {
 			}
 		})
 
+		t.Run(authName+"/preserves unsafe loopback HTTPS upgrade", func(t *testing.T) {
+			redirectedCredential := ""
+			target := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				redirectedCredential = req.Header.Get(auth.header)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"ok":true}`))
+			}))
+			t.Cleanup(target.Close)
+
+			sourceRequests := 0
+			source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				sourceRequests++
+				http.Redirect(w, req, target.URL+"/final", http.StatusTemporaryRedirect)
+			}))
+			t.Cleanup(source.Close)
+
+			transport := target.Client().Transport.(*http.Transport).Clone()
+			transport.Proxy = nil
+			client := openai.NewClient(
+				WithEndpoint(source.URL, "2024-10-21"),
+				auth.option(),
+				WithUnsafeAllowHTTP(),
+				option.WithMaxRetries(0),
+				option.WithHTTPClient(&http.Client{Transport: transport}),
+			)
+
+			var res map[string]any
+			if err := client.Execute(context.Background(), http.MethodGet, "models", nil, &res); err != nil {
+				t.Fatalf("request failed: %v", err)
+			}
+			if sourceRequests != 1 {
+				t.Fatalf("source requests = %d, want 1", sourceRequests)
+			}
+			if redirectedCredential != auth.headerValue {
+				t.Fatalf("redirected credential = %q, want %q", redirectedCredential, auth.headerValue)
+			}
+		})
+
 		t.Run(authName+"/preserves caller redirect policy", func(t *testing.T) {
 			finalReached := false
 			secureServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -785,11 +846,6 @@ func TestAzureUnsafeHTTPMatchesProxyBypass(t *testing.T) {
 	t.Setenv("HTTP_PROXY", proxy.URL)
 	t.Setenv("http_proxy", proxy.URL)
 
-	proxyURL, err := url.Parse(proxy.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	hosts := map[string]struct {
 		host        string
 		wantAllowed bool
@@ -827,7 +883,13 @@ func TestAzureUnsafeHTTPMatchesProxyBypass(t *testing.T) {
 				}
 
 				originRequests := make(chan requestObservation, 1)
-				origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				network := "tcp4"
+				listenAddress := "127.0.0.1:0"
+				if host.host == "[::1]" {
+					network = "tcp6"
+					listenAddress = "[::1]:0"
+				}
+				origin := newLoopbackHTTPServer(t, network, listenAddress, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 					originRequests <- requestObservation{
 						host:          req.URL.Hostname(),
 						apiKey:        req.Header.Get("Api-Key"),
@@ -836,7 +898,6 @@ func TestAzureUnsafeHTTPMatchesProxyBypass(t *testing.T) {
 					w.Header().Set("Content-Type", "application/json")
 					_, _ = w.Write([]byte(`{"ok":true}`))
 				}))
-				t.Cleanup(origin.Close)
 				originURL, parseErr := url.Parse(origin.URL)
 				if parseErr != nil {
 					t.Fatal(parseErr)
@@ -844,13 +905,6 @@ func TestAzureUnsafeHTTPMatchesProxyBypass(t *testing.T) {
 
 				transport := http.DefaultTransport.(*http.Transport).Clone()
 				transport.Proxy = http.ProxyFromEnvironment
-				dialer := &net.Dialer{}
-				transport.DialContext = func(ctx context.Context, network string, address string) (net.Conn, error) {
-					if address == proxyURL.Host {
-						return dialer.DialContext(ctx, network, proxyURL.Host)
-					}
-					return dialer.DialContext(ctx, network, originURL.Host)
-				}
 
 				endpoint := "http://" + host.host + ":" + originURL.Port()
 				client := openai.NewClient(
@@ -898,6 +952,131 @@ func TestAzureUnsafeHTTPMatchesProxyBypass(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+func TestAzureUnsafeHTTPForcesDirectTransport(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("OPENAI_ADMIN_KEY", "")
+
+	authOptions := map[string]struct {
+		option      func() option.RequestOption
+		header      string
+		headerValue string
+	}{
+		"API key": {
+			option:      func() option.RequestOption { return WithAPIKey("azure-api-key") },
+			header:      "Api-Key",
+			headerValue: "azure-api-key",
+		},
+		"token": {
+			option:      func() option.RequestOption { return WithTokenCredential(&fake.TokenCredential{}) },
+			header:      "Authorization",
+			headerValue: "Bearer fake_token",
+		},
+	}
+
+	for authName, auth := range authOptions {
+		t.Run(authName, func(t *testing.T) {
+			originCredential := make(chan string, 1)
+			origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				originCredential <- req.Header.Get(auth.header)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"ok":true}`))
+			}))
+			t.Cleanup(origin.Close)
+			originURL, err := url.Parse(origin.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			proxyCredential := make(chan string, 1)
+			proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				proxyCredential <- req.Header.Get(auth.header)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"ok":true}`))
+			}))
+			t.Cleanup(proxy.Close)
+			proxyURL, err := url.Parse(proxy.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			transport := http.DefaultTransport.(*http.Transport).Clone()
+			transport.Proxy = http.ProxyURL(proxyURL)
+			dialer := &net.Dialer{}
+			transport.DialContext = func(ctx context.Context, network string, _ string) (net.Conn, error) {
+				return dialer.DialContext(ctx, network, proxyURL.Host)
+			}
+			client := openai.NewClient(
+				WithEndpoint("http://localhost:"+originURL.Port(), "2024-10-21"),
+				auth.option(),
+				WithUnsafeAllowHTTP(),
+				option.WithMaxRetries(0),
+				option.WithHTTPClient(&http.Client{Transport: transport}),
+			)
+
+			var res map[string]any
+			if err := client.Execute(context.Background(), http.MethodGet, "models", nil, &res); err != nil {
+				t.Fatalf("request failed: %v", err)
+			}
+			select {
+			case credential := <-proxyCredential:
+				t.Fatalf("loopback credential reached explicit proxy: %q", credential)
+			default:
+			}
+			select {
+			case credential := <-originCredential:
+				if credential != auth.headerValue {
+					t.Fatalf("%s header = %q, want %q", auth.header, credential, auth.headerValue)
+				}
+			default:
+				t.Fatal("direct loopback origin did not receive request")
+			}
+		})
+	}
+}
+
+func TestAzureUnsafeHTTPBypassesOpaqueRoundTripper(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("OPENAI_ADMIN_KEY", "")
+
+	originReached := false
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		originReached = true
+		if got := req.Header.Get("Api-Key"); got != "azure-api-key" {
+			t.Errorf("Api-Key header = %q, want %q", got, "azure-api-key")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(origin.Close)
+	originURL, err := url.Parse(origin.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	transportCalled := false
+	client := openai.NewClient(
+		WithEndpoint("http://localhost:"+originURL.Port(), "2024-10-21"),
+		WithAPIKey("azure-api-key"),
+		WithUnsafeAllowHTTP(),
+		option.WithMaxRetries(0),
+		option.WithHTTPClient(&http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			transportCalled = true
+			return nil, errors.New("unexpected transport call")
+		})}),
+	)
+
+	var res map[string]any
+	if err := client.Execute(context.Background(), http.MethodGet, "models", nil, &res); err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	if transportCalled {
+		t.Fatal("opaque transport received unsafe loopback request")
+	}
+	if !originReached {
+		t.Fatal("direct loopback origin did not receive request")
 	}
 }
 
@@ -1134,6 +1313,24 @@ func newMultipartRouteRequest(t *testing.T, route string, model string) *http.Re
 	}
 	req.Header.Set("Content-Type", mw.FormDataContentType())
 	return req
+}
+
+func newLoopbackHTTPServer(t *testing.T, network string, address string, handler http.Handler) *httptest.Server {
+	t.Helper()
+	listener, err := net.Listen(network, address)
+	if err != nil {
+		if network == "tcp6" {
+			t.Skipf("IPv6 loopback is unavailable: %v", err)
+		}
+		t.Fatal(err)
+	}
+
+	server := httptest.NewUnstartedServer(handler)
+	_ = server.Listener.Close()
+	server.Listener = listener
+	server.Start()
+	t.Cleanup(server.Close)
+	return server
 }
 
 type roundTripFunc func(*http.Request) (*http.Response, error)

--- a/azure/azure_test.go
+++ b/azure/azure_test.go
@@ -484,6 +484,42 @@ func TestAzureCredentialTransportSecurityRedirects(t *testing.T) {
 	}
 
 	for authName, auth := range authOptions {
+		t.Run(authName+"/rejects opaque custom doer", func(t *testing.T) {
+			redirectedCredential := ""
+			insecureTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				redirectedCredential = req.Header.Get(auth.header)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"ok":true}`))
+			}))
+			t.Cleanup(insecureTarget.Close)
+
+			sourceRequests := 0
+			secureSource := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				sourceRequests++
+				http.Redirect(w, req, insecureTarget.URL+"/final", http.StatusTemporaryRedirect)
+			}))
+			t.Cleanup(secureSource.Close)
+
+			client := openai.NewClient(
+				WithEndpoint(secureSource.URL, "2024-10-21"),
+				auth.option(),
+				option.WithMaxRetries(0),
+				option.WithHTTPClient(delegatingHTTPDoer{client: secureSource.Client()}),
+			)
+
+			var res map[string]any
+			err := client.Execute(context.Background(), http.MethodGet, "models", nil, &res)
+			if err == nil || !strings.Contains(err.Error(), "custom HTTP clients") {
+				t.Errorf("expected custom HTTP client error, got %v", err)
+			}
+			if sourceRequests != 0 {
+				t.Errorf("custom HTTP client reached redirect source %d times", sourceRequests)
+			}
+			if redirectedCredential != "" {
+				t.Errorf("credential reached insecure redirect target: %q", redirectedCredential)
+			}
+		})
+
 		t.Run(authName+"/rejects HTTPS downgrade", func(t *testing.T) {
 			redirectedCredential := ""
 			insecureTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -1002,6 +1038,14 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
+}
+
+type delegatingHTTPDoer struct {
+	client *http.Client
+}
+
+func (d delegatingHTTPDoer) Do(req *http.Request) (*http.Response, error) {
+	return d.client.Do(req)
 }
 
 const azureVectorStoreResponse = `{

--- a/azure/azure_test.go
+++ b/azure/azure_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strconv"
 	"strings"
@@ -457,6 +458,166 @@ func TestAzureCredentialTransportSecurity(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+func TestAzureCredentialTransportSecurityRedirects(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("OPENAI_ADMIN_KEY", "")
+
+	authOptions := map[string]struct {
+		option      func() option.RequestOption
+		header      string
+		headerValue string
+	}{
+		"API key": {
+			option:      func() option.RequestOption { return WithAPIKey("azure-api-key") },
+			header:      "Api-Key",
+			headerValue: "azure-api-key",
+		},
+		"token": {
+			option:      func() option.RequestOption { return WithTokenCredential(&fake.TokenCredential{}) },
+			header:      "Authorization",
+			headerValue: "Bearer fake_token",
+		},
+	}
+
+	for authName, auth := range authOptions {
+		t.Run(authName+"/rejects HTTPS downgrade", func(t *testing.T) {
+			redirectedCredential := ""
+			insecureTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				redirectedCredential = req.Header.Get(auth.header)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"ok":true}`))
+			}))
+			t.Cleanup(insecureTarget.Close)
+
+			sourceRequests := 0
+			secureSource := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				sourceRequests++
+				if req.URL.Path != "/hop" {
+					http.Redirect(w, req, "/hop", http.StatusTemporaryRedirect)
+					return
+				}
+				http.Redirect(w, req, insecureTarget.URL+"/final", http.StatusTemporaryRedirect)
+			}))
+			t.Cleanup(secureSource.Close)
+
+			client := openai.NewClient(
+				WithEndpoint(secureSource.URL, "2024-10-21"),
+				auth.option(),
+				option.WithMaxRetries(0),
+				option.WithHTTPClient(secureSource.Client()),
+			)
+
+			var res map[string]any
+			err := client.Execute(context.Background(), http.MethodGet, "models", nil, &res)
+			if err == nil || !strings.Contains(err.Error(), "azure: authenticated requests require HTTPS") {
+				t.Fatalf("expected HTTPS requirement error, got %v", err)
+			}
+			if redirectedCredential != "" {
+				t.Fatalf("credential reached insecure redirect target: %q", redirectedCredential)
+			}
+			if sourceRequests != 2 {
+				t.Fatalf("secure source requests = %d, want 2", sourceRequests)
+			}
+		})
+
+		t.Run(authName+"/preserves HTTPS redirect", func(t *testing.T) {
+			redirectedCredential := ""
+			secureServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				if req.URL.Path != "/final" {
+					http.Redirect(w, req, "/final", http.StatusTemporaryRedirect)
+					return
+				}
+				redirectedCredential = req.Header.Get(auth.header)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"ok":true}`))
+			}))
+			t.Cleanup(secureServer.Close)
+
+			client := openai.NewClient(
+				WithEndpoint(secureServer.URL, "2024-10-21"),
+				auth.option(),
+				option.WithMaxRetries(0),
+				option.WithHTTPClient(secureServer.Client()),
+			)
+
+			var res map[string]any
+			if err := client.Execute(context.Background(), http.MethodGet, "models", nil, &res); err != nil {
+				t.Fatalf("request failed: %v", err)
+			}
+			if redirectedCredential != auth.headerValue {
+				t.Fatalf("redirected credential = %q, want %q", redirectedCredential, auth.headerValue)
+			}
+		})
+
+		t.Run(authName+"/preserves unsafe loopback redirect", func(t *testing.T) {
+			redirectedCredential := ""
+			target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				redirectedCredential = req.Header.Get(auth.header)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"ok":true}`))
+			}))
+			t.Cleanup(target.Close)
+
+			source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				http.Redirect(w, req, target.URL+"/final", http.StatusTemporaryRedirect)
+			}))
+			t.Cleanup(source.Close)
+
+			client := openai.NewClient(
+				WithEndpoint(source.URL, "2024-10-21"),
+				auth.option(),
+				WithUnsafeAllowHTTP(),
+				option.WithMaxRetries(0),
+				option.WithHTTPClient(source.Client()),
+			)
+
+			var res map[string]any
+			if err := client.Execute(context.Background(), http.MethodGet, "models", nil, &res); err != nil {
+				t.Fatalf("request failed: %v", err)
+			}
+			if redirectedCredential != auth.headerValue {
+				t.Fatalf("redirected credential = %q, want %q", redirectedCredential, auth.headerValue)
+			}
+		})
+
+		t.Run(authName+"/preserves caller redirect policy", func(t *testing.T) {
+			finalReached := false
+			secureServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				if req.URL.Path != "/final" {
+					http.Redirect(w, req, "/final", http.StatusTemporaryRedirect)
+					return
+				}
+				finalReached = true
+			}))
+			t.Cleanup(secureServer.Close)
+
+			redirectPolicyCalled := false
+			httpClient := secureServer.Client()
+			httpClient.CheckRedirect = func(*http.Request, []*http.Request) error {
+				redirectPolicyCalled = true
+				return http.ErrUseLastResponse
+			}
+			client := openai.NewClient(
+				WithEndpoint(secureServer.URL, "2024-10-21"),
+				auth.option(),
+				option.WithMaxRetries(0),
+				option.WithHTTPClient(httpClient),
+			)
+
+			var res map[string]any
+			if err := client.Execute(context.Background(), http.MethodGet, "models", nil, &res); err == nil {
+				t.Fatal("expected redirect response error")
+			}
+			if !redirectPolicyCalled {
+				t.Fatal("caller redirect policy was not invoked")
+			}
+			if finalReached {
+				t.Fatal("redirect target was reached despite caller policy")
+			}
+		})
 	}
 }
 

--- a/azure/azure_test.go
+++ b/azure/azure_test.go
@@ -894,14 +894,17 @@ func TestAzureUnsafeHTTPMatchesProxyBypass(t *testing.T) {
 	t.Setenv("http_proxy", proxy.URL)
 
 	hosts := map[string]struct {
-		host        string
-		wantAllowed bool
+		host          string
+		network       string
+		listenAddress string
+		wantAllowed   bool
 	}{
-		"localhost":           {host: "localhost", wantAllowed: true},
-		"uppercase localhost": {host: "LOCALHOST"},
-		"localhost dot":       {host: "localhost."},
-		"IPv4 loopback":       {host: "127.0.0.1", wantAllowed: true},
-		"IPv6 loopback":       {host: "[::1]", wantAllowed: true},
+		"localhost":                  {host: "localhost", network: "tcp4", listenAddress: "127.0.0.1:0", wantAllowed: true},
+		"localhost with IPv6 origin": {host: "localhost", network: "tcp6", listenAddress: "[::1]:0", wantAllowed: true},
+		"uppercase localhost":        {host: "LOCALHOST", network: "tcp4", listenAddress: "127.0.0.1:0"},
+		"localhost dot":              {host: "localhost.", network: "tcp4", listenAddress: "127.0.0.1:0"},
+		"IPv4 loopback":              {host: "127.0.0.1", network: "tcp4", listenAddress: "127.0.0.1:0", wantAllowed: true},
+		"IPv6 loopback":              {host: "[::1]", network: "tcp6", listenAddress: "[::1]:0", wantAllowed: true},
 	}
 	authOptions := map[string]struct {
 		option      func() option.RequestOption
@@ -930,13 +933,7 @@ func TestAzureUnsafeHTTPMatchesProxyBypass(t *testing.T) {
 				}
 
 				originRequests := make(chan requestObservation, 1)
-				network := "tcp4"
-				listenAddress := "127.0.0.1:0"
-				if host.host == "[::1]" {
-					network = "tcp6"
-					listenAddress = "[::1]:0"
-				}
-				origin := newLoopbackHTTPServer(t, network, listenAddress, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				origin := newLoopbackHTTPServer(t, host.network, host.listenAddress, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 					originRequests <- requestObservation{
 						host:          req.URL.Hostname(),
 						apiKey:        req.Header.Get("Api-Key"),

--- a/azure/azure_test.go
+++ b/azure/azure_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"mime/multipart"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -618,6 +619,147 @@ func TestAzureCredentialTransportSecurityRedirects(t *testing.T) {
 				t.Fatal("redirect target was reached despite caller policy")
 			}
 		})
+	}
+}
+
+func TestAzureUnsafeHTTPMatchesProxyBypass(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("OPENAI_ADMIN_KEY", "")
+	t.Setenv("NO_PROXY", "")
+	t.Setenv("no_proxy", "")
+
+	type requestObservation struct {
+		host          string
+		apiKey        string
+		authorization string
+	}
+	proxyRequests := make(chan requestObservation, 1)
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		proxyRequests <- requestObservation{
+			host:          req.URL.Hostname(),
+			apiKey:        req.Header.Get("Api-Key"),
+			authorization: req.Header.Get("Authorization"),
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(proxy.Close)
+	t.Setenv("HTTP_PROXY", proxy.URL)
+	t.Setenv("http_proxy", proxy.URL)
+
+	proxyURL, err := url.Parse(proxy.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hosts := map[string]struct {
+		host        string
+		wantAllowed bool
+	}{
+		"localhost":           {host: "localhost", wantAllowed: true},
+		"uppercase localhost": {host: "LOCALHOST"},
+		"localhost dot":       {host: "localhost."},
+		"IPv4 loopback":       {host: "127.0.0.1", wantAllowed: true},
+		"IPv6 loopback":       {host: "[::1]", wantAllowed: true},
+	}
+	authOptions := map[string]struct {
+		option      func() option.RequestOption
+		header      string
+		headerValue string
+	}{
+		"API key": {
+			option:      func() option.RequestOption { return WithAPIKey("azure-api-key") },
+			header:      "Api-Key",
+			headerValue: "azure-api-key",
+		},
+		"token": {
+			option:      func() option.RequestOption { return WithTokenCredential(&fake.TokenCredential{}) },
+			header:      "Authorization",
+			headerValue: "Bearer fake_token",
+		},
+	}
+
+	for authName, auth := range authOptions {
+		for hostName, host := range hosts {
+			t.Run(authName+"/"+hostName, func(t *testing.T) {
+				select {
+				case <-proxyRequests:
+					t.Fatal("unexpected stale proxy request")
+				default:
+				}
+
+				originRequests := make(chan requestObservation, 1)
+				origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+					originRequests <- requestObservation{
+						host:          req.URL.Hostname(),
+						apiKey:        req.Header.Get("Api-Key"),
+						authorization: req.Header.Get("Authorization"),
+					}
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{"ok":true}`))
+				}))
+				t.Cleanup(origin.Close)
+				originURL, parseErr := url.Parse(origin.URL)
+				if parseErr != nil {
+					t.Fatal(parseErr)
+				}
+
+				transport := http.DefaultTransport.(*http.Transport).Clone()
+				transport.Proxy = http.ProxyFromEnvironment
+				dialer := &net.Dialer{}
+				transport.DialContext = func(ctx context.Context, network string, address string) (net.Conn, error) {
+					if address == proxyURL.Host {
+						return dialer.DialContext(ctx, network, proxyURL.Host)
+					}
+					return dialer.DialContext(ctx, network, originURL.Host)
+				}
+
+				endpoint := "http://" + host.host + ":" + originURL.Port()
+				client := openai.NewClient(
+					WithEndpoint(endpoint, "2024-10-21"),
+					auth.option(),
+					WithUnsafeAllowHTTP(),
+					option.WithMaxRetries(0),
+					option.WithHTTPClient(&http.Client{Transport: transport}),
+				)
+
+				var res map[string]any
+				requestErr := client.Execute(context.Background(), http.MethodGet, "models", nil, &res)
+				if !host.wantAllowed {
+					if requestErr == nil || !strings.Contains(requestErr.Error(), "azure: authenticated requests require HTTPS") {
+						t.Errorf("expected HTTPS requirement error, got %v", requestErr)
+					}
+					select {
+					case got := <-proxyRequests:
+						t.Errorf("rejected hostname reached proxy: %q", got.host)
+					default:
+					}
+					select {
+					case got := <-originRequests:
+						t.Errorf("rejected hostname reached origin: %q", got.host)
+					default:
+					}
+					return
+				}
+
+				if requestErr != nil {
+					t.Fatalf("request failed: %v", requestErr)
+				}
+				select {
+				case got := <-proxyRequests:
+					t.Fatalf("loopback request reached proxy: %q", got.host)
+				default:
+				}
+				select {
+				case got := <-originRequests:
+					if credential := map[string]string{"Api-Key": got.apiKey, "Authorization": got.authorization}[auth.header]; credential != auth.headerValue {
+						t.Fatalf("%s header = %q, want %q", auth.header, credential, auth.headerValue)
+					}
+				default:
+					t.Fatal("allowed loopback request did not reach origin")
+				}
+			})
+		}
 	}
 }
 

--- a/azure/azure_test.go
+++ b/azure/azure_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/internal/apijson"
 	"github.com/openai/openai-go/v3/internal/requestconfig"
@@ -317,6 +318,145 @@ func TestAPIKeyAuthenticationSuppressesAutomaticAuthorization(t *testing.T) {
 				t.Fatalf("Authorization header = %q, want empty", got)
 			}
 		})
+	}
+}
+
+func TestAzureCredentialTransportSecurity(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("OPENAI_ADMIN_KEY", "")
+
+	tests := map[string]struct {
+		endpoint        string
+		unsafe          bool
+		requestBaseURL  string
+		rewriteToRemote bool
+		wantRequest     bool
+	}{
+		"HTTPS": {
+			endpoint:    "https://my-resource.openai.azure.com",
+			wantRequest: true,
+		},
+		"remote HTTP": {
+			endpoint: "http://my-resource.openai.azure.com",
+		},
+		"mixed-case remote HTTP": {
+			endpoint: "HtTp://my-resource.openai.azure.com",
+		},
+		"non-HTTP scheme": {
+			endpoint: "ftp://my-resource.openai.azure.com",
+		},
+		"request-level remote HTTP override": {
+			endpoint:       "https://my-resource.openai.azure.com",
+			requestBaseURL: "http://request.example",
+		},
+		"middleware remote HTTP rewrite": {
+			endpoint:        "https://my-resource.openai.azure.com",
+			rewriteToRemote: true,
+		},
+		"unsafe localhost HTTP": {
+			endpoint:    "http://localhost:8080",
+			unsafe:      true,
+			wantRequest: true,
+		},
+		"unsafe IPv4 loopback HTTP": {
+			endpoint:    "http://127.0.0.2:8080",
+			unsafe:      true,
+			wantRequest: true,
+		},
+		"unsafe IPv6 loopback HTTP": {
+			endpoint:    "http://[::1]:8080",
+			unsafe:      true,
+			wantRequest: true,
+		},
+		"unsafe remote HTTP": {
+			endpoint: "http://my-resource.openai.azure.com",
+			unsafe:   true,
+		},
+		"unsafe loopback rewritten to remote HTTP": {
+			endpoint:        "http://127.0.0.1:8080",
+			unsafe:          true,
+			rewriteToRemote: true,
+		},
+	}
+
+	authOptions := map[string]struct {
+		option      func() option.RequestOption
+		header      string
+		headerValue string
+	}{
+		"API key": {
+			option:      func() option.RequestOption { return WithAPIKey("azure-api-key") },
+			header:      "Api-Key",
+			headerValue: "azure-api-key",
+		},
+		"token": {
+			option:      func() option.RequestOption { return WithTokenCredential(&fake.TokenCredential{}) },
+			header:      "Authorization",
+			headerValue: "Bearer fake_token",
+		},
+	}
+
+	for authName, auth := range authOptions {
+		for testName, test := range tests {
+			t.Run(authName+"/"+testName, func(t *testing.T) {
+				var captured *http.Request
+				opts := []option.RequestOption{
+					WithEndpoint(test.endpoint, "2024-10-21"),
+					auth.option(),
+				}
+				if test.unsafe {
+					opts = append(opts, WithUnsafeAllowHTTP())
+				}
+				if test.rewriteToRemote {
+					opts = append(opts, option.WithMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+						req.URL.Scheme = "http"
+						req.URL.Host = "middleware.example"
+						return next(req)
+					}))
+				}
+				opts = append(opts,
+					option.WithMaxRetries(0),
+					option.WithHTTPClient(&http.Client{
+						Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+							captured = req
+							return &http.Response{
+								StatusCode: http.StatusOK,
+								Header:     http.Header{"Content-Type": []string{"application/json"}},
+								Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+								Request:    req,
+							}, nil
+						}),
+					}),
+				)
+				client := openai.NewClient(opts...)
+
+				var requestOptions []option.RequestOption
+				if test.requestBaseURL != "" {
+					requestOptions = append(requestOptions, option.WithBaseURL(test.requestBaseURL))
+				}
+				var res map[string]any
+				err := client.Execute(context.Background(), http.MethodGet, "models", nil, &res, requestOptions...)
+				if test.wantRequest {
+					if err != nil {
+						t.Fatalf("request failed: %v", err)
+					}
+					if captured == nil {
+						t.Fatal("request did not reach the transport")
+					}
+					if got := captured.Header.Get(auth.header); got != auth.headerValue {
+						t.Fatalf("%s header = %q, want %q", auth.header, got, auth.headerValue)
+					}
+					return
+				}
+
+				if err == nil || !strings.Contains(err.Error(), "azure: authenticated requests require HTTPS") {
+					t.Fatalf("expected HTTPS requirement error, got %v", err)
+				}
+				if captured != nil {
+					t.Fatal("insecure credential transport reached the network")
+				}
+			})
+		}
 	}
 }
 

--- a/azure/azure_test.go
+++ b/azure/azure_test.go
@@ -560,6 +560,89 @@ func TestAzureCredentialTransportSecurityRedirects(t *testing.T) {
 			}
 		})
 
+		crossOriginTargets := map[string]func(string) string{
+			"different port": func(targetURL string) string { return targetURL },
+			"different host": func(targetURL string) string {
+				return strings.Replace(targetURL, "127.0.0.1", "localhost", 1)
+			},
+		}
+		for targetName, redirectTarget := range crossOriginTargets {
+			t.Run(authName+"/rejects HTTPS cross-origin redirect/"+targetName, func(t *testing.T) {
+				redirectedCredential := ""
+				target := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+					redirectedCredential = req.Header.Get(auth.header)
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{"ok":true}`))
+				}))
+				t.Cleanup(target.Close)
+
+				sourceRequests := 0
+				source := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+					sourceRequests++
+					http.Redirect(w, req, redirectTarget(target.URL)+"/final", http.StatusTemporaryRedirect)
+				}))
+				t.Cleanup(source.Close)
+
+				client := openai.NewClient(
+					WithEndpoint(source.URL, "2024-10-21"),
+					auth.option(),
+					option.WithMaxRetries(0),
+					option.WithHTTPClient(source.Client()),
+				)
+
+				var res map[string]any
+				err := client.Execute(context.Background(), http.MethodGet, "models", nil, &res)
+				if err == nil || !strings.Contains(err.Error(), "authenticated redirects must remain on the original origin") {
+					t.Fatalf("expected origin restriction error, got %v", err)
+				}
+				if sourceRequests != 1 {
+					t.Fatalf("secure source requests = %d, want 1", sourceRequests)
+				}
+				if redirectedCredential != "" {
+					t.Fatalf("credential reached cross-origin redirect target: %q", redirectedCredential)
+				}
+			})
+		}
+
+		t.Run(authName+"/unsafe remote HTTPS cannot redirect to loopback HTTP", func(t *testing.T) {
+			targetReached := false
+			target := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+				targetReached = true
+			}))
+			t.Cleanup(target.Close)
+
+			source := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				http.Redirect(w, req, target.URL+"/final", http.StatusTemporaryRedirect)
+			}))
+			t.Cleanup(source.Close)
+			sourceURL, err := url.Parse(source.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+			transport := source.Client().Transport.(*http.Transport).Clone()
+			dialer := &net.Dialer{}
+			transport.DialContext = func(ctx context.Context, network string, _ string) (net.Conn, error) {
+				return dialer.DialContext(ctx, network, sourceURL.Host)
+			}
+
+			client := openai.NewClient(
+				WithEndpoint("https://example.com:"+sourceURL.Port(), "2024-10-21"),
+				auth.option(),
+				WithUnsafeAllowHTTP(),
+				option.WithMaxRetries(0),
+				option.WithHTTPClient(&http.Client{Transport: transport}),
+			)
+
+			var res map[string]any
+			requestErr := client.Execute(context.Background(), http.MethodGet, "models", nil, &res)
+			if requestErr == nil || !strings.Contains(requestErr.Error(), "azure: authenticated requests require HTTPS") {
+				t.Fatalf("expected HTTPS requirement error, got %v", requestErr)
+			}
+			if targetReached {
+				t.Fatal("credential request reached loopback redirect target")
+			}
+		})
+
 		t.Run(authName+"/preserves HTTPS redirect", func(t *testing.T) {
 			redirectedCredential := ""
 			secureServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {

--- a/azure/azure_test.go
+++ b/azure/azure_test.go
@@ -1162,6 +1162,45 @@ func TestAzureUnsafeHTTPPreservesResponseHeaderTimeout(t *testing.T) {
 	}
 }
 
+func TestAzureUnsafeHTTPReusesDirectTransport(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("OPENAI_ADMIN_KEY", "")
+
+	var connections atomic.Int32
+	origin := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	origin.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			connections.Add(1)
+		}
+	}
+	origin.Start()
+	t.Cleanup(origin.Close)
+	originURL, err := url.Parse(origin.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client := openai.NewClient(
+		WithEndpoint("http://localhost:"+originURL.Port(), "2024-10-21"),
+		WithAPIKey("azure-api-key"),
+		WithUnsafeAllowHTTP(),
+		option.WithMaxRetries(0),
+	)
+
+	for range 2 {
+		var res map[string]any
+		if err := client.Execute(context.Background(), http.MethodGet, "models", nil, &res); err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+	}
+	if got := connections.Load(); got != 1 {
+		t.Fatalf("loopback connections = %d, want 1 shared connection", got)
+	}
+}
+
 func TestJSONRoutePathConstruction(t *testing.T) {
 	cases := []struct {
 		path     string


### PR DESCRIPTION
## Summary

- require secure transport for authenticated Azure requests
- provide an explicit loopback-only HTTP option for local development and tests
- validate the final effective request URL after client- and request-level options

## Compatibility

- preserves existing HTTPS behavior, Azure credential headers, token scopes, custom clients, and middleware composition
- changes only handwritten Azure integration code and focused tests; no generated SDK output changes

## Validation

- `go test ./azure -count=1`
- `go test -race ./azure -count=1`
- full root test suite with the repository-pinned mock server
- `./scripts/lint`
- `./scripts/check-go-mod`
- examples and external-consumer tests
- strict maintainability review, committed-change review, and exact-head security review
