### PR TITLE
fix(azure): validate deployment routing bodies

### DIFF
--- a/azure/azure.go
+++ b/azure/azure.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"mime"
 	"mime/multipart"
@@ -214,22 +215,29 @@ func setEscapedPath(u *url.URL, escapedPath string) error {
 }
 
 func getJSONRoute(req *http.Request) (string, error) {
+	if req.Body == nil {
+		return "", errors.New("azure: deployment routing requires a JSON request body")
+	}
+
 	// we need to deserialize the body, partly, in order to read out the model field.
 	jsonBytes, err := io.ReadAll(req.Body)
 
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("azure: could not read JSON request body for deployment routing: %w", err)
 	}
 
 	// make sure we restore the body so it can be used in later middlewares.
 	req.Body = io.NopCloser(bytes.NewReader(jsonBytes))
 
-	var v *struct {
+	var v struct {
 		Model string `json:"model"`
 	}
 
 	if err := json.Unmarshal(jsonBytes, &v); err != nil {
-		return "", err
+		return "", fmt.Errorf("azure: could not parse JSON request body for deployment routing: %w", err)
+	}
+	if v.Model == "" {
+		return "", errors.New("azure: deployment routing requires a non-empty model field")
 	}
 
 	// Convert path from /chat/completions to /openai/deployments/{deployment-id}/chat/completions

--- a/azure/azure.go
+++ b/azure/azure.go
@@ -62,11 +62,11 @@ func WithEndpoint(endpoint string, apiVersion string) option.RequestOption {
 		replacementPath, err := getReplacementPathWithDeployment(r)
 
 		if err != nil {
-			return nil, err
+			return nil, requestconfig.WithNoRetryError(err)
 		}
 
 		if err := setEscapedPath(r.URL, replacementPath); err != nil {
-			return nil, err
+			return nil, requestconfig.WithNoRetryError(err)
 		}
 		return mn(r)
 	})

--- a/azure/azure_test.go
+++ b/azure/azure_test.go
@@ -115,10 +115,14 @@ func TestAzureJSONRoutesRejectInvalidBodiesBeforeTransport(t *testing.T) {
 	}
 
 	transportCalls := 0
+	routingAttempts := 0
 	client := openai.NewClient(
+		option.WithMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+			routingAttempts++
+			return next(req)
+		}),
 		WithEndpoint("https://my-resource.openai.azure.com", "2024-10-21"),
 		WithAPIKey("azure-api-key"),
-		option.WithMaxRetries(0),
 		option.WithHTTPClient(&http.Client{
 			Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
 				transportCalls++
@@ -127,9 +131,11 @@ func TestAzureJSONRoutesRejectInvalidBodiesBeforeTransport(t *testing.T) {
 		}),
 	)
 
+	wantRoutingAttempts := 0
 	for _, route := range routes {
 		for _, tc := range invalidJSONRouteBodies {
 			t.Run(route+"/"+tc.name, func(t *testing.T) {
+				wantRoutingAttempts++
 				var body any
 				if tc.body != nil {
 					body = tc.body
@@ -144,6 +150,9 @@ func TestAzureJSONRoutesRejectInvalidBodiesBeforeTransport(t *testing.T) {
 				}
 				if transportCalls != 0 {
 					t.Fatalf("transport called %d times, want 0", transportCalls)
+				}
+				if routingAttempts != wantRoutingAttempts {
+					t.Fatalf("routing attempted %d times, want %d", routingAttempts, wantRoutingAttempts)
 				}
 			})
 		}

--- a/azure/azure_test.go
+++ b/azure/azure_test.go
@@ -3,6 +3,7 @@ package azure
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -16,6 +17,22 @@ import (
 	"github.com/openai/openai-go/v3/internal/requestconfig"
 	"github.com/openai/openai-go/v3/option"
 )
+
+var invalidJSONRouteBodies = []struct {
+	name      string
+	body      []byte
+	wantError string
+}{
+	{name: "nil body", wantError: "requires a JSON request body"},
+	{name: "empty body", body: []byte{}, wantError: "could not parse JSON request body"},
+	{name: "null", body: []byte("null"), wantError: "requires a non-empty model field"},
+	{name: "empty object", body: []byte("{}"), wantError: "requires a non-empty model field"},
+	{name: "missing model", body: []byte(`{"input":"hello"}`), wantError: "requires a non-empty model field"},
+	{name: "empty model", body: []byte(`{"model":""}`), wantError: "requires a non-empty model field"},
+	{name: "scalar", body: []byte(`"gpt-4"`), wantError: "could not parse JSON request body"},
+	{name: "wrong model type", body: []byte(`{"model":123}`), wantError: "could not parse JSON request body"},
+	{name: "malformed", body: []byte(`{"model":`), wantError: "could not parse JSON request body"},
+}
 
 func TestJSONRoute(t *testing.T) {
 	chatCompletionParams := openai.ChatCompletionNewParams{
@@ -46,6 +63,141 @@ func TestJSONRoute(t *testing.T) {
 
 	if replacementPath != "/openai/deployments/arbitraryDeployment/chat/completions" {
 		t.Fatalf("replacementpath didn't match: %s", replacementPath)
+	}
+
+	restoredBody, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(restoredBody, serializedBytes) {
+		t.Fatalf("restored body = %q, want %q", restoredBody, serializedBytes)
+	}
+}
+
+func TestJSONRouteRejectsInvalidBodies(t *testing.T) {
+	for _, tc := range invalidJSONRouteBodies {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodPost, "/chat/completions", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tc.body != nil {
+				req.Body = io.NopCloser(bytes.NewReader(tc.body))
+			}
+
+			if _, err = getJSONRoute(req); err == nil {
+				t.Fatal("expected an error")
+			} else if !strings.Contains(err.Error(), tc.wantError) {
+				t.Fatalf("error = %q, want it to contain %q", err, tc.wantError)
+			}
+
+			if tc.body == nil {
+				return
+			}
+			restoredBody, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(restoredBody, tc.body) {
+				t.Fatalf("restored body = %q, want %q", restoredBody, tc.body)
+			}
+		})
+	}
+}
+
+func TestAzureJSONRoutesRejectInvalidBodiesBeforeTransport(t *testing.T) {
+	routes := []string{
+		"/completions",
+		"/chat/completions",
+		"/embeddings",
+		"/audio/speech",
+		"/images/generations",
+	}
+
+	transportCalls := 0
+	client := openai.NewClient(
+		WithEndpoint("https://my-resource.openai.azure.com", "2024-10-21"),
+		WithAPIKey("azure-api-key"),
+		option.WithMaxRetries(0),
+		option.WithHTTPClient(&http.Client{
+			Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				transportCalls++
+				return nil, errors.New("unexpected transport call")
+			}),
+		}),
+	)
+
+	for _, route := range routes {
+		for _, tc := range invalidJSONRouteBodies {
+			t.Run(route+"/"+tc.name, func(t *testing.T) {
+				var body any
+				if tc.body != nil {
+					body = tc.body
+				}
+
+				err := client.Execute(context.Background(), http.MethodPost, route, body, nil)
+				if err == nil {
+					t.Fatal("expected an error")
+				}
+				if !strings.Contains(err.Error(), tc.wantError) {
+					t.Fatalf("error = %q, want it to contain %q", err, tc.wantError)
+				}
+				if transportCalls != 0 {
+					t.Fatalf("transport called %d times, want 0", transportCalls)
+				}
+			})
+		}
+	}
+}
+
+func TestAzureJSONRoutesPreserveValidBodyAndRewritePath(t *testing.T) {
+	routes := []string{
+		"/completions",
+		"/chat/completions",
+		"/embeddings",
+		"/audio/speech",
+		"/images/generations",
+	}
+	body := []byte("{\n  \"model\" : \"deployment-name\",\n  \"input\" : \"unchanged\"\n}\n")
+
+	for _, route := range routes {
+		t.Run(route, func(t *testing.T) {
+			transportCalls := 0
+			client := openai.NewClient(
+				WithEndpoint("https://my-resource.openai.azure.com", "2024-10-21"),
+				WithAPIKey("azure-api-key"),
+				option.WithMaxRetries(0),
+				option.WithHTTPClient(&http.Client{
+					Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+						transportCalls++
+						if got, want := req.URL.EscapedPath(), "/openai/deployments/deployment-name"+route; got != want {
+							t.Errorf("path = %q, want %q", got, want)
+						}
+						gotBody, err := io.ReadAll(req.Body)
+						if err != nil {
+							t.Fatal(err)
+						}
+						if !bytes.Equal(gotBody, body) {
+							t.Errorf("body = %q, want %q", gotBody, body)
+						}
+						return &http.Response{
+							StatusCode: http.StatusOK,
+							Header:     http.Header{"Content-Type": []string{"application/json"}},
+							Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+							Request:    req,
+						}, nil
+					}),
+				}),
+			)
+
+			var response map[string]any
+			if err := client.Execute(context.Background(), http.MethodPost, route, body, &response); err != nil {
+				t.Fatal(err)
+			}
+			if transportCalls != 1 {
+				t.Fatalf("transport called %d times, want 1", transportCalls)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- harden Azure deployment routing validation for invalid request bodies
- keep deterministic routing failures out of the generic retry loop
- preserve valid deployment rewriting and request payload bytes

## Testing

- go test ./azure -run TestAzureJSONRoutes -count=1
- GOFLAGS=-buildvcs=false ./scripts/lint