### PR TITLE
fix(webhooks): validate prefixed signing secrets

### DIFF
--- a/webhooks/webhook.go
+++ b/webhooks/webhook.go
@@ -119,6 +119,10 @@ func (r *WebhookService) VerifySignatureWithToleranceAndTime(body []byte, header
 	if webhookSecret == "" {
 		return errors.New("webhook secret must be provided either in the method call or configured on the client")
 	}
+	decodedSecret, err := decodeWebhookSecret(webhookSecret)
+	if err != nil {
+		return err
+	}
 
 	if headers == nil {
 		return errors.New("headers are required for webhook verification")
@@ -167,17 +171,6 @@ func (r *WebhookService) VerifySignatureWithToleranceAndTime(body []byte, header
 		} else {
 			signatures = append(signatures, part)
 		}
-	}
-
-	// Decode the secret if it starts with whsec_
-	var decodedSecret []byte
-	if strings.HasPrefix(webhookSecret, "whsec_") {
-		decodedSecret, err = base64.StdEncoding.DecodeString(webhookSecret[6:])
-		if err != nil {
-			return fmt.Errorf("invalid webhook secret format: %v", err)
-		}
-	} else {
-		decodedSecret = []byte(webhookSecret)
 	}
 
 	// Create the signed payload: {webhook_id}.{timestamp}.{payload}

--- a/webhooks/webhook_secret.go
+++ b/webhooks/webhook_secret.go
@@ -1,0 +1,34 @@
+package webhooks
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const (
+	webhookSecretPrefix = "whsec_"
+	// Standard Webhooks symmetric signing keys contain at least 24 bytes.
+	minimumWebhookSecretBytes = 24
+)
+
+func decodeWebhookSecret(secret string) ([]byte, error) {
+	encodedSecret, prefixed := strings.CutPrefix(secret, webhookSecretPrefix)
+	if !prefixed {
+		return []byte(secret), nil
+	}
+
+	decodedSecret, err := base64.StdEncoding.Strict().DecodeString(encodedSecret)
+	if err != nil {
+		return nil, fmt.Errorf("invalid webhook secret format: %v", err)
+	}
+	if base64.StdEncoding.EncodeToString(decodedSecret) != encodedSecret {
+		return nil, errors.New("invalid webhook secret format: expected canonical base64 encoding")
+	}
+	if len(decodedSecret) < minimumWebhookSecretBytes {
+		return nil, fmt.Errorf("invalid webhook secret: decoded secret must be at least %d bytes", minimumWebhookSecretBytes)
+	}
+
+	return decodedSecret, nil
+}

--- a/webhooks/webhook_test.go
+++ b/webhooks/webhook_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"net/http"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -117,6 +118,10 @@ func TestWebhookService_RequestOptionsOverrideClientOptions(t *testing.T) {
 	}
 }
 
+func createTestHeadersForSecret(secret []byte) http.Header {
+	return createSignedTestHeaders(string(secret), testTimestamp)
+}
+
 func TestWebhookService_VerifySignature_ValidSignature(t *testing.T) {
 	client := openai.NewClient(
 		option.WithAPIKey("test-key"),
@@ -128,6 +133,162 @@ func TestWebhookService_VerifySignature_ValidSignature(t *testing.T) {
 	err := client.Webhooks.VerifySignatureWithToleranceAndTime([]byte(testPayload), createTestHeaders(), 5*time.Minute, fixedTime)
 	if err != nil {
 		t.Errorf("VerifySignatureWithToleranceAndTime should have succeeded with valid signature: %v", err)
+	}
+}
+
+func TestWebhookService_VerifySignature_RejectsInvalidPrefixedSecrets(t *testing.T) {
+	validSecret, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(testSecret, "whsec_"))
+	if err != nil {
+		t.Fatalf("failed to decode test secret: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		secret  string
+		key     []byte
+		wantErr string
+	}{
+		{
+			name:    "empty",
+			secret:  "whsec_",
+			key:     nil,
+			wantErr: "invalid webhook secret: decoded secret must be at least 24 bytes",
+		},
+		{
+			name:    "undersized",
+			secret:  "whsec_YQ==",
+			key:     []byte("a"),
+			wantErr: "invalid webhook secret: decoded secret must be at least 24 bytes",
+		},
+		{
+			name:    "non-zero trailing base64 bits",
+			secret:  strings.TrimSuffix(testSecret, "c=") + "d=",
+			key:     validSecret,
+			wantErr: "invalid webhook secret format",
+		},
+		{
+			name:    "non-canonical base64 line break",
+			secret:  strings.Replace(testSecret, "+", "+\n", 1),
+			key:     validSecret,
+			wantErr: "expected canonical base64 encoding",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := openai.NewClient(
+				option.WithAPIKey("test-key"),
+				option.WithWebhookSecret(test.secret),
+			)
+
+			err := client.Webhooks.VerifySignatureWithToleranceAndTime(
+				[]byte(testPayload),
+				createTestHeadersForSecret(test.key),
+				5*time.Minute,
+				time.Unix(testTimestamp, 0),
+			)
+			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("VerifySignatureWithToleranceAndTime error = %v, want error containing %q", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestWebhookService_VerifySignature_AcceptsMinimumLengthPrefixedSecret(t *testing.T) {
+	secret := []byte("123456789012345678901234")
+	client := openai.NewClient(
+		option.WithAPIKey("test-key"),
+		option.WithWebhookSecret("whsec_"+base64.StdEncoding.EncodeToString(secret)),
+	)
+
+	err := client.Webhooks.VerifySignatureWithToleranceAndTime(
+		[]byte(testPayload),
+		createTestHeadersForSecret(secret),
+		5*time.Minute,
+		time.Unix(testTimestamp, 0),
+	)
+	if err != nil {
+		t.Fatalf("VerifySignatureWithToleranceAndTime should have accepted a 24-byte prefixed secret: %v", err)
+	}
+}
+
+func TestWebhookService_VerifySignature_AcceptsRawSecret(t *testing.T) {
+	secret := "legacy-raw-secret"
+	client := openai.NewClient(
+		option.WithAPIKey("test-key"),
+		option.WithWebhookSecret(secret),
+	)
+
+	err := client.Webhooks.VerifySignatureWithToleranceAndTime(
+		[]byte(testPayload),
+		createTestHeadersForSecret([]byte(secret)),
+		5*time.Minute,
+		time.Unix(testTimestamp, 0),
+	)
+	if err != nil {
+		t.Fatalf("VerifySignatureWithToleranceAndTime should have accepted a valid raw secret: %v", err)
+	}
+}
+
+func TestWebhookService_VerifySignature_RejectsInvalidEnvironmentSecret(t *testing.T) {
+	t.Setenv("OPENAI_WEBHOOK_SECRET", "whsec_")
+	client := openai.NewClient(option.WithAPIKey("test-key"))
+
+	err := client.Webhooks.VerifySignatureWithToleranceAndTime(
+		[]byte(testPayload),
+		createTestHeadersForSecret(nil),
+		5*time.Minute,
+		time.Unix(testTimestamp, 0),
+	)
+	if err == nil || !strings.Contains(err.Error(), "decoded secret must be at least 24 bytes") {
+		t.Fatalf("VerifySignatureWithToleranceAndTime error = %v, want invalid webhook secret error", err)
+	}
+}
+
+func TestWebhookService_VerifySignature_ExplicitSecretOverridesInvalidEnvironmentDefault(t *testing.T) {
+	t.Setenv("OPENAI_WEBHOOK_SECRET", "whsec_")
+	client := openai.NewClient(
+		option.WithAPIKey("test-key"),
+		option.WithWebhookSecret(testSecret),
+	)
+
+	err := client.Webhooks.VerifySignatureWithToleranceAndTime(
+		[]byte(testPayload),
+		createTestHeaders(),
+		5*time.Minute,
+		time.Unix(testTimestamp, 0),
+	)
+	if err != nil {
+		t.Fatalf("VerifySignatureWithToleranceAndTime should have accepted the explicit valid secret: %v", err)
+	}
+}
+
+func TestWebhookService_VerifySignature_ValidatesEffectiveRequestSecret(t *testing.T) {
+	t.Setenv("OPENAI_WEBHOOK_SECRET", "")
+	fixedTime := time.Unix(testTimestamp, 0)
+
+	clientWithInvalidSecret := openai.NewClient(option.WithWebhookSecret("whsec_"))
+	err := clientWithInvalidSecret.Webhooks.VerifySignatureWithToleranceAndTime(
+		[]byte(testPayload),
+		createTestHeaders(),
+		5*time.Minute,
+		fixedTime,
+		option.WithWebhookSecret(testSecret),
+	)
+	if err != nil {
+		t.Fatalf("VerifySignatureWithToleranceAndTime should have accepted the valid request secret: %v", err)
+	}
+
+	clientWithValidSecret := openai.NewClient(option.WithWebhookSecret(testSecret))
+	err = clientWithValidSecret.Webhooks.VerifySignatureWithToleranceAndTime(
+		[]byte(testPayload),
+		createTestHeadersForSecret(nil),
+		5*time.Minute,
+		fixedTime,
+		option.WithWebhookSecret("whsec_"),
+	)
+	if err == nil || !strings.Contains(err.Error(), "decoded secret must be at least 24 bytes") {
+		t.Fatalf("VerifySignatureWithToleranceAndTime error = %v, want invalid request secret error", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- centralize prefixed webhook signing-secret parsing at the final effective configuration boundary
- reject malformed, noncanonical, and undersized prefixed configuration while preserving legacy raw-secret behavior
- cover client options, environment defaults, precedence, protocol-minimum configuration, and compatibility through public verifier tests

## Implementation note

The verifier in webhooks/webhook.go is a repository-specific customization inside a Castiron-generated file. Parsing policy is isolated in a small handwritten helper to minimize generated merge surface.

## Testing

- go test ./webhooks
- go test ./internal/requestconfig
- full root go test ./... with the repository-pinned mock server
- GOFLAGS=-buildvcs=false ./scripts/lint
- git diff --check
- thermo-nuclear code-quality review
- exhaustive committed openai-go PR review
- exact-commit Codex Security diff scan (complete, zero findings)

Webhook verification changes require SDK CODEOWNER review.