### PR TITLE
feat(ssestream): add opt-in event budget

### DIFF
--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -335,6 +335,7 @@ type RequestConfig struct {
 	MaxRetries                 int
 	MaxRetryDelay              time.Duration
 	RequestTimeout             time.Duration
+	SSEMaxEventBytes           int
 	Context                    context.Context
 	Request                    *http.Request
 	BaseURL                    *url.URL
@@ -658,6 +659,7 @@ func (cfg *RequestConfig) Execute() (err error) {
 
 		attemptBody := req.Body
 		res, err = handler(req)
+		attachSSEMaxEventBytes(res, req, cfg.SSEMaxEventBytes)
 		if err != nil {
 			if req.Body != nil {
 				_ = req.Body.Close()

--- a/internal/requestconfig/streaming.go
+++ b/internal/requestconfig/streaming.go
@@ -1,0 +1,35 @@
+package requestconfig
+
+import (
+	"context"
+	"net/http"
+)
+
+type sseMaxEventBytesKey struct{}
+
+// WithSSEMaxEventBytes attaches an SSE event budget to req. This function is
+// internal API and may change without notice.
+func WithSSEMaxEventBytes(req *http.Request, maxBytes int) *http.Request {
+	return req.WithContext(context.WithValue(req.Context(), sseMaxEventBytesKey{}, maxBytes))
+}
+
+// SSEMaxEventBytes returns the SSE event budget attached to req. This function
+// is internal API and may change without notice.
+func SSEMaxEventBytes(req *http.Request) int {
+	if req == nil {
+		return 0
+	}
+	maxBytes, _ := req.Context().Value(sseMaxEventBytesKey{}).(int)
+	return maxBytes
+}
+
+func attachSSEMaxEventBytes(res *http.Response, fallbackRequest *http.Request, maxBytes int) {
+	if res == nil || maxBytes <= 0 {
+		return
+	}
+	request := res.Request
+	if request == nil {
+		request = fallbackRequest
+	}
+	res.Request = WithSSEMaxEventBytes(request, maxBytes)
+}

--- a/internal/testutil/large_payload_contract_test.go
+++ b/internal/testutil/large_payload_contract_test.go
@@ -83,6 +83,44 @@ func TestLargeResponsesPayloadContract(t *testing.T) {
 	}
 }
 
+func TestLargeSegmentedSSEEventContract(t *testing.T) {
+	const whitespaceChunkSize = 8 * 1024
+	whitespace := strings.Repeat(" ", whitespaceChunkSize)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/responses" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		writeLargePayload(t, w, "event: response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\n")
+		remainingWhitespace := largePayloadSize
+		for remainingWhitespace > 0 {
+			chunkSize := min(remainingWhitespace, whitespaceChunkSize)
+			writeLargePayload(t, w, "data: "+whitespace[:chunkSize]+"\n")
+			remainingWhitespace -= chunkSize
+		}
+		writeLargePayload(t, w, "data: \"text\":\"ok\",\"item_id\":\"msg_test\",\"output_index\":0,\"content_index\":0,\"sequence_number\":1,\"logprobs\":[]}\n\ndata: [DONE]\n\n")
+	}))
+	defer server.Close()
+
+	client := openai.NewClient(option.WithAPIKey("test-key"), option.WithBaseURL(server.URL), option.WithMaxRetries(0))
+	stream := client.Responses.NewStreaming(context.Background(), responses.ResponseNewParams{
+		Model: "gpt-4o-mini",
+		Input: responses.ResponseNewParamsInputUnion{OfString: openai.String("Hello")},
+	})
+	defer func() { _ = stream.Close() }()
+
+	if !stream.Next() {
+		t.Fatalf("large segmented event was not delivered: %v", stream.Err())
+	}
+	event := stream.Current()
+	if event.Type != "response.output_text.done" || event.AsResponseOutputTextDone().Text != "ok" {
+		t.Fatal("large segmented event was truncated or changed")
+	}
+}
+
 func TestLargeChatCompletionPayloadContract(t *testing.T) {
 	for _, streaming := range []bool{false, true} {
 		name := "blocking JSON"

--- a/option/requestoption.go
+++ b/option/requestoption.go
@@ -123,6 +123,26 @@ func WithMaxRetryDelay(delay time.Duration) RequestOption {
 	})
 }
 
+// WithSSEMaxEventBytes returns a RequestOption that limits the aggregate size
+// of each server-sent event decoded by the built-in text/event-stream decoder.
+// The budget counts each non-empty SSE line after normalizing its ending to one
+// byte and excludes the blank event delimiter. It composes with the decoder's
+// existing per-line limit and does not apply to decoders installed with
+// ssestream.RegisterDecoder.
+//
+// The aggregate limit is opt-in: zero preserves the default unlimited
+// aggregate event size and can disable a client-level limit for one request.
+// Negative limits panic.
+func WithSSEMaxEventBytes(maxBytes int) RequestOption {
+	if maxBytes < 0 {
+		panic("option: SSE event size limit cannot be negative")
+	}
+	return requestconfig.RequestOptionFunc(func(r *requestconfig.RequestConfig) error {
+		r.SSEMaxEventBytes = maxBytes
+		return nil
+	})
+}
+
 // WithHeader returns a RequestOption that sets the header value to the associated key. It overwrites
 // any value if there was one already present.
 func WithHeader(key, value string) RequestOption {

--- a/option/requestoption_sse_test.go
+++ b/option/requestoption_sse_test.go
@@ -1,0 +1,12 @@
+package option
+
+import "testing"
+
+func TestWithSSEMaxEventBytesRejectsNegativeLimit(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("WithSSEMaxEventBytes did not panic for a negative limit")
+		}
+	}()
+	_ = WithSSEMaxEventBytes(-1)
+}

--- a/packages/ssestream/event_limit.go
+++ b/packages/ssestream/event_limit.go
@@ -1,0 +1,109 @@
+package ssestream
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"math"
+)
+
+const maxScanTokenBytes = bufio.MaxScanTokenSize << 9
+
+type eventLimit struct {
+	reader            io.Reader
+	maxBytes          int
+	remainingBytes    int
+	bufferedLineBytes int
+	err               error
+}
+
+func newEventLimit(reader io.Reader, maxBytes int) *eventLimit {
+	return &eventLimit{
+		reader:         reader,
+		maxBytes:       maxBytes,
+		remainingBytes: maxBytes,
+	}
+}
+
+func (l *eventLimit) maxScanTokenBytes() int {
+	if l.maxBytes >= maxScanTokenBytes {
+		return maxScanTokenBytes
+	}
+	return l.maxBytes + 1
+}
+
+// Read prevents Scanner from fetching beyond the current line's share of the
+// event byte budget. The extra byte lets scanLines distinguish framing from
+// actual overflow at the boundary.
+func (l *eventLimit) Read(p []byte) (int, error) {
+	maxRead := l.remainingBytes - l.bufferedLineBytes
+	if maxRead < 0 {
+		maxRead = 0
+	}
+	if maxRead < math.MaxInt {
+		maxRead++
+	}
+	if len(p) > maxRead {
+		p = p[:maxRead]
+	}
+	return l.reader.Read(p)
+}
+
+func (l *eventLimit) scanLines(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if newline := bytes.IndexByte(data, '\n'); newline >= 0 {
+		l.bufferedLineBytes = 0
+		line := data[:newline]
+		if isEventDelimiter(line) {
+			l.remainingBytes = l.maxBytes
+			return bufio.ScanLines(data, atEOF)
+		}
+		if !logicalLineFits(line, l.remainingBytes) {
+			return 0, nil, l.tooLargeError()
+		}
+		l.remainingBytes -= logicalLineBytes(line)
+		return bufio.ScanLines(data, atEOF)
+	}
+
+	if atEOF {
+		l.bufferedLineBytes = 0
+		if isEventDelimiter(data) {
+			l.remainingBytes = l.maxBytes
+			return bufio.ScanLines(data, atEOF)
+		}
+		if len(data) > l.remainingBytes {
+			return 0, nil, l.tooLargeError()
+		}
+		return len(data), nil, nil
+	}
+
+	if len(data) > l.remainingBytes && !(l.remainingBytes == 0 && isEventDelimiter(data)) {
+		return 0, nil, l.tooLargeError()
+	}
+	l.bufferedLineBytes = len(data)
+	return 0, nil, nil
+}
+
+func (l *eventLimit) tooLargeError() error {
+	if l.err == nil {
+		l.err = fmt.Errorf("%w: maximum event size is %d bytes", ErrEventTooLarge, l.maxBytes)
+	}
+	return l.err
+}
+
+func isEventDelimiter(line []byte) bool {
+	return len(line) == 0 || len(line) == 1 && line[0] == '\r'
+}
+
+func logicalLineBytes(line []byte) int {
+	if len(line) > 0 && line[len(line)-1] == '\r' {
+		return len(line)
+	}
+	return len(line) + 1
+}
+
+// logicalLineFits counts either an omitted LF or a trailing CR as one logical
+// line ending, matching bufio.ScanLines normalization and event accounting.
+func logicalLineFits(line []byte, maxBytes int) bool {
+	return logicalLineBytes(line) <= maxBytes
+}

--- a/packages/ssestream/ssestream.go
+++ b/packages/ssestream/ssestream.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -13,8 +14,13 @@ import (
 	"sync/atomic"
 
 	shimjson "github.com/openai/openai-go/v3/internal/encoding/json"
+	"github.com/openai/openai-go/v3/internal/requestconfig"
 	"github.com/tidwall/gjson"
 )
+
+// ErrEventTooLarge is returned when an SSE event exceeds the explicit limit
+// configured with option.WithSSEMaxEventBytes.
+var ErrEventTooLarge = errors.New("ssestream: event exceeds configured limit")
 
 type Decoder interface {
 	Event() Event
@@ -41,9 +47,18 @@ func NewDecoder(res *http.Response) Decoder {
 		}
 	}
 
-	scn := bufio.NewScanner(res.Body)
-	scn.Buffer(nil, bufio.MaxScanTokenSize<<9)
-	return &eventStreamDecoder{rc: res.Body, scn: scn}
+	maxEventBytes := requestconfig.SSEMaxEventBytes(res.Request)
+	if maxEventBytes <= 0 {
+		scn := bufio.NewScanner(res.Body)
+		scn.Buffer(nil, maxScanTokenBytes)
+		return &eventStreamDecoder{rc: res.Body, scn: scn}
+	}
+
+	limit := newEventLimit(res.Body, maxEventBytes)
+	scn := bufio.NewScanner(limit)
+	scn.Buffer(nil, limit.maxScanTokenBytes())
+	scn.Split(limit.scanLines)
+	return &eventStreamDecoder{rc: res.Body, scn: scn, limit: limit}
 }
 
 var decoderTypes = map[string](func(io.ReadCloser) Decoder){}
@@ -81,10 +96,11 @@ func (e *StreamError) Error() string {
 
 // A base implementation of a Decoder for text/event-stream.
 type eventStreamDecoder struct {
-	evt Event
-	rc  io.ReadCloser
-	scn *bufio.Scanner
-	err error
+	evt   Event
+	rc    io.ReadCloser
+	scn   *bufio.Scanner
+	err   error
+	limit *eventLimit
 }
 
 func (s *eventStreamDecoder) Next() bool {
@@ -131,8 +147,11 @@ func (s *eventStreamDecoder) Next() bool {
 		}
 	}
 
-	if s.scn.Err() != nil {
-		s.err = s.scn.Err()
+	if scanErr := s.scn.Err(); scanErr != nil {
+		s.err = scanErr
+		if s.limit != nil && s.limit.err != nil && !errors.Is(scanErr, ErrEventTooLarge) {
+			s.err = errors.Join(s.limit.err, scanErr)
+		}
 	}
 
 	return false

--- a/packages/ssestream/ssestream_event_limit_test.go
+++ b/packages/ssestream/ssestream_event_limit_test.go
@@ -1,0 +1,285 @@
+package ssestream
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/openai/openai-go/v3/internal/requestconfig"
+)
+
+func TestDecoderEnforcesExplicitAggregateEventLimit(t *testing.T) {
+	const body = "data: first\ndata: second\n\n"
+	for name, test := range map[string]struct {
+		maxBytes int
+		wantErr  bool
+	}{
+		"exact limit": {
+			maxBytes: len("data: first\ndata: second\n"),
+		},
+		"overflow": {
+			maxBytes: len("data: first\ndata: second\n") - 1,
+			wantErr:  true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			decoder := newLimitedDecoder(t, io.NopCloser(strings.NewReader(body)), test.maxBytes)
+
+			if test.wantErr {
+				if decoder.Next() {
+					t.Fatalf("oversized event unexpectedly decoded: %+v", decoder.Event())
+				}
+				if !errors.Is(decoder.Err(), ErrEventTooLarge) {
+					t.Fatalf("decoder error = %v, want ErrEventTooLarge", decoder.Err())
+				}
+				return
+			}
+
+			if !decoder.Next() {
+				t.Fatalf("decoder stopped before boundary-sized event: %v", decoder.Err())
+			}
+			if got, want := string(decoder.Event().Data), "first\nsecond\n"; got != want {
+				t.Fatalf("event data = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestDecoderExplicitLimitCapsReadAhead(t *testing.T) {
+	const (
+		firstLine = ": x\n"
+		maxBytes  = 8
+	)
+	body := &countingDripReadCloser{data: firstLine + strings.Repeat("x", maxBytes)}
+	decoder := newLimitedDecoder(t, body, maxBytes)
+
+	if decoder.Next() {
+		t.Fatalf("oversized event unexpectedly decoded: %+v", decoder.Event())
+	}
+	if !errors.Is(decoder.Err(), ErrEventTooLarge) {
+		t.Fatalf("decoder error = %v, want ErrEventTooLarge", decoder.Err())
+	}
+	if body.read > maxBytes+1 {
+		t.Fatalf("decoder read %d bytes, want at most aggregate limit plus lookahead %d", body.read, maxBytes+1)
+	}
+}
+
+func TestDecoderExplicitLimitCapsBulkReadAtRemainingBudget(t *testing.T) {
+	const maxBytes = 16
+	firstLine := "data: " + strings.Repeat("x", maxBytes-len("data: \n")) + "\n"
+	body := &countingReadCloser{Reader: io.MultiReader(
+		strings.NewReader(firstLine),
+		strings.NewReader(strings.Repeat("x", maxBytes)),
+	)}
+	decoder := newLimitedDecoder(t, body, maxBytes)
+
+	if decoder.Next() {
+		t.Fatalf("oversized event unexpectedly decoded: %+v", decoder.Event())
+	}
+	if !errors.Is(decoder.Err(), ErrEventTooLarge) {
+		t.Fatalf("decoder error = %v, want ErrEventTooLarge", decoder.Err())
+	}
+	if body.read > maxBytes+1 {
+		t.Fatalf("decoder read %d bytes, want at most aggregate limit plus lookahead %d", body.read, maxBytes+1)
+	}
+}
+
+func TestDecoderExplicitLimitPreservesIncompleteEventEOF(t *testing.T) {
+	const maxBytes = 8
+	for name, test := range map[string]struct {
+		bodyLen int
+		wantErr bool
+	}{
+		"exact limit is clean EOF": {bodyLen: maxBytes},
+		"overflow is an error":     {bodyLen: maxBytes + 1, wantErr: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			decoder := newLimitedDecoder(t,
+				io.NopCloser(strings.NewReader(strings.Repeat("x", test.bodyLen))),
+				maxBytes,
+			)
+
+			if decoder.Next() {
+				t.Fatalf("incomplete event unexpectedly decoded: %+v", decoder.Event())
+			}
+			if test.wantErr {
+				if !errors.Is(decoder.Err(), ErrEventTooLarge) {
+					t.Fatalf("decoder error = %v, want ErrEventTooLarge", decoder.Err())
+				}
+			} else if decoder.Err() != nil {
+				t.Fatalf("decoder error = %v, want clean EOF", decoder.Err())
+			}
+		})
+	}
+}
+
+func TestDecoderExplicitLimitPreservesFramingAtBoundary(t *testing.T) {
+	const eventBytes = len("data: x\n")
+	for name, body := range map[string]string{
+		"LF":          "data: x\n\n",
+		"CRLF":        "data: x\r\n\r\n",
+		"terminal CR": "data: x\n\r",
+	} {
+		t.Run(name, func(t *testing.T) {
+			decoder := newLimitedDecoder(t,
+				&countingDripReadCloser{data: body},
+				eventBytes,
+			)
+
+			if !decoder.Next() {
+				t.Fatalf("decoder stopped before boundary-sized event: %v", decoder.Err())
+			}
+			if got, want := string(decoder.Event().Data), "x\n"; got != want {
+				t.Fatalf("event data = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestDecoderExplicitLimitResetsBetweenEvents(t *testing.T) {
+	const (
+		line     = "data: x\n"
+		maxBytes = len(line)
+	)
+	decoder := newLimitedDecoder(t, io.NopCloser(strings.NewReader(line+"\n"+line+"\n")), maxBytes)
+
+	for event := 1; event <= 2; event++ {
+		if !decoder.Next() {
+			t.Fatalf("decoder stopped before exact-budget event %d: %v", event, decoder.Err())
+		}
+		if got, want := string(decoder.Event().Data), "x\n"; got != want {
+			t.Fatalf("event %d data = %q, want %q", event, got, want)
+		}
+	}
+}
+
+func TestDecoderExplicitLimitResetsAfterIgnoredBlock(t *testing.T) {
+	const (
+		ignored  = "event: ignored\n"
+		data     = "data: x\n"
+		maxBytes = len(ignored)
+	)
+	decoder := newLimitedDecoder(t, io.NopCloser(strings.NewReader(ignored+"\n"+data+"\n")), maxBytes)
+
+	if !decoder.Next() {
+		t.Fatalf("decoder stopped before data following ignored block: %v", decoder.Err())
+	}
+	if got, want := string(decoder.Event().Data), "x\n"; got != want {
+		t.Fatalf("event data = %q, want %q", got, want)
+	}
+}
+
+func TestDecoderExplicitLimitPreservesLegacyLineLimit(t *testing.T) {
+	line := strings.Repeat("x", maxScanTokenBytes)
+	defaultDecoder := newLimitedDecoder(t, io.NopCloser(strings.NewReader(line)), 0)
+	limitedDecoder := newLimitedDecoder(t, io.NopCloser(strings.NewReader(line)), maxScanTokenBytes*2)
+
+	if defaultDecoder.Next() || defaultDecoder.Err() == nil {
+		t.Fatalf("default decoder error = %v, want oversized-token error", defaultDecoder.Err())
+	}
+	if limitedDecoder.Next() || limitedDecoder.Err() == nil {
+		t.Fatalf("limited decoder error = %v, want oversized-token error", limitedDecoder.Err())
+	}
+	if got, want := limitedDecoder.Err().Error(), defaultDecoder.Err().Error(); got != want {
+		t.Fatalf("limited decoder error = %q, want legacy error %q", got, want)
+	}
+}
+
+func TestDecoderExplicitLimitPreservesReaderError(t *testing.T) {
+	const maxBytes = 8
+	decoder := newLimitedDecoder(t, &dataErrorReadCloser{
+		data: strings.Repeat("x", maxBytes+1),
+		err:  io.ErrUnexpectedEOF,
+	}, maxBytes)
+
+	if decoder.Next() {
+		t.Fatalf("oversized event unexpectedly decoded: %+v", decoder.Event())
+	}
+	if !errors.Is(decoder.Err(), ErrEventTooLarge) {
+		t.Fatalf("decoder error = %v, want ErrEventTooLarge", decoder.Err())
+	}
+	if !errors.Is(decoder.Err(), io.ErrUnexpectedEOF) {
+		t.Fatalf("decoder error = %v, want underlying %v", decoder.Err(), io.ErrUnexpectedEOF)
+	}
+}
+
+func TestRegisteredDecoderIgnoresExplicitEventLimit(t *testing.T) {
+	const contentType = "application/x-openai-go-event-limit-test"
+	want := &testDecoder{}
+	RegisterDecoder(contentType, func(io.ReadCloser) Decoder { return want })
+	t.Cleanup(func() { delete(decoderTypes, contentType) })
+
+	response := limitedResponse(io.NopCloser(strings.NewReader("")), 1)
+	t.Cleanup(func() { _ = response.Body.Close() })
+	response.Header.Set("Content-Type", contentType)
+	if got := NewDecoder(response); got != want {
+		t.Fatalf("decoder = %T, want registered decoder", got)
+	}
+}
+
+func newLimitedDecoder(t *testing.T, body io.ReadCloser, maxBytes int) Decoder {
+	t.Helper()
+	response := limitedResponse(body, maxBytes)
+	t.Cleanup(func() { _ = response.Body.Close() })
+	return NewDecoder(response)
+}
+
+func limitedResponse(body io.ReadCloser, maxBytes int) *http.Response {
+	req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	if err != nil {
+		panic(err)
+	}
+	req = requestconfig.WithSSEMaxEventBytes(req, maxBytes)
+	return &http.Response{
+		Header:  http.Header{"Content-Type": {"text/event-stream"}},
+		Body:    body,
+		Request: req,
+	}
+}
+
+type countingDripReadCloser struct {
+	data string
+	read int
+}
+
+func (r *countingDripReadCloser) Read(p []byte) (int, error) {
+	if r.read == len(r.data) {
+		return 0, io.EOF
+	}
+	p[0] = r.data[r.read]
+	r.read++
+	return 1, nil
+}
+
+func (r *countingDripReadCloser) Close() error { return nil }
+
+type countingReadCloser struct {
+	io.Reader
+	read int
+}
+
+func (r *countingReadCloser) Read(p []byte) (int, error) {
+	n, err := r.Reader.Read(p)
+	r.read += n
+	return n, err
+}
+
+func (r *countingReadCloser) Close() error { return nil }
+
+type dataErrorReadCloser struct {
+	data string
+	err  error
+	done bool
+}
+
+func (r *dataErrorReadCloser) Read(p []byte) (int, error) {
+	if r.done {
+		return 0, io.EOF
+	}
+	r.done = true
+	return copy(p, r.data), r.err
+}
+
+func (r *dataErrorReadCloser) Close() error { return nil }

--- a/streaming_event_budget_test.go
+++ b/streaming_event_budget_test.go
@@ -1,0 +1,103 @@
+package openai_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+	"github.com/openai/openai-go/v3/packages/ssestream"
+)
+
+type eventBudgetDoer struct {
+	body string
+}
+
+func (d eventBudgetDoer) Do(*http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": {"text/event-stream"}},
+		Body:       io.NopCloser(strings.NewReader(d.body)),
+	}, nil
+}
+
+func TestStreamingEventBudgetIsOptIn(t *testing.T) {
+	payload := `{"id":"chatcmpl_test","object":"chat.completion.chunk","choices":[]}`
+	body := "data: " + payload + "\n\n"
+	eventBytes := len("data: " + payload + "\n")
+
+	tests := map[string]struct {
+		clientBudget       int
+		methodBudget       int
+		disableClientLimit bool
+		wantErr            bool
+	}{
+		"default remains unlimited": {},
+		"exact explicit budget": {
+			methodBudget: eventBytes,
+		},
+		"explicit overflow": {
+			methodBudget: eventBytes - 1,
+			wantErr:      true,
+		},
+		"client-level overflow": {
+			clientBudget: eventBytes - 1,
+			wantErr:      true,
+		},
+		"method disables client budget": {
+			clientBudget:       eventBytes - 1,
+			disableClientLimit: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			clientOptions := []option.RequestOption{
+				option.WithAPIKey("test-key"),
+				option.WithBaseURL("https://example.com"),
+				option.WithMaxRetries(0),
+				option.WithHTTPClient(eventBudgetDoer{body: body}),
+			}
+			if test.clientBudget > 0 {
+				clientOptions = append(clientOptions, option.WithSSEMaxEventBytes(test.clientBudget))
+			}
+			client := openai.NewClient(clientOptions...)
+
+			var methodOptions []option.RequestOption
+			switch {
+			case test.methodBudget > 0:
+				methodOptions = append(methodOptions, option.WithSSEMaxEventBytes(test.methodBudget))
+			case test.disableClientLimit:
+				methodOptions = append(methodOptions, option.WithSSEMaxEventBytes(0))
+			}
+
+			stream := client.Chat.Completions.NewStreaming(
+				context.Background(),
+				openai.ChatCompletionNewParams{Model: "gpt-4o-mini"},
+				methodOptions...,
+			)
+			defer func() { _ = stream.Close() }()
+
+			if test.wantErr {
+				if stream.Next() {
+					t.Fatal("oversized event unexpectedly produced a value")
+				}
+				if !errors.Is(stream.Err(), ssestream.ErrEventTooLarge) {
+					t.Fatalf("stream error = %v, want ErrEventTooLarge", stream.Err())
+				}
+				return
+			}
+
+			if !stream.Next() {
+				t.Fatalf("event was not delivered: %v", stream.Err())
+			}
+			if got := stream.Current().ID; got != "chatcmpl_test" {
+				t.Fatalf("event ID = %q, want chatcmpl_test", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- add an opt-in `option.WithSSEMaxEventBytes` request policy for callers that want an aggregate event budget
- preserve the existing default streaming contract, including large segmented events and the established per-line scanner limit
- return the stable `ssestream.ErrEventTooLarge` sentinel while preserving SSE framing, EOF, reader errors, custom transports, and registered decoders

The option counts normalized non-empty SSE lines plus one logical newline per line; blank event delimiters are excluded. A method-level value of zero can disable a client-level budget for that request.

## Validation

- focused parser and public-entrypoint regressions, repeated 20x/10x
- full root test suite and full race suite
- supported Go 1.25 test suite
- lint and static analysis
- module tidy checks plus examples and external-consumer tests
- fresh exhaustive openai-go PR review: zero findings
- thermo-nuclear code-quality review: zero findings
- exact-commit security diff scan: zero findings
- Castiron pinned-snapshot ownership and custom-code budget checks

All changed paths are handwritten-only; no Castiron or generator update is required.
