### PR TITLE
fix(client): add non-streaming response policies

### DIFF
--- a/auth_test.go
+++ b/auth_test.go
@@ -1,6 +1,8 @@
 package openai_test
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -210,6 +212,80 @@ func TestWorkloadIdentity401Retry(t *testing.T) {
 
 	if provider.GetCallCount() != 2 {
 		t.Errorf("Provider call count = %d, want 2", provider.GetCallCount())
+	}
+}
+
+func TestWorkloadIdentity401RetryPreservesManagedGzip(t *testing.T) {
+	provider := &mockSubjectTokenProvider{
+		token:     "test-subject-token",
+		tokenType: auth.SubjectTokenTypeJWT,
+	}
+
+	var compressed bytes.Buffer
+	zw := gzip.NewWriter(&compressed)
+	if _, err := io.WriteString(zw, `{"ok":true}`); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	oauthCallCount := 0
+	apiCallCount := 0
+	mockHTTPClient := &http.Client{
+		Transport: &closureTransport{
+			fn: func(req *http.Request) (*http.Response, error) {
+				if strings.Contains(req.URL.String(), "/oauth/token") {
+					oauthCallCount++
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body: io.NopCloser(strings.NewReader(fmt.Sprintf(
+							`{"access_token":"token-%d","expires_in":3600}`,
+							oauthCallCount,
+						))),
+						Header: http.Header{"Content-Type": {"application/json"}},
+					}, nil
+				}
+
+				apiCallCount++
+				if got := req.Header.Get("Accept-Encoding"); got != "gzip" {
+					t.Errorf("API attempt %d Accept-Encoding = %q, want gzip", apiCallCount, got)
+				}
+				if apiCallCount == 1 {
+					return &http.Response{
+						StatusCode: http.StatusUnauthorized,
+						Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"Unauthorized"}}`)),
+						Header:     http.Header{"Content-Type": {"application/json"}},
+					}, nil
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader(compressed.Bytes())),
+					Header: http.Header{
+						"Content-Type":     {"application/json"},
+						"Content-Encoding": {"gzip"},
+					},
+				}, nil
+			},
+		},
+	}
+
+	client := openai.NewClient(
+		option.WithWorkloadIdentity(testWorkloadIdentity(provider)),
+		option.WithHTTPClient(mockHTTPClient),
+		option.WithMaxRetries(0),
+	)
+	var response struct {
+		OK bool `json:"ok"`
+	}
+	if err := client.Get(context.Background(), "test", nil, &response); err != nil {
+		t.Fatal(err)
+	}
+	if !response.OK {
+		t.Fatal("decoded response OK = false, want true")
+	}
+	if apiCallCount != 2 {
+		t.Fatalf("API call count = %d, want 2", apiCallCount)
 	}
 }
 

--- a/auth_test.go
+++ b/auth_test.go
@@ -233,7 +233,7 @@ func TestWorkloadIdentity401RetryPreservesManagedGzip(t *testing.T) {
 	oauthCallCount := 0
 	apiCallCount := 0
 	mockHTTPClient := &http.Client{
-		Transport: &closureTransport{
+		Transport: managedCompressionRoundTripper{RoundTripper: &closureTransport{
 			fn: func(req *http.Request) (*http.Response, error) {
 				if strings.Contains(req.URL.String(), "/oauth/token") {
 					oauthCallCount++
@@ -267,7 +267,7 @@ func TestWorkloadIdentity401RetryPreservesManagedGzip(t *testing.T) {
 					},
 				}, nil
 			},
-		},
+		}},
 	}
 
 	client := openai.NewClient(

--- a/auth_test.go
+++ b/auth_test.go
@@ -274,6 +274,7 @@ func TestWorkloadIdentity401RetryPreservesManagedGzip(t *testing.T) {
 		option.WithWorkloadIdentity(testWorkloadIdentity(provider)),
 		option.WithHTTPClient(mockHTTPClient),
 		option.WithMaxRetries(0),
+		option.WithMaxResponseBodyBytes(1024),
 	)
 	var response struct {
 		OK bool `json:"ok"`

--- a/auth_test.go
+++ b/auth_test.go
@@ -273,7 +273,7 @@ func TestWorkloadIdentity401RetryPreservesManagedGzip(t *testing.T) {
 	client := openai.NewClient(
 		option.WithWorkloadIdentity(testWorkloadIdentity(provider)),
 		option.WithHTTPClient(mockHTTPClient),
-		option.WithMaxRetries(0),
+		option.WithMaxRetries(1),
 		option.WithMaxResponseBodyBytes(1024),
 	)
 	var response struct {

--- a/azure/authentication_test.go
+++ b/azure/authentication_test.go
@@ -166,44 +166,59 @@ func TestReusedTokenCredentialOptionAuthenticatesOnce(t *testing.T) {
 }
 
 func TestAzureTokenCredentialBodyTimeoutBoundsRetryableResponse(t *testing.T) {
-	var attempts atomic.Int32
-	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		attempts.Add(1)
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusTooManyRequests)
-		flusher, ok := w.(http.Flusher)
-		if !ok {
-			t.Error("response writer does not support flushing")
-			return
-		}
-		flusher.Flush()
-		<-req.Context().Done()
-	}))
-	t.Cleanup(server.Close)
+	tests := []struct {
+		name          string
+		overrideRetry bool
+	}{
+		{name: "default Azure retry policy"},
+		{name: "caller Azure retry override", overrideRetry: true},
+	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	client := openai.NewClient(
-		WithEndpoint(server.URL, "2024-10-21"),
-		WithTokenCredential(&fake.TokenCredential{}),
-		option.WithMaxRetries(0),
-		option.WithResponseBodyTimeout(20*time.Millisecond),
-		option.WithHTTPClient(server.Client()),
-	)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var attempts atomic.Int32
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				attempts.Add(1)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusTooManyRequests)
+				flusher, ok := w.(http.Flusher)
+				if !ok {
+					t.Error("response writer does not support flushing")
+					return
+				}
+				flusher.Flush()
+				<-req.Context().Done()
+			}))
+			t.Cleanup(server.Close)
 
-	var response map[string]any
-	err := client.Execute(ctx, http.MethodGet, "models", nil, &response)
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("Execute() error = %v, want response body deadline exceeded", err)
-	}
-	if ctx.Err() != nil {
-		t.Fatal("Azure retry consumed the response body until the caller safety deadline")
-	}
-	if !strings.Contains(err.Error(), "response body read timed out") {
-		t.Fatalf("Execute() error = %v, want SDK response body timeout", err)
-	}
-	if got := attempts.Load(); got != 1 {
-		t.Fatalf("request attempts = %d, want 1", got)
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			if test.overrideRetry {
+				ctx = policy.WithRetryOptions(ctx, policy.RetryOptions{MaxRetries: 1})
+			}
+			client := openai.NewClient(
+				WithEndpoint(server.URL, "2024-10-21"),
+				WithTokenCredential(&fake.TokenCredential{}),
+				option.WithMaxRetries(0),
+				option.WithResponseBodyTimeout(20*time.Millisecond),
+				option.WithHTTPClient(server.Client()),
+			)
+
+			var response map[string]any
+			err := client.Execute(ctx, http.MethodGet, "models", nil, &response)
+			if !errors.Is(err, context.DeadlineExceeded) {
+				t.Fatalf("Execute() error = %v, want response body deadline exceeded", err)
+			}
+			if ctx.Err() != nil {
+				t.Fatal("Azure retry consumed the response body until the caller safety deadline")
+			}
+			if !strings.Contains(err.Error(), "response body read timed out") {
+				t.Fatalf("Execute() error = %v, want SDK response body timeout", err)
+			}
+			if got := attempts.Load(); got != 1 {
+				t.Fatalf("request attempts = %d, want 1", got)
+			}
+		})
 	}
 }
 

--- a/azure/authentication_test.go
+++ b/azure/authentication_test.go
@@ -1,9 +1,12 @@
 package azure
 
 import (
+	"compress/gzip"
 	"context"
+	"errors"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"slices"
 	"strings"
 	"sync/atomic"
@@ -159,6 +162,147 @@ func TestReusedTokenCredentialOptionAuthenticatesOnce(t *testing.T) {
 	}
 	if authorization != "Bearer counting_token" {
 		t.Fatalf("Authorization = %q", authorization)
+	}
+}
+
+func TestAzureTokenCredentialBodyTimeoutBoundsRetryableResponse(t *testing.T) {
+	var attempts atomic.Int32
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		attempts.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Error("response writer does not support flushing")
+			return
+		}
+		flusher.Flush()
+		<-req.Context().Done()
+	}))
+	t.Cleanup(server.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	client := openai.NewClient(
+		WithEndpoint(server.URL, "2024-10-21"),
+		WithTokenCredential(&fake.TokenCredential{}),
+		option.WithMaxRetries(0),
+		option.WithResponseBodyTimeout(20*time.Millisecond),
+		option.WithHTTPClient(server.Client()),
+	)
+
+	var response map[string]any
+	err := client.Execute(ctx, http.MethodGet, "models", nil, &response)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Execute() error = %v, want response body deadline exceeded", err)
+	}
+	if ctx.Err() != nil {
+		t.Fatal("Azure retry consumed the response body until the caller safety deadline")
+	}
+	if !strings.Contains(err.Error(), "response body read timed out") {
+		t.Fatalf("Execute() error = %v, want SDK response body timeout", err)
+	}
+	if got := attempts.Load(); got != 1 {
+		t.Fatalf("request attempts = %d, want 1", got)
+	}
+}
+
+func TestAzureTokenCredentialUsesSDKRetryPolicy(t *testing.T) {
+	var attempts atomic.Int32
+	retryCounts := make(chan string, 2)
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		retryCounts <- req.Header.Get("X-Stainless-Retry-Count")
+		w.Header().Set("Content-Type", "application/json")
+		if attempts.Add(1) == 1 {
+			w.Header().Set("Retry-After-Ms", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			if _, err := io.WriteString(w, `{"error":{"message":"retry"}}`); err != nil {
+				t.Errorf("write retry response: %v", err)
+			}
+			return
+		}
+		if _, err := io.WriteString(w, `{"ok":true}`); err != nil {
+			t.Errorf("write success response: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client := openai.NewClient(
+		WithEndpoint(server.URL, "2024-10-21"),
+		WithTokenCredential(&fake.TokenCredential{}),
+		option.WithMaxRetries(1),
+		option.WithMaxRetryDelay(time.Millisecond),
+		option.WithHTTPClient(server.Client()),
+	)
+	var response map[string]any
+	if err := client.Execute(context.Background(), http.MethodGet, "models", nil, &response); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := attempts.Load(); got != 2 {
+		t.Fatalf("request attempts = %d, want 2", got)
+	}
+	for _, want := range []string{"0", "1"} {
+		if got := <-retryCounts; got != want {
+			t.Fatalf("X-Stainless-Retry-Count = %q, want %q", got, want)
+		}
+	}
+}
+
+func TestAzureAuthenticationPreservesDisabledNativeCompression(t *testing.T) {
+	authModes := []struct {
+		name string
+		auth option.RequestOption
+	}{
+		{name: "API key", auth: WithAPIKey("azure-api-key")},
+		{name: "token credential", auth: WithTokenCredential(&fake.TokenCredential{})},
+	}
+
+	for _, authMode := range authModes {
+		t.Run(authMode.name, func(t *testing.T) {
+			var acceptEncoding atomicString
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				acceptEncoding.Store(req.Header.Get("Accept-Encoding"))
+				w.Header().Set("Content-Type", "application/json")
+				if strings.Contains(req.Header.Get("Accept-Encoding"), "gzip") {
+					w.Header().Set("Content-Encoding", "gzip")
+					compressed := gzip.NewWriter(w)
+					if _, err := compressed.Write([]byte("{}")); err != nil {
+						t.Errorf("write gzip response: %v", err)
+						return
+					}
+					if err := compressed.Close(); err != nil {
+						t.Errorf("close gzip response: %v", err)
+					}
+					return
+				}
+				if _, err := io.WriteString(w, "{}"); err != nil {
+					t.Errorf("write response: %v", err)
+				}
+			}))
+			t.Cleanup(server.Close)
+
+			serverTransport, ok := server.Client().Transport.(*http.Transport)
+			if !ok {
+				t.Fatalf("server transport = %T, want *http.Transport", server.Client().Transport)
+			}
+			transport := serverTransport.Clone()
+			transport.DisableCompression = true
+			client := openai.NewClient(
+				WithEndpoint(server.URL, "2024-10-21"),
+				authMode.auth,
+				option.WithMaxRetries(0),
+				option.WithMaxResponseBodyBytes(2),
+				option.WithHTTPClient(&http.Client{Transport: transport}),
+			)
+
+			var response map[string]any
+			if err := client.Execute(context.Background(), http.MethodGet, "models", nil, &response); err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+			if got := acceptEncoding.Load(); got != "" {
+				t.Fatalf("Accept-Encoding = %q, want no compression negotiation", got)
+			}
+		})
 	}
 }
 

--- a/azure/authentication_test.go
+++ b/azure/authentication_test.go
@@ -274,14 +274,19 @@ func TestAzureAuthenticationPreservesDisabledNativeCompression(t *testing.T) {
 		name     string
 		auth     option.RequestOption
 		wrapped  bool
+		opaque   bool
 		loopback bool
 	}{
 		{name: "API key/native transport", auth: WithAPIKey("azure-api-key")},
 		{name: "API key/wrapped transport", auth: WithAPIKey("azure-api-key"), wrapped: true},
+		{name: "API key/opaque transport", auth: WithAPIKey("azure-api-key"), opaque: true},
 		{name: "API key/wrapped loopback transport", auth: WithAPIKey("azure-api-key"), wrapped: true, loopback: true},
+		{name: "API key/opaque loopback transport", auth: WithAPIKey("azure-api-key"), opaque: true, loopback: true},
 		{name: "token credential/native transport", auth: WithTokenCredential(&fake.TokenCredential{})},
 		{name: "token credential/wrapped transport", auth: WithTokenCredential(&fake.TokenCredential{}), wrapped: true},
+		{name: "token credential/opaque transport", auth: WithTokenCredential(&fake.TokenCredential{}), opaque: true},
 		{name: "token credential/wrapped loopback transport", auth: WithTokenCredential(&fake.TokenCredential{}), wrapped: true, loopback: true},
+		{name: "token credential/opaque loopback transport", auth: WithTokenCredential(&fake.TokenCredential{}), opaque: true, loopback: true},
 	}
 
 	for _, authMode := range authModes {
@@ -323,6 +328,8 @@ func TestAzureAuthenticationPreservesDisabledNativeCompression(t *testing.T) {
 			var selectedTransport http.RoundTripper = transport
 			if authMode.wrapped {
 				selectedTransport = compressionDisabledRoundTripper{RoundTripper: transport}
+			} else if authMode.opaque {
+				selectedTransport = roundTripFunc(transport.RoundTrip)
 			}
 			opts := []option.RequestOption{
 				WithEndpoint(server.URL, "2024-10-21"),
@@ -340,8 +347,12 @@ func TestAzureAuthenticationPreservesDisabledNativeCompression(t *testing.T) {
 			if err := client.Execute(context.Background(), http.MethodGet, "models", nil, &response); err != nil {
 				t.Fatalf("Execute() error = %v", err)
 			}
-			if got := acceptEncoding.Load(); got != "" {
-				t.Fatalf("Accept-Encoding = %q, want no compression negotiation", got)
+			wantEncoding := ""
+			if authMode.opaque {
+				wantEncoding = "identity"
+			}
+			if got := acceptEncoding.Load(); got != wantEncoding {
+				t.Fatalf("Accept-Encoding = %q, want %q", got, wantEncoding)
 			}
 		})
 	}

--- a/azure/authentication_test.go
+++ b/azure/authentication_test.go
@@ -358,6 +358,62 @@ func TestAzureAuthenticationPreservesDisabledNativeCompression(t *testing.T) {
 	}
 }
 
+func TestAzureAuthenticationPreservesLoopbackCompressionWithoutLimits(t *testing.T) {
+	authModes := []struct {
+		name string
+		auth option.RequestOption
+	}{
+		{name: "API key", auth: WithAPIKey("azure-api-key")},
+		{name: "token credential", auth: WithTokenCredential(&fake.TokenCredential{})},
+	}
+	transports := []struct {
+		name             string
+		disableNative    bool
+		declareDisabled  bool
+		wantAcceptHeader string
+	}{
+		{name: "opaque enabled", wantAcceptHeader: "gzip"},
+		{name: "declared disabled", disableNative: true, declareDisabled: true},
+	}
+
+	for _, authMode := range authModes {
+		for _, transportMode := range transports {
+			t.Run(authMode.name+"/"+transportMode.name, func(t *testing.T) {
+				var acceptEncoding atomicString
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+					acceptEncoding.Store(req.Header.Get("Accept-Encoding"))
+					w.Header().Set("Content-Type", "application/json")
+					if _, err := io.WriteString(w, "{}"); err != nil {
+						t.Errorf("write response: %v", err)
+					}
+				}))
+				t.Cleanup(server.Close)
+
+				transport := server.Client().Transport.(*http.Transport).Clone()
+				transport.DisableCompression = transportMode.disableNative
+				var selected http.RoundTripper = roundTripFunc(transport.RoundTrip)
+				if transportMode.declareDisabled {
+					selected = compressionDisabledRoundTripper{RoundTripper: transport}
+				}
+				client := openai.NewClient(
+					WithEndpoint(server.URL, "2024-10-21"),
+					authMode.auth,
+					WithUnsafeAllowHTTP(),
+					option.WithMaxRetries(0),
+					option.WithHTTPClient(&http.Client{Transport: selected}),
+				)
+				var response map[string]any
+				if err := client.Get(context.Background(), "models", nil, &response); err != nil {
+					t.Fatalf("Get() error = %v", err)
+				}
+				if got := acceptEncoding.Load(); got != transportMode.wantAcceptHeader {
+					t.Fatalf("Accept-Encoding = %q, want %q", got, transportMode.wantAcceptHeader)
+				}
+			})
+		}
+	}
+}
+
 func TestAzureAuthenticationIsolatesOpenAIEnvironment(t *testing.T) {
 	environments := []struct {
 		name        string

--- a/azure/authentication_test.go
+++ b/azure/authentication_test.go
@@ -21,6 +21,12 @@ import (
 	"github.com/openai/openai-go/v3/option"
 )
 
+type compressionDisabledRoundTripper struct {
+	http.RoundTripper
+}
+
+func (compressionDisabledRoundTripper) CompressionDisabled() bool { return true }
+
 func TestEndpointRequiresExplicitAzureAuthentication(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -265,11 +271,14 @@ func TestAzureTokenCredentialUsesSDKRetryPolicy(t *testing.T) {
 
 func TestAzureAuthenticationPreservesDisabledNativeCompression(t *testing.T) {
 	authModes := []struct {
-		name string
-		auth option.RequestOption
+		name    string
+		auth    option.RequestOption
+		wrapped bool
 	}{
-		{name: "API key", auth: WithAPIKey("azure-api-key")},
-		{name: "token credential", auth: WithTokenCredential(&fake.TokenCredential{})},
+		{name: "API key/native transport", auth: WithAPIKey("azure-api-key")},
+		{name: "API key/wrapped transport", auth: WithAPIKey("azure-api-key"), wrapped: true},
+		{name: "token credential/native transport", auth: WithTokenCredential(&fake.TokenCredential{})},
+		{name: "token credential/wrapped transport", auth: WithTokenCredential(&fake.TokenCredential{}), wrapped: true},
 	}
 
 	for _, authMode := range authModes {
@@ -302,12 +311,16 @@ func TestAzureAuthenticationPreservesDisabledNativeCompression(t *testing.T) {
 			}
 			transport := serverTransport.Clone()
 			transport.DisableCompression = true
+			var selectedTransport http.RoundTripper = transport
+			if authMode.wrapped {
+				selectedTransport = compressionDisabledRoundTripper{RoundTripper: transport}
+			}
 			client := openai.NewClient(
 				WithEndpoint(server.URL, "2024-10-21"),
 				authMode.auth,
 				option.WithMaxRetries(0),
 				option.WithMaxResponseBodyBytes(2),
-				option.WithHTTPClient(&http.Client{Transport: transport}),
+				option.WithHTTPClient(&http.Client{Transport: selectedTransport}),
 			)
 
 			var response map[string]any

--- a/azure/authentication_test.go
+++ b/azure/authentication_test.go
@@ -271,20 +271,23 @@ func TestAzureTokenCredentialUsesSDKRetryPolicy(t *testing.T) {
 
 func TestAzureAuthenticationPreservesDisabledNativeCompression(t *testing.T) {
 	authModes := []struct {
-		name    string
-		auth    option.RequestOption
-		wrapped bool
+		name     string
+		auth     option.RequestOption
+		wrapped  bool
+		loopback bool
 	}{
 		{name: "API key/native transport", auth: WithAPIKey("azure-api-key")},
 		{name: "API key/wrapped transport", auth: WithAPIKey("azure-api-key"), wrapped: true},
+		{name: "API key/wrapped loopback transport", auth: WithAPIKey("azure-api-key"), wrapped: true, loopback: true},
 		{name: "token credential/native transport", auth: WithTokenCredential(&fake.TokenCredential{})},
 		{name: "token credential/wrapped transport", auth: WithTokenCredential(&fake.TokenCredential{}), wrapped: true},
+		{name: "token credential/wrapped loopback transport", auth: WithTokenCredential(&fake.TokenCredential{}), wrapped: true, loopback: true},
 	}
 
 	for _, authMode := range authModes {
 		t.Run(authMode.name, func(t *testing.T) {
 			var acceptEncoding atomicString
-			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 				acceptEncoding.Store(req.Header.Get("Accept-Encoding"))
 				w.Header().Set("Content-Type", "application/json")
 				if strings.Contains(req.Header.Get("Accept-Encoding"), "gzip") {
@@ -302,7 +305,13 @@ func TestAzureAuthenticationPreservesDisabledNativeCompression(t *testing.T) {
 				if _, err := io.WriteString(w, "{}"); err != nil {
 					t.Errorf("write response: %v", err)
 				}
-			}))
+			})
+			var server *httptest.Server
+			if authMode.loopback {
+				server = httptest.NewServer(handler)
+			} else {
+				server = httptest.NewTLSServer(handler)
+			}
 			t.Cleanup(server.Close)
 
 			serverTransport, ok := server.Client().Transport.(*http.Transport)
@@ -315,13 +324,17 @@ func TestAzureAuthenticationPreservesDisabledNativeCompression(t *testing.T) {
 			if authMode.wrapped {
 				selectedTransport = compressionDisabledRoundTripper{RoundTripper: transport}
 			}
-			client := openai.NewClient(
+			opts := []option.RequestOption{
 				WithEndpoint(server.URL, "2024-10-21"),
 				authMode.auth,
 				option.WithMaxRetries(0),
 				option.WithMaxResponseBodyBytes(2),
 				option.WithHTTPClient(&http.Client{Transport: selectedTransport}),
-			)
+			}
+			if authMode.loopback {
+				opts = append(opts, WithUnsafeAllowHTTP())
+			}
+			client := openai.NewClient(opts...)
 
 			var response map[string]any
 			if err := client.Execute(context.Background(), http.MethodGet, "models", nil, &response); err != nil {

--- a/azure/azure.go
+++ b/azure/azure.go
@@ -456,6 +456,11 @@ func (t azureCredentialTransport) RoundTrip(req *http.Request) (*http.Response, 
 	return transport.RoundTrip(req)
 }
 
+func (t azureCredentialTransport) CompressionDisabled() bool {
+	transport, ok := t.base.(*http.Transport)
+	return ok && transport.DisableCompression
+}
+
 func rejectAzureCredentialTransport(req *http.Request, err error) (*http.Response, error) {
 	if req.Body != nil {
 		_ = req.Body.Close()

--- a/azure/azure.go
+++ b/azure/azure.go
@@ -374,7 +374,10 @@ func newAzureDirectLoopbackHTTPTransport(base http.RoundTripper) *http.Transport
 	if baseTransport, ok := base.(*http.Transport); ok {
 		transport = baseTransport.Clone()
 	} else {
-		transport = &http.Transport{}
+		// Opaque wrappers are intentionally bypassed for hardened loopback
+		// dialing. Leave compression negotiation to the SDK so their policy
+		// cannot be contradicted by this shared fallback transport.
+		transport = &http.Transport{DisableCompression: true}
 	}
 
 	transport.Proxy = nil

--- a/azure/azure.go
+++ b/azure/azure.go
@@ -457,6 +457,9 @@ func (t azureCredentialTransport) RoundTrip(req *http.Request) (*http.Response, 
 }
 
 func (t azureCredentialTransport) CompressionDisabled() bool {
+	if transport, ok := t.base.(interface{ CompressionDisabled() bool }); ok {
+		return transport.CompressionDisabled()
+	}
 	transport, ok := t.base.(*http.Transport)
 	return ok && transport.DisableCompression
 }

--- a/azure/azure.go
+++ b/azure/azure.go
@@ -342,8 +342,7 @@ func newAzureCredentialTransport(base http.RoundTripper, directTransports *azure
 // there would defeat keep-alive reuse and retain ordinary HTTPS overrides.
 type azureDirectLoopbackTransportCache struct {
 	transports sync.Map // map[*http.Transport]*http.Transport
-	fallback   sync.Once
-	direct     *http.Transport
+	fallback   sync.Map // map[bool]*http.Transport, keyed by disabled compression
 }
 
 func (c *azureDirectLoopbackTransportCache) get(base http.RoundTripper) *http.Transport {
@@ -356,10 +355,16 @@ func (c *azureDirectLoopbackTransportCache) get(base http.RoundTripper) *http.Tr
 		return cached.(*http.Transport)
 	}
 
-	c.fallback.Do(func() {
-		c.direct = newAzureDirectLoopbackHTTPTransport(base)
-	})
-	return c.direct
+	disabled := false
+	if policy, ok := base.(interface{ CompressionDisabled() bool }); ok {
+		disabled = policy.CompressionDisabled()
+	}
+	if cached, ok := c.fallback.Load(disabled); ok {
+		return cached.(*http.Transport)
+	}
+	direct := newAzureDirectLoopbackHTTPTransport(base)
+	cached, _ := c.fallback.LoadOrStore(disabled, direct)
+	return cached.(*http.Transport)
 }
 
 const (
@@ -374,10 +379,10 @@ func newAzureDirectLoopbackHTTPTransport(base http.RoundTripper) *http.Transport
 	if baseTransport, ok := base.(*http.Transport); ok {
 		transport = baseTransport.Clone()
 	} else {
-		// Opaque wrappers are intentionally bypassed for hardened loopback
-		// dialing. Leave compression negotiation to the SDK so their policy
-		// cannot be contradicted by this shared fallback transport.
-		transport = &http.Transport{DisableCompression: true}
+		transport = &http.Transport{}
+		if policy, ok := base.(interface{ CompressionDisabled() bool }); ok {
+			transport.DisableCompression = policy.CompressionDisabled()
+		}
 	}
 
 	transport.Proxy = nil

--- a/azure/azure.go
+++ b/azure/azure.go
@@ -467,6 +467,14 @@ func (t azureCredentialTransport) CompressionDisabled() bool {
 	return ok && transport.DisableCompression
 }
 
+func (t azureCredentialTransport) CompressionPolicyKnown() bool {
+	if _, ok := t.base.(interface{ CompressionDisabled() bool }); ok {
+		return true
+	}
+	_, ok := t.base.(*http.Transport)
+	return ok
+}
+
 func rejectAzureCredentialTransport(req *http.Request, err error) (*http.Response, error) {
 	if req.Body != nil {
 		_ = req.Body.Close()

--- a/client.go
+++ b/client.go
@@ -173,9 +173,9 @@ func NewClient(opts ...option.RequestOption) (r Client) {
 // Successful non-streaming responses preserve their existing unbounded size and
 // caller-controlled lifetime unless [option.WithMaxResponseBodyBytes] or
 // [option.WithResponseBodyTimeout] opts into a limit. Error response bodies are
-// bounded by default and can be configured with
-// [option.WithMaxErrorResponseBodyBytes]. Raw [*http.Response] success bodies
-// remain streaming and are not subject to those non-streaming limits.
+// likewise unbounded unless [option.WithMaxErrorResponseBodyBytes] opts into a
+// limit. Raw [*http.Response] success bodies remain streaming and are not
+// subject to those non-streaming limits.
 //
 // For even greater flexibility, see [option.WithResponseInto] and
 // [option.WithResponseBodyInto].

--- a/client.go
+++ b/client.go
@@ -170,11 +170,12 @@ func NewClient(opts ...option.RequestOption) (r Client) {
 //     respects UnmarshalJSON if it is defined on the type.
 //   - A nil value will not read the response body.
 //
-// Non-streaming responses use bounded body size and read-duration defaults.
-// Use [option.WithMaxResponseBodyBytes], [option.WithMaxErrorResponseBodyBytes],
-// and [option.WithResponseBodyTimeout] to override them for a client or request.
-// Raw [*http.Response] success bodies remain streaming and are not subject to
-// those non-streaming limits.
+// Successful non-streaming responses preserve their existing unbounded size and
+// caller-controlled lifetime unless [option.WithMaxResponseBodyBytes] or
+// [option.WithResponseBodyTimeout] opts into a limit. Error response bodies are
+// bounded by default and can be configured with
+// [option.WithMaxErrorResponseBodyBytes]. Raw [*http.Response] success bodies
+// remain streaming and are not subject to those non-streaming limits.
 //
 // For even greater flexibility, see [option.WithResponseInto] and
 // [option.WithResponseBodyInto].

--- a/client.go
+++ b/client.go
@@ -170,6 +170,12 @@ func NewClient(opts ...option.RequestOption) (r Client) {
 //     respects UnmarshalJSON if it is defined on the type.
 //   - A nil value will not read the response body.
 //
+// Non-streaming responses use bounded body size and read-duration defaults.
+// Use [option.WithMaxResponseBodyBytes], [option.WithMaxErrorResponseBodyBytes],
+// and [option.WithResponseBodyTimeout] to override them for a client or request.
+// Raw [*http.Response] success bodies remain streaming and are not subject to
+// those non-streaming limits.
+//
 // For even greater flexibility, see [option.WithResponseInto] and
 // [option.WithResponseBodyInto].
 func (r *Client) Execute(ctx context.Context, method string, path string, params any, res any, opts ...option.RequestOption) error {

--- a/default_http_client.go
+++ b/default_http_client.go
@@ -20,7 +20,8 @@ const defaultResponseHeaderTimeout = 10 * time.Minute
 // instead of compounding across retries.
 // If [http.DefaultTransport] has been wrapped (for example by otelhttp for
 // distributed tracing), the wrapping is preserved and the header timeout is
-// skipped.
+// skipped. The shared executor separately enforces non-streaming response-body
+// size and read-duration policies so raw streaming responses remain unaffected.
 func defaultHTTPClient() *requestconfig.DefaultHTTPClient {
 	if t, ok := http.DefaultTransport.(*http.Transport); ok {
 		t = t.Clone()

--- a/image.go
+++ b/image.go
@@ -33,12 +33,19 @@ type ImageService struct {
 	Options []option.RequestOption
 }
 
+// maxImageResponseBodyBytes accommodates the documented maximum batch of
+// base64-encoded 4K images while retaining a finite response bound.
+const maxImageResponseBodyBytes int64 = 512 << 20
+
 // NewImageService generates a new service that applies the given options to each
 // request. These options are applied after the parent client's options (if there
 // is one), and before any request-specific options.
 func NewImageService(opts ...option.RequestOption) (r ImageService) {
 	r = ImageService{}
-	r.Options = requestconfig.InheritedOptions(opts...)
+	r.Options = requestconfig.InheritedOptions(slices.Concat(
+		[]option.RequestOption{option.WithMaxResponseBodyBytes(maxImageResponseBodyBytes)},
+		opts,
+	)...)
 	return
 }
 

--- a/image.go
+++ b/image.go
@@ -33,19 +33,12 @@ type ImageService struct {
 	Options []option.RequestOption
 }
 
-// maxImageResponseBodyBytes accommodates the documented maximum batch of
-// base64-encoded 4K images while retaining a finite response bound.
-const maxImageResponseBodyBytes int64 = 512 << 20
-
 // NewImageService generates a new service that applies the given options to each
 // request. These options are applied after the parent client's options (if there
 // is one), and before any request-specific options.
 func NewImageService(opts ...option.RequestOption) (r ImageService) {
 	r = ImageService{}
-	r.Options = requestconfig.InheritedOptions(slices.Concat(
-		[]option.RequestOption{option.WithMaxResponseBodyBytes(maxImageResponseBodyBytes)},
-		opts,
-	)...)
+	r.Options = requestconfig.InheritedOptions(opts...)
 	return
 }
 

--- a/internal/requestconfig/compression.go
+++ b/internal/requestconfig/compression.go
@@ -112,8 +112,9 @@ func (cfg *RequestConfig) withManagedGzip(next middlewareNext) middlewareNext {
 	return func(req *http.Request) (*http.Response, error) {
 		manageGzip := cfg.shouldManageGzip(req)
 		if manageGzip {
-			// Set this below user middleware, matching net/http's transparent gzip
-			// negotiation while retaining access to compressed wire bytes.
+			// Decorate a per-attempt clone so authentication or other outer
+			// middleware can replay the pristine request through this layer.
+			req = req.Clone(req.Context())
 			req.Header.Set("Accept-Encoding", "gzip")
 		}
 

--- a/internal/requestconfig/compression.go
+++ b/internal/requestconfig/compression.go
@@ -1,0 +1,140 @@
+package requestconfig
+
+import (
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+type compressedResponseBodyLimitError struct {
+	limit int64
+	cause error
+}
+
+func (e *compressedResponseBodyLimitError) Error() string {
+	return fmt.Sprintf("compressed response body exceeded configured limit of %d bytes", e.limit)
+}
+
+func (e *compressedResponseBodyLimitError) Unwrap() error { return e.cause }
+
+type wireLimitReader struct {
+	reader    io.Reader
+	remaining int64
+	limit     int64
+}
+
+func (r *wireLimitReader) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if r.remaining == 0 {
+		var extra [1]byte
+		n, err := r.reader.Read(extra[:])
+		if n != 0 {
+			return 0, &compressedResponseBodyLimitError{limit: r.limit}
+		}
+		return 0, err
+	}
+	if int64(len(p)) > r.remaining {
+		p = p[:r.remaining]
+	}
+	n, err := r.reader.Read(p)
+	r.remaining -= int64(n)
+	return n, err
+}
+
+type gzipResponseBody struct {
+	body       io.ReadCloser
+	compressed io.Reader
+	decoded    io.Reader
+	initOnce   sync.Once
+	initErr    error
+}
+
+func newGzipResponseBody(body io.ReadCloser, wireLimit int64) *gzipResponseBody {
+	var reader io.Reader = body
+	if wireLimit > 0 {
+		reader = &wireLimitReader{reader: body, remaining: wireLimit, limit: wireLimit}
+	}
+	return &gzipResponseBody{body: body, compressed: reader}
+}
+
+func (b *gzipResponseBody) Read(p []byte) (int, error) {
+	b.initOnce.Do(func() {
+		b.decoded, b.initErr = gzip.NewReader(b.compressed)
+	})
+	if b.initErr != nil {
+		return 0, b.initErr
+	}
+	return b.decoded.Read(p)
+}
+
+func (b *gzipResponseBody) Close() error {
+	// gzip.Reader.Close does not close its underlying reader. Closing the wire
+	// body directly preserves net/http's guarantee that Close can unblock Read.
+	return b.body.Close()
+}
+
+func (cfg *RequestConfig) ownsSuccessResponseBody() bool {
+	if cfg.ResponseBodyInto == nil {
+		return false
+	}
+	_, raw := cfg.ResponseBodyInto.(**http.Response)
+	return !raw
+}
+
+func (cfg *RequestConfig) shouldManageGzip(req *http.Request) bool {
+	if cfg.CustomHTTPDoer != nil ||
+		req.Method == http.MethodHead ||
+		req.Header.Get("Accept-Encoding") != "" ||
+		req.Header.Get("Range") != "" {
+		return false
+	}
+
+	// Respect explicit stdlib transport configuration. Wrapped and custom
+	// transports can opt out in the portable way by setting Accept-Encoding.
+	if cfg.HTTPClient != nil {
+		transport := cfg.HTTPClient.Transport
+		if transport == nil {
+			transport = http.DefaultTransport
+		}
+		if transport, ok := transport.(*http.Transport); ok && transport.DisableCompression {
+			return false
+		}
+	}
+	return true
+}
+
+func (cfg *RequestConfig) withManagedGzip(next middlewareNext) middlewareNext {
+	return func(req *http.Request) (*http.Response, error) {
+		manageGzip := cfg.shouldManageGzip(req)
+		if manageGzip {
+			// Set this below user middleware, matching net/http's transparent gzip
+			// negotiation while retaining access to compressed wire bytes.
+			req.Header.Set("Accept-Encoding", "gzip")
+		}
+
+		res, err := next(req)
+		if err != nil || res == nil || res.Body == nil || !manageGzip ||
+			!strings.EqualFold(res.Header.Get("Content-Encoding"), "gzip") {
+			return res, err
+		}
+
+		var wireLimit int64
+		switch {
+		case res.StatusCode >= http.StatusBadRequest:
+			wireLimit = cfg.MaxErrorResponseBodyBytes
+		case cfg.ownsSuccessResponseBody():
+			wireLimit = cfg.MaxResponseBodyBytes
+		}
+		res.Body = newGzipResponseBody(res.Body, wireLimit)
+		res.Header.Del("Content-Encoding")
+		res.Header.Del("Content-Length")
+		res.ContentLength = -1
+		res.Uncompressed = true
+		return res, nil
+	}
+}

--- a/internal/requestconfig/compression.go
+++ b/internal/requestconfig/compression.go
@@ -86,11 +86,19 @@ func (cfg *RequestConfig) ownsSuccessResponseBody() bool {
 	return !raw
 }
 
-func (cfg *RequestConfig) shouldManageGzip(req *http.Request) bool {
+type responseCompressionPolicy uint8
+
+const (
+	responseCompressionPreserved responseCompressionPolicy = iota
+	responseCompressionManaged
+	responseCompressionIdentity
+)
+
+func (cfg *RequestConfig) compressionPolicy(req *http.Request) responseCompressionPolicy {
 	if req.Method == http.MethodHead ||
 		req.Header.Get("Accept-Encoding") != "" ||
 		req.Header.Get("Range") != "" {
-		return false
+		return responseCompressionPreserved
 	}
 
 	// Respect explicit stdlib transport configuration, including SDK-owned
@@ -102,26 +110,46 @@ func (cfg *RequestConfig) shouldManageGzip(req *http.Request) bool {
 		}
 		switch transport := transport.(type) {
 		case *http.Transport:
-			return !transport.DisableCompression
+			if transport.DisableCompression {
+				return responseCompressionPreserved
+			}
+		case interface {
+			CompressionDisabled() bool
+			CompressionPolicyKnown() bool
+		}:
+			if !transport.CompressionPolicyKnown() {
+				return responseCompressionIdentity
+			}
+			if transport.CompressionDisabled() {
+				return responseCompressionPreserved
+			}
 		case interface{ CompressionDisabled() bool }:
-			return !transport.CompressionDisabled()
+			if transport.CompressionDisabled() {
+				return responseCompressionPreserved
+			}
 		default:
-			// Opaque wrappers own their native transport's compression policy;
-			// injecting gzip here could override an inaccessible disabled setting.
-			return false
+			// Hidden native transports may either disable gzip or transparently
+			// decompress it before wire bytes can be bounded. Identity preserves
+			// both policies without guessing which transport the wrapper owns.
+			return responseCompressionIdentity
 		}
 	}
-	return true
+	return responseCompressionManaged
 }
 
 func (cfg *RequestConfig) withManagedGzip(next middlewareNext) middlewareNext {
 	return func(req *http.Request) (*http.Response, error) {
-		manageGzip := cfg.shouldManageGzip(req)
-		if manageGzip {
+		policy := cfg.compressionPolicy(req)
+		manageGzip := policy == responseCompressionManaged
+		if policy != responseCompressionPreserved {
 			// Decorate a per-attempt clone so authentication or other outer
 			// middleware can replay the pristine request through this layer.
 			req = req.Clone(req.Context())
-			req.Header.Set("Accept-Encoding", "gzip")
+			encoding := "identity"
+			if manageGzip {
+				encoding = "gzip"
+			}
+			req.Header.Set("Accept-Encoding", encoding)
 		}
 
 		res, err := next(req)

--- a/internal/requestconfig/compression.go
+++ b/internal/requestconfig/compression.go
@@ -119,6 +119,9 @@ func (cfg *RequestConfig) compressionPolicy(req *http.Request) responseCompressi
 		if transport == nil {
 			transport = http.DefaultTransport
 		}
+		if guarded, ok := UnwrapCredentialRedirectGuard(transport); ok {
+			transport = guarded
+		}
 		switch transport := transport.(type) {
 		case *http.Transport:
 			if transport.DisableCompression {

--- a/internal/requestconfig/compression.go
+++ b/internal/requestconfig/compression.go
@@ -93,15 +93,18 @@ func (cfg *RequestConfig) shouldManageGzip(req *http.Request) bool {
 		return false
 	}
 
-	// Respect explicit stdlib transport configuration. Wrapped and custom
-	// transports can opt out in the portable way by setting Accept-Encoding.
+	// Respect explicit stdlib transport configuration, including SDK-owned
+	// wrappers that preserve the selected native transport's policy.
 	if cfg.CustomHTTPDoer == nil && cfg.HTTPClient != nil {
 		transport := cfg.HTTPClient.Transport
 		if transport == nil {
 			transport = http.DefaultTransport
 		}
-		if transport, ok := transport.(*http.Transport); ok && transport.DisableCompression {
-			return false
+		switch transport := transport.(type) {
+		case *http.Transport:
+			return !transport.DisableCompression
+		case interface{ CompressionDisabled() bool }:
+			return !transport.CompressionDisabled()
 		}
 	}
 	return true

--- a/internal/requestconfig/compression.go
+++ b/internal/requestconfig/compression.go
@@ -101,9 +101,20 @@ func (cfg *RequestConfig) compressionPolicy(req *http.Request) responseCompressi
 		return responseCompressionPreserved
 	}
 
+	if cfg.CustomHTTPDoer != nil {
+		policy, ok := cfg.CustomHTTPDoer.(interface{ CompressionDisabled() bool })
+		if !ok {
+			return responseCompressionIdentity
+		}
+		if policy.CompressionDisabled() {
+			return responseCompressionPreserved
+		}
+		return responseCompressionManaged
+	}
+
 	// Respect explicit stdlib transport configuration, including SDK-owned
 	// wrappers that preserve the selected native transport's policy.
-	if cfg.CustomHTTPDoer == nil && cfg.HTTPClient != nil {
+	if cfg.HTTPClient != nil {
 		transport := cfg.HTTPClient.Transport
 		if transport == nil {
 			transport = http.DefaultTransport

--- a/internal/requestconfig/compression.go
+++ b/internal/requestconfig/compression.go
@@ -87,8 +87,7 @@ func (cfg *RequestConfig) ownsSuccessResponseBody() bool {
 }
 
 func (cfg *RequestConfig) shouldManageGzip(req *http.Request) bool {
-	if cfg.CustomHTTPDoer != nil ||
-		req.Method == http.MethodHead ||
+	if req.Method == http.MethodHead ||
 		req.Header.Get("Accept-Encoding") != "" ||
 		req.Header.Get("Range") != "" {
 		return false
@@ -96,7 +95,7 @@ func (cfg *RequestConfig) shouldManageGzip(req *http.Request) bool {
 
 	// Respect explicit stdlib transport configuration. Wrapped and custom
 	// transports can opt out in the portable way by setting Accept-Encoding.
-	if cfg.HTTPClient != nil {
+	if cfg.CustomHTTPDoer == nil && cfg.HTTPClient != nil {
 		transport := cfg.HTTPClient.Transport
 		if transport == nil {
 			transport = http.DefaultTransport

--- a/internal/requestconfig/compression.go
+++ b/internal/requestconfig/compression.go
@@ -105,6 +105,10 @@ func (cfg *RequestConfig) shouldManageGzip(req *http.Request) bool {
 			return !transport.DisableCompression
 		case interface{ CompressionDisabled() bool }:
 			return !transport.CompressionDisabled()
+		default:
+			// Opaque wrappers own their native transport's compression policy;
+			// injecting gzip here could override an inaccessible disabled setting.
+			return false
 		}
 	}
 	return true

--- a/internal/requestconfig/compression.go
+++ b/internal/requestconfig/compression.go
@@ -149,6 +149,13 @@ func (cfg *RequestConfig) compressionPolicy(req *http.Request) responseCompressi
 }
 
 func (cfg *RequestConfig) withManagedGzip(next middlewareNext) middlewareNext {
+	if cfg.MaxErrorResponseBodyBytes == 0 &&
+		(cfg.MaxResponseBodyBytes == 0 || !cfg.ownsSuccessResponseBody()) {
+		// Without an applicable wire limit, preserve native transport
+		// negotiation and caller-owned raw streaming exactly as before.
+		return next
+	}
+
 	return func(req *http.Request) (*http.Response, error) {
 		policy := cfg.compressionPolicy(req)
 		manageGzip := policy == responseCompressionManaged

--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -550,6 +550,27 @@ func WaitForDelay(ctx context.Context, delay time.Duration) error {
 	}
 }
 
+func (cfg *RequestConfig) waitForRetry(
+	ctx context.Context,
+	cancel context.CancelFunc,
+	res *http.Response,
+	retryCount int,
+) error {
+	waitCtx := cfg.Request.Context()
+	if deadline, ok := ctx.Deadline(); ok {
+		var stop context.CancelFunc
+		waitCtx, stop = context.WithDeadline(waitCtx, deadline)
+		defer stop()
+	}
+
+	if res != nil && res.Body != nil {
+		newResponseBodyLifecycle(res.Body, cancel).abort()
+	} else {
+		cancel()
+	}
+	return WaitForDelay(waitCtx, retryDelay(res, retryCount, cfg.MaxRetryDelay))
+}
+
 func (cfg *RequestConfig) Execute() (err error) {
 	if cfg.BaseURL == nil {
 		if cfg.DefaultBaseURL != nil {
@@ -670,16 +691,9 @@ func (cfg *RequestConfig) Execute() (err error) {
 			break
 		}
 
-		// Close the response body before retrying to prevent connection leaks
-		if res != nil && res.Body != nil {
-			_ = res.Body.Close()
-		}
-
-		if waitErr := WaitForDelay(ctx, retryDelay(res, retryCount, cfg.MaxRetryDelay)); waitErr != nil {
-			cancel()
+		if waitErr := cfg.waitForRetry(ctx, cancel, res, retryCount); waitErr != nil {
 			return waitErr
 		}
-		cancel()
 	}
 
 	// Save *http.Response if it is requested to, even if there was an error making the request. This is

--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -563,11 +563,7 @@ func (cfg *RequestConfig) waitForRetry(
 		defer stop()
 	}
 
-	if res != nil && res.Body != nil {
-		newResponseBodyLifecycle(res.Body, cancel).abort()
-	} else {
-		cancel()
-	}
+	cancel()
 	return WaitForDelay(waitCtx, retryDelay(res, retryCount, cfg.MaxRetryDelay))
 }
 
@@ -691,6 +687,10 @@ func (cfg *RequestConfig) Execute() (err error) {
 			break
 		}
 
+		if res != nil && res.Body != nil {
+			retryResponse := res
+			context.AfterFunc(ctx, func() { _ = retryResponse.Body.Close() })
+		}
 		if waitErr := cfg.waitForRetry(ctx, cancel, res, retryCount); waitErr != nil {
 			return waitErr
 		}

--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -494,28 +494,25 @@ func isBeforeContextDeadline(t time.Time, ctx context.Context) bool {
 	return t.Before(d)
 }
 
-// bodyWithTimeout is an io.ReadCloser which can observe a context's cancel func
-// to handle timeouts etc. It wraps an existing io.ReadCloser.
-type bodyWithTimeout struct {
-	stop func() // stops the time.Timer waiting to cancel the request
+// bodyWithCancel keeps a raw response tied to its request context until the
+// caller finishes reading or closes the body.
+type bodyWithCancel struct {
+	stop func() // ends the request context lifecycle
 	rc   io.ReadCloser
+	once sync.Once
 }
 
-func (b *bodyWithTimeout) Read(p []byte) (n int, err error) {
+func (b *bodyWithCancel) Read(p []byte) (n int, err error) {
 	n, err = b.rc.Read(p)
-	if err == nil {
-		return n, nil
-	}
-	if err == io.EOF {
-		return n, err
+	if err != nil {
+		b.once.Do(b.stop)
 	}
 	return n, err
 }
 
-func (b *bodyWithTimeout) Close() error {
-	err := b.rc.Close()
-	b.stop()
-	return err
+func (b *bodyWithCancel) Close() error {
+	b.once.Do(b.stop)
+	return b.rc.Close()
 }
 
 // closeOnceReadCloser lets Execute clean up bodies when middleware returns an
@@ -630,6 +627,7 @@ func (cfg *RequestConfig) Execute() (err error) {
 	if cfg.CustomHTTPDoer != nil {
 		handler = enforceRequestOrigin(cfg.BaseURL, cfg.CustomHTTPDoer.Do)
 	}
+	handler = cfg.withManagedGzip(handler)
 	for i := len(cfg.Middlewares) - 1; i >= 0; i -= 1 {
 		handler = applyMiddleware(cfg.Middlewares[i], handler)
 	}
@@ -643,12 +641,11 @@ func (cfg *RequestConfig) Execute() (err error) {
 		ctx := cfg.Request.Context()
 		if cfg.RequestTimeout != time.Duration(0) && isBeforeContextDeadline(time.Now().Add(cfg.RequestTimeout), ctx) {
 			ctx, cancel = context.WithTimeout(ctx, cfg.RequestTimeout)
-			defer func() {
-				// The cancel function is nil if it was handed off to be handled in a different scope.
-				if cancel != nil {
-					cancel()
-				}
-			}()
+		} else {
+			// Every attempt gets a cancellable lifecycle. Non-streaming response
+			// policy can then interrupt supported custom transports through the
+			// same request context used by net/http.
+			ctx, cancel = context.WithCancel(ctx)
 		}
 
 		req := cfg.Request.Clone(ctx)
@@ -669,8 +666,13 @@ func (cfg *RequestConfig) Execute() (err error) {
 				_ = attemptBody.Close()
 			}
 		}
-		if ctx != nil && ctx.Err() != nil {
-			return ctx.Err()
+		if ctx.Err() != nil {
+			if res != nil && res.Body != nil {
+				_ = res.Body.Close()
+			}
+			ctxErr := ctx.Err()
+			cancel()
+			return ctxErr
 		}
 		if !shouldRetry(cfg.Request, res, err) || retryCount >= cfg.MaxRetries {
 			break
@@ -680,6 +682,7 @@ func (cfg *RequestConfig) Execute() (err error) {
 		if cfg.Request.GetBody != nil {
 			cfg.Request.Body, err = cfg.Request.GetBody()
 			if err != nil {
+				cancel()
 				return err
 			}
 		}
@@ -695,8 +698,10 @@ func (cfg *RequestConfig) Execute() (err error) {
 		}
 
 		if waitErr := WaitForDelay(ctx, retryDelay(res, retryCount, cfg.MaxRetryDelay)); waitErr != nil {
+			cancel()
 			return waitErr
 		}
+		cancel()
 	}
 
 	// Save *http.Response if it is requested to, even if there was an error making the request. This is
@@ -712,11 +717,12 @@ func (cfg *RequestConfig) Execute() (err error) {
 	// If there was a connection error in the final request or any other transport error,
 	// return that early without trying to coerce into an APIError.
 	if err != nil {
+		cancel()
 		return err
 	}
 
 	if res.StatusCode >= 400 {
-		return cfg.handleErrorResponse(res)
+		return cfg.handleErrorResponse(res, cancel)
 	}
 
 	_, intoCustomResponseBody := cfg.ResponseBodyInto.(**http.Response)
@@ -724,14 +730,11 @@ func (cfg *RequestConfig) Execute() (err error) {
 		// We aren't reading the response body in this scope, but whoever is will need the
 		// cancel func from the context to observe request timeouts.
 		// Put the cancel function in the response body so it can be handled elsewhere.
-		if cancel != nil {
-			res.Body = &bodyWithTimeout{rc: res.Body, stop: cancel}
-			cancel = nil
-		}
+		res.Body = &bodyWithCancel{rc: res.Body, stop: cancel}
 		return nil
 	}
 
-	return cfg.handleSuccessResponse(res)
+	return cfg.handleSuccessResponse(res, cancel)
 }
 
 func ExecuteNewRequest(ctx context.Context, method string, u string, body any, dst any, opts ...RequestOption) error {

--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -511,7 +511,7 @@ func (b *bodyWithCancel) Read(p []byte) (n int, err error) {
 }
 
 func (b *bodyWithCancel) Close() error {
-	b.once.Do(b.stop)
+	defer b.once.Do(b.stop)
 	return b.rc.Close()
 }
 
@@ -726,15 +726,20 @@ func (cfg *RequestConfig) Execute() (err error) {
 	}
 
 	_, intoCustomResponseBody := cfg.ResponseBodyInto.(**http.Response)
-	if cfg.ResponseBodyInto == nil || intoCustomResponseBody {
-		// We aren't reading the response body in this scope, but whoever is will need the
-		// cancel func from the context to observe request timeouts.
-		// Put the cancel function in the response body so it can be handled elsewhere.
-		res.Body = &bodyWithCancel{rc: res.Body, stop: cancel}
+	if cfg.ResponseBodyInto != nil && !intoCustomResponseBody {
+		return cfg.handleSuccessResponse(res, cancel)
+	}
+
+	if cfg.ResponseInto == nil && !intoCustomResponseBody {
+		_ = res.Body.Close()
+		cancel()
 		return nil
 	}
 
-	return cfg.handleSuccessResponse(res, cancel)
+	// The caller owns this raw response. Keep its attempt context alive until
+	// reading finishes or Close releases the underlying body.
+	res.Body = &bodyWithCancel{rc: res.Body, stop: cancel}
+	return nil
 }
 
 func ExecuteNewRequest(ctx context.Context, method string, u string, body any, dst any, opts ...RequestOption) error {

--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"math"
 	"math/rand"
-	"mime"
 	"net/http"
 	"net/url"
 	"runtime"
@@ -19,10 +18,8 @@ import (
 	"time"
 
 	"github.com/openai/openai-go/v3/internal"
-	"github.com/openai/openai-go/v3/internal/apierror"
 	"github.com/openai/openai-go/v3/internal/apiform"
 	"github.com/openai/openai-go/v3/internal/apiquery"
-	"github.com/tidwall/gjson"
 )
 
 // DefaultMaxServerDelay bounds server-directed retry and polling waits unless
@@ -279,12 +276,15 @@ func NewRequestConfig(ctx context.Context, method string, u string, body any, ds
 		req.Header.Add(k, v)
 	}
 	cfg := RequestConfig{
-		MaxRetries:    2,
-		MaxRetryDelay: DefaultMaxServerDelay,
-		Context:       ctx,
-		Request:       req,
-		HTTPClient:    http.DefaultClient,
-		Body:          reader,
+		MaxRetries:                2,
+		MaxRetryDelay:             DefaultMaxServerDelay,
+		MaxResponseBodyBytes:      defaultMaxResponseBodyBytes,
+		MaxErrorResponseBodyBytes: defaultMaxErrorResponseBodyBytes,
+		ResponseBodyTimeout:       defaultResponseBodyTimeout,
+		Context:                   ctx,
+		Request:                   req,
+		HTTPClient:                http.DefaultClient,
+		Body:                      reader,
 	}
 	cfg.ResponseBodyInto = dst
 	cfg.Security = Security{
@@ -335,6 +335,9 @@ type RequestConfig struct {
 	MaxRetries                 int
 	MaxRetryDelay              time.Duration
 	RequestTimeout             time.Duration
+	MaxResponseBodyBytes       int64
+	MaxErrorResponseBodyBytes  int64
+	ResponseBodyTimeout        time.Duration
 	Context                    context.Context
 	Request                    *http.Request
 	BaseURL                    *url.URL
@@ -713,24 +716,7 @@ func (cfg *RequestConfig) Execute() (err error) {
 	}
 
 	if res.StatusCode >= 400 {
-		contents, readErr := io.ReadAll(res.Body)
-		_ = res.Body.Close()
-		if readErr != nil {
-			return readErr
-		}
-
-		// If there is an APIError, re-populate the response body so that debugging
-		// utilities can conveniently dump the response without issue.
-		res.Body = io.NopCloser(bytes.NewBuffer(contents))
-
-		// Load the contents into the error format if it is provided.
-		aerr := apierror.Error{Request: cfg.Request, Response: res, StatusCode: res.StatusCode}
-		unwrapped := gjson.GetBytes(contents, "error").Raw
-		err = aerr.UnmarshalJSON([]byte(unwrapped))
-		if err != nil {
-			return err
-		}
-		return &aerr
+		return cfg.handleErrorResponse(res)
 	}
 
 	_, intoCustomResponseBody := cfg.ResponseBodyInto.(**http.Response)
@@ -745,43 +731,7 @@ func (cfg *RequestConfig) Execute() (err error) {
 		return nil
 	}
 
-	contents, err := io.ReadAll(res.Body)
-	_ = res.Body.Close()
-	if err != nil {
-		return fmt.Errorf("error reading response body: %w", err)
-	}
-
-	// If we are not json, return plaintext
-	contentType := res.Header.Get("content-type")
-	mediaType, _, _ := mime.ParseMediaType(contentType)
-	isJSON := strings.Contains(mediaType, "application/json") || strings.HasSuffix(mediaType, "+json")
-	if !isJSON {
-		switch dst := cfg.ResponseBodyInto.(type) {
-		case *string:
-			*dst = string(contents)
-		case **string:
-			tmp := string(contents)
-			*dst = &tmp
-		case *[]byte:
-			*dst = contents
-		default:
-			return fmt.Errorf("expected destination type of 'string' or '[]byte' for responses with content-type '%s' that is not 'application/json'", contentType)
-		}
-		return nil
-	}
-
-	switch dst := cfg.ResponseBodyInto.(type) {
-	// If the response happens to be a byte array, deserialize the body as-is.
-	case *[]byte:
-		*dst = contents
-	default:
-		err = json.NewDecoder(bytes.NewReader(contents)).Decode(cfg.ResponseBodyInto)
-		if err != nil {
-			return fmt.Errorf("error parsing response json: %w", err)
-		}
-	}
-
-	return nil
+	return cfg.handleSuccessResponse(res)
 }
 
 func ExecuteNewRequest(ctx context.Context, method string, u string, body any, dst any, opts ...RequestOption) error {

--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -278,9 +278,7 @@ func NewRequestConfig(ctx context.Context, method string, u string, body any, ds
 	cfg := RequestConfig{
 		MaxRetries:                2,
 		MaxRetryDelay:             DefaultMaxServerDelay,
-		MaxResponseBodyBytes:      defaultMaxResponseBodyBytes,
 		MaxErrorResponseBodyBytes: defaultMaxErrorResponseBodyBytes,
-		ResponseBodyTimeout:       defaultResponseBodyTimeout,
 		Context:                   ctx,
 		Request:                   req,
 		HTTPClient:                http.DefaultClient,

--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -494,27 +494,6 @@ func isBeforeContextDeadline(t time.Time, ctx context.Context) bool {
 	return t.Before(d)
 }
 
-// bodyWithCancel keeps a raw response tied to its request context until the
-// caller finishes reading or closes the body.
-type bodyWithCancel struct {
-	stop func() // ends the request context lifecycle
-	rc   io.ReadCloser
-	once sync.Once
-}
-
-func (b *bodyWithCancel) Read(p []byte) (n int, err error) {
-	n, err = b.rc.Read(p)
-	if err != nil {
-		b.once.Do(b.stop)
-	}
-	return n, err
-}
-
-func (b *bodyWithCancel) Close() error {
-	defer b.once.Do(b.stop)
-	return b.rc.Close()
-}
-
 // closeOnceReadCloser lets Execute clean up bodies when middleware returns an
 // error before reaching the transport, without double-closing bodies that a
 // transport has already closed.
@@ -721,24 +700,24 @@ func (cfg *RequestConfig) Execute() (err error) {
 		return err
 	}
 
+	lifecycle := newResponseBodyLifecycle(res.Body, cancel)
 	if res.StatusCode >= 400 {
-		return cfg.handleErrorResponse(res, cancel)
+		return cfg.handleErrorResponse(res, lifecycle)
 	}
 
 	_, intoCustomResponseBody := cfg.ResponseBodyInto.(**http.Response)
 	if cfg.ResponseBodyInto != nil && !intoCustomResponseBody {
-		return cfg.handleSuccessResponse(res, cancel)
+		return cfg.handleSuccessResponse(res, lifecycle)
 	}
 
 	if cfg.ResponseInto == nil && !intoCustomResponseBody {
-		_ = res.Body.Close()
-		cancel()
+		_ = lifecycle.Close()
 		return nil
 	}
 
 	// The caller owns this raw response. Keep its attempt context alive until
-	// reading finishes or Close releases the underlying body.
-	res.Body = &bodyWithCancel{rc: res.Body, stop: cancel}
+	// Close releases the underlying body.
+	res.Body = lifecycle
 	return nil
 }
 

--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -276,13 +276,12 @@ func NewRequestConfig(ctx context.Context, method string, u string, body any, ds
 		req.Header.Add(k, v)
 	}
 	cfg := RequestConfig{
-		MaxRetries:                2,
-		MaxRetryDelay:             DefaultMaxServerDelay,
-		MaxErrorResponseBodyBytes: defaultMaxErrorResponseBodyBytes,
-		Context:                   ctx,
-		Request:                   req,
-		HTTPClient:                http.DefaultClient,
-		Body:                      reader,
+		MaxRetries:    2,
+		MaxRetryDelay: DefaultMaxServerDelay,
+		Context:       ctx,
+		Request:       req,
+		HTTPClient:    http.DefaultClient,
+		Body:          reader,
 	}
 	cfg.ResponseBodyInto = dst
 	cfg.Security = Security{

--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -712,7 +712,11 @@ func (cfg *RequestConfig) Execute() (err error) {
 	}
 
 	if cfg.ResponseInto == nil && !intoCustomResponseBody {
-		_ = lifecycle.Close()
+		if res.ContentLength == 0 {
+			_ = lifecycle.Close()
+		} else {
+			lifecycle.abort()
+		}
 		return nil
 	}
 

--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -646,11 +646,12 @@ func (cfg *RequestConfig) Execute() (err error) {
 			}
 		}
 		if ctx.Err() != nil {
-			if res != nil && res.Body != nil {
-				_ = res.Body.Close()
-			}
 			ctxErr := ctx.Err()
-			cancel()
+			if res != nil && res.Body != nil {
+				newResponseBodyLifecycle(res.Body, cancel).abort()
+			} else {
+				cancel()
+			}
 			return ctxErr
 		}
 		if !shouldRetry(cfg.Request, res, err) || retryCount >= cfg.MaxRetries {

--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -727,11 +727,7 @@ func (cfg *RequestConfig) Execute() (err error) {
 	}
 
 	if cfg.ResponseInto == nil && !intoCustomResponseBody {
-		if res.ContentLength == 0 {
-			_ = lifecycle.Close()
-		} else {
-			lifecycle.abort()
-		}
+		lifecycle.abort()
 		return nil
 	}
 

--- a/internal/requestconfig/requestconfig_test.go
+++ b/internal/requestconfig/requestconfig_test.go
@@ -300,8 +300,8 @@ func TestNewRequestConfigSetsAndClonesResponsePolicies(t *testing.T) {
 	if cfg.MaxResponseBodyBytes != 0 {
 		t.Fatalf("MaxResponseBodyBytes = %d, want disabled by default", cfg.MaxResponseBodyBytes)
 	}
-	if cfg.MaxErrorResponseBodyBytes != defaultMaxErrorResponseBodyBytes {
-		t.Fatalf("MaxErrorResponseBodyBytes = %d, want %d", cfg.MaxErrorResponseBodyBytes, defaultMaxErrorResponseBodyBytes)
+	if cfg.MaxErrorResponseBodyBytes != 0 {
+		t.Fatalf("MaxErrorResponseBodyBytes = %d, want disabled by default", cfg.MaxErrorResponseBodyBytes)
 	}
 	if cfg.ResponseBodyTimeout != 0 {
 		t.Fatalf("ResponseBodyTimeout = %s, want disabled by default", cfg.ResponseBodyTimeout)

--- a/internal/requestconfig/requestconfig_test.go
+++ b/internal/requestconfig/requestconfig_test.go
@@ -292,6 +292,40 @@ func TestWaitForDelayObservesCancellation(t *testing.T) {
 	}
 }
 
+func TestNewRequestConfigSetsAndClonesResponsePolicies(t *testing.T) {
+	cfg, err := NewRequestConfig(context.Background(), http.MethodGet, "/models", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.MaxResponseBodyBytes != defaultMaxResponseBodyBytes {
+		t.Fatalf("MaxResponseBodyBytes = %d, want %d", cfg.MaxResponseBodyBytes, defaultMaxResponseBodyBytes)
+	}
+	if cfg.MaxErrorResponseBodyBytes != defaultMaxErrorResponseBodyBytes {
+		t.Fatalf("MaxErrorResponseBodyBytes = %d, want %d", cfg.MaxErrorResponseBodyBytes, defaultMaxErrorResponseBodyBytes)
+	}
+	if cfg.ResponseBodyTimeout != defaultResponseBodyTimeout {
+		t.Fatalf("ResponseBodyTimeout = %s, want %s", cfg.ResponseBodyTimeout, defaultResponseBodyTimeout)
+	}
+
+	cloned := cfg.Clone(context.Background())
+	if cloned == nil {
+		t.Fatal("Clone() = nil")
+	}
+	if cloned.MaxResponseBodyBytes != cfg.MaxResponseBodyBytes ||
+		cloned.MaxErrorResponseBodyBytes != cfg.MaxErrorResponseBodyBytes ||
+		cloned.ResponseBodyTimeout != cfg.ResponseBodyTimeout {
+		t.Fatalf(
+			"cloned response policies = (%d, %d, %s), want (%d, %d, %s)",
+			cloned.MaxResponseBodyBytes,
+			cloned.MaxErrorResponseBodyBytes,
+			cloned.ResponseBodyTimeout,
+			cfg.MaxResponseBodyBytes,
+			cfg.MaxErrorResponseBodyBytes,
+			cfg.ResponseBodyTimeout,
+		)
+	}
+}
+
 func TestExecuteClosesAttemptBodyOnHandlerError(t *testing.T) {
 	t.Run("no retry", func(t *testing.T) {
 		body := newTrackedFileBody(t)

--- a/internal/requestconfig/requestconfig_test.go
+++ b/internal/requestconfig/requestconfig_test.go
@@ -336,6 +336,49 @@ func TestNewRequestConfigLeavesResponseBodyTimeoutDisabledByDefault(t *testing.T
 	}
 }
 
+func TestResponseBodyTimeoutStopsAfterBufferedReads(t *testing.T) {
+	const bodyTimeout = 15 * time.Millisecond
+	postReadError := errors.New("API error parsing completed")
+	tests := []struct {
+		name         string
+		limit        int64
+		wantOverflow bool
+	}{
+		{name: "complete success or error response"},
+		{name: "configured limit overflow", limit: 1, wantOverflow: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			lifecycle := newResponseBodyLifecycle(io.NopCloser(strings.NewReader(`{"ok":true}`)), cancel)
+			cfg := RequestConfig{ResponseBodyTimeout: bodyTimeout}
+			contextErrAfterRead := error(nil)
+
+			err := cfg.withResponseBodyTimeout(lifecycle, func(body *responseBodyLifecycle) error {
+				_, overflow, readErr := readBodyUpTo(body, test.limit)
+				if readErr != nil {
+					return readErr
+				}
+				if overflow != test.wantOverflow {
+					t.Fatalf("read overflow = %v, want %v", overflow, test.wantOverflow)
+				}
+				<-time.After(3 * bodyTimeout)
+				contextErrAfterRead = ctx.Err()
+				return postReadError
+			})
+
+			if !errors.Is(err, postReadError) {
+				t.Fatalf("response error = %v, want post-read error %v", err, postReadError)
+			}
+			if contextErrAfterRead != nil {
+				t.Fatalf("attempt context during parsing = %v, want active context", contextErrAfterRead)
+			}
+		})
+	}
+}
+
 func TestExecuteClosesAttemptBodyOnHandlerError(t *testing.T) {
 	t.Run("no retry", func(t *testing.T) {
 		body := newTrackedFileBody(t)

--- a/internal/requestconfig/requestconfig_test.go
+++ b/internal/requestconfig/requestconfig_test.go
@@ -297,14 +297,14 @@ func TestNewRequestConfigSetsAndClonesResponsePolicies(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cfg.MaxResponseBodyBytes != defaultMaxResponseBodyBytes {
-		t.Fatalf("MaxResponseBodyBytes = %d, want %d", cfg.MaxResponseBodyBytes, defaultMaxResponseBodyBytes)
+	if cfg.MaxResponseBodyBytes != 0 {
+		t.Fatalf("MaxResponseBodyBytes = %d, want disabled by default", cfg.MaxResponseBodyBytes)
 	}
 	if cfg.MaxErrorResponseBodyBytes != defaultMaxErrorResponseBodyBytes {
 		t.Fatalf("MaxErrorResponseBodyBytes = %d, want %d", cfg.MaxErrorResponseBodyBytes, defaultMaxErrorResponseBodyBytes)
 	}
-	if cfg.ResponseBodyTimeout != defaultResponseBodyTimeout {
-		t.Fatalf("ResponseBodyTimeout = %s, want %s", cfg.ResponseBodyTimeout, defaultResponseBodyTimeout)
+	if cfg.ResponseBodyTimeout != 0 {
+		t.Fatalf("ResponseBodyTimeout = %s, want disabled by default", cfg.ResponseBodyTimeout)
 	}
 
 	cloned := cfg.Clone(context.Background())
@@ -323,6 +323,16 @@ func TestNewRequestConfigSetsAndClonesResponsePolicies(t *testing.T) {
 			cfg.MaxErrorResponseBodyBytes,
 			cfg.ResponseBodyTimeout,
 		)
+	}
+}
+
+func TestNewRequestConfigLeavesResponseBodyTimeoutDisabledByDefault(t *testing.T) {
+	cfg, err := NewRequestConfig(context.Background(), http.MethodGet, "/models", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.ResponseBodyTimeout != 0 {
+		t.Fatalf("ResponseBodyTimeout = %s, want disabled by default", cfg.ResponseBodyTimeout)
 	}
 }
 

--- a/internal/requestconfig/response.go
+++ b/internal/requestconfig/response.go
@@ -161,6 +161,11 @@ func (l *responseBodyLifecycle) interrupt(interrupted chan<- struct{}) {
 	_ = l.body.Close()
 }
 
+func (l *responseBodyLifecycle) abort() {
+	l.stopAttempt()
+	go func() { _ = l.body.Close() }()
+}
+
 func (cfg *RequestConfig) withResponseBodyTimeout(
 	lifecycle *responseBodyLifecycle,
 	read func(io.Reader) error,
@@ -182,6 +187,14 @@ func (cfg *RequestConfig) withResponseBodyTimeout(
 	}
 	if timedOut.Load() {
 		return fmt.Errorf("response body read timed out after %s: %w", cfg.ResponseBodyTimeout, context.DeadlineExceeded)
+	}
+	var bodyLimitErr *responseBodyLimitError
+	var compressedLimitErr *compressedResponseBodyLimitError
+	if errors.As(err, &bodyLimitErr) || errors.As(err, &compressedLimitErr) {
+		// An oversized body still has unread bytes, so HTTP/2 Close can block
+		// while resetting its stream. Return the established limit immediately.
+		lifecycle.abort()
+		return err
 	}
 	_ = lifecycle.Close()
 	return err

--- a/internal/requestconfig/response.go
+++ b/internal/requestconfig/response.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -38,10 +39,11 @@ func (e *responseBodyLimitError) Error() string {
 
 func (e *responseBodyLimitError) Unwrap() error { return e.cause }
 
-func (cfg *RequestConfig) handleErrorResponse(res *http.Response) error {
-	return cfg.withResponseBodyTimeout(res, func(body io.Reader) error {
+func (cfg *RequestConfig) handleErrorResponse(res *http.Response, cancel context.CancelFunc) error {
+	return cfg.withResponseBodyTimeout(res, cancel, func(body io.Reader) error {
 		contents, overflow, readErr := readBodyUpTo(body, cfg.MaxErrorResponseBodyBytes)
-		if readErr != nil {
+		var compressedLimitErr *compressedResponseBodyLimitError
+		if readErr != nil && !errors.As(readErr, &compressedLimitErr) {
 			return readErr
 		}
 
@@ -49,7 +51,7 @@ func (cfg *RequestConfig) handleErrorResponse(res *http.Response) error {
 		// another unbounded copy. ContentLength describes the retained body when
 		// the server response was larger than the configured limit.
 		res.Body = io.NopCloser(bytes.NewReader(contents))
-		if overflow {
+		if overflow || compressedLimitErr != nil {
 			res.ContentLength = int64(len(contents))
 		}
 
@@ -63,6 +65,12 @@ func (cfg *RequestConfig) handleErrorResponse(res *http.Response) error {
 				cause:      &aerr,
 			}
 		}
+		if compressedLimitErr != nil {
+			return &compressedResponseBodyLimitError{
+				limit: compressedLimitErr.limit,
+				cause: &aerr,
+			}
+		}
 		if parseErr != nil {
 			return parseErr
 		}
@@ -70,8 +78,8 @@ func (cfg *RequestConfig) handleErrorResponse(res *http.Response) error {
 	})
 }
 
-func (cfg *RequestConfig) handleSuccessResponse(res *http.Response) error {
-	return cfg.withResponseBodyTimeout(res, func(body io.Reader) error {
+func (cfg *RequestConfig) handleSuccessResponse(res *http.Response, cancel context.CancelFunc) error {
+	return cfg.withResponseBodyTimeout(res, cancel, func(body io.Reader) error {
 		contentType := res.Header.Get("content-type")
 		mediaType, _, _ := mime.ParseMediaType(contentType)
 		isJSON := strings.Contains(mediaType, "application/json") || strings.HasSuffix(mediaType, "+json")
@@ -119,11 +127,20 @@ func (cfg *RequestConfig) handleSuccessResponse(res *http.Response) error {
 	})
 }
 
-func (cfg *RequestConfig) withResponseBodyTimeout(res *http.Response, read func(io.Reader) error) error {
+func (cfg *RequestConfig) withResponseBodyTimeout(
+	res *http.Response,
+	cancel context.CancelFunc,
+	read func(io.Reader) error,
+) error {
 	body := res.Body
-	var closeOnce sync.Once
-	closeBody := func() {
-		closeOnce.Do(func() { _ = body.Close() })
+	var stopOnce sync.Once
+	stopRead := func() {
+		stopOnce.Do(func() {
+			if cancel != nil {
+				cancel()
+			}
+			_ = body.Close()
+		})
 	}
 	var timedOut atomic.Bool
 	var timer *time.Timer
@@ -133,7 +150,9 @@ func (cfg *RequestConfig) withResponseBodyTimeout(res *http.Response, read func(
 		timer = time.AfterFunc(cfg.ResponseBodyTimeout, func() {
 			defer close(timeoutDone)
 			timedOut.Store(true)
-			closeBody()
+			// Cancel first so supported custom transports whose Body.Close does
+			// not interrupt Read can observe the request lifecycle ending.
+			stopRead()
 		})
 	}
 
@@ -141,7 +160,7 @@ func (cfg *RequestConfig) withResponseBodyTimeout(res *http.Response, read func(
 	if timer != nil && !timer.Stop() {
 		<-timeoutDone
 	}
-	closeBody()
+	stopRead()
 	if timedOut.Load() {
 		return fmt.Errorf("response body read timed out after %s: %w", cfg.ResponseBodyTimeout, context.DeadlineExceeded)
 	}

--- a/internal/requestconfig/response.go
+++ b/internal/requestconfig/response.go
@@ -1,0 +1,173 @@
+package requestconfig
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/openai/openai-go/v3/internal/apierror"
+	"github.com/tidwall/gjson"
+)
+
+const (
+	defaultMaxResponseBodyBytes      int64 = 64 << 20
+	defaultMaxErrorResponseBodyBytes int64 = 64 << 10
+	defaultResponseBodyTimeout             = 10 * time.Minute
+)
+
+type responseBodyLimitError struct {
+	limit      int64
+	statusCode int
+	cause      error
+}
+
+func (e *responseBodyLimitError) Error() string {
+	if e.statusCode != 0 {
+		return fmt.Sprintf("error response body for status %d exceeded configured limit of %d bytes", e.statusCode, e.limit)
+	}
+	return fmt.Sprintf("response body exceeded configured limit of %d bytes", e.limit)
+}
+
+func (e *responseBodyLimitError) Unwrap() error { return e.cause }
+
+func (cfg *RequestConfig) handleErrorResponse(res *http.Response) error {
+	return cfg.withResponseBodyTimeout(res, func(body io.Reader) error {
+		contents, overflow, readErr := readBodyUpTo(body, cfg.MaxErrorResponseBodyBytes)
+		if readErr != nil {
+			return readErr
+		}
+
+		// Keep only the bounded diagnostic body so Error.DumpResponse cannot make
+		// another unbounded copy. ContentLength describes the retained body when
+		// the server response was larger than the configured limit.
+		res.Body = io.NopCloser(bytes.NewReader(contents))
+		if overflow {
+			res.ContentLength = int64(len(contents))
+		}
+
+		aerr := apierror.Error{Request: cfg.Request, Response: res, StatusCode: res.StatusCode}
+		unwrapped := gjson.GetBytes(contents, "error").Raw
+		parseErr := aerr.UnmarshalJSON([]byte(unwrapped))
+		if overflow {
+			return &responseBodyLimitError{
+				limit:      cfg.MaxErrorResponseBodyBytes,
+				statusCode: res.StatusCode,
+				cause:      &aerr,
+			}
+		}
+		if parseErr != nil {
+			return parseErr
+		}
+		return &aerr
+	})
+}
+
+func (cfg *RequestConfig) handleSuccessResponse(res *http.Response) error {
+	return cfg.withResponseBodyTimeout(res, func(body io.Reader) error {
+		contentType := res.Header.Get("content-type")
+		mediaType, _, _ := mime.ParseMediaType(contentType)
+		isJSON := strings.Contains(mediaType, "application/json") || strings.HasSuffix(mediaType, "+json")
+
+		if isJSON {
+			if dst, ok := cfg.ResponseBodyInto.(*[]byte); ok {
+				contents, overflow, readErr := readBodyUpTo(body, cfg.MaxResponseBodyBytes)
+				if readErr != nil {
+					return fmt.Errorf("error reading response body: %w", readErr)
+				}
+				if overflow {
+					return &responseBodyLimitError{limit: cfg.MaxResponseBodyBytes}
+				}
+				*dst = contents
+				return nil
+			}
+
+			overflow, err := decodeJSONUpTo(body, cfg.MaxResponseBodyBytes, cfg.ResponseBodyInto)
+			if overflow {
+				return &responseBodyLimitError{limit: cfg.MaxResponseBodyBytes}
+			}
+			return err
+		}
+
+		contents, overflow, readErr := readBodyUpTo(body, cfg.MaxResponseBodyBytes)
+		if readErr != nil {
+			return fmt.Errorf("error reading response body: %w", readErr)
+		}
+		if overflow {
+			return &responseBodyLimitError{limit: cfg.MaxResponseBodyBytes}
+		}
+
+		switch dst := cfg.ResponseBodyInto.(type) {
+		case *string:
+			*dst = string(contents)
+		case **string:
+			tmp := string(contents)
+			*dst = &tmp
+		case *[]byte:
+			*dst = contents
+		default:
+			return fmt.Errorf("expected destination type of 'string' or '[]byte' for responses with content-type '%s' that is not 'application/json'", contentType)
+		}
+		return nil
+	})
+}
+
+func (cfg *RequestConfig) withResponseBodyTimeout(res *http.Response, read func(io.Reader) error) error {
+	body := res.Body
+	var closeOnce sync.Once
+	closeBody := func() {
+		closeOnce.Do(func() { _ = body.Close() })
+	}
+	var timedOut atomic.Bool
+	var timer *time.Timer
+	var timeoutDone chan struct{}
+	if cfg.ResponseBodyTimeout > 0 {
+		timeoutDone = make(chan struct{})
+		timer = time.AfterFunc(cfg.ResponseBodyTimeout, func() {
+			defer close(timeoutDone)
+			timedOut.Store(true)
+			closeBody()
+		})
+	}
+
+	err := read(body)
+	if timer != nil && !timer.Stop() {
+		<-timeoutDone
+	}
+	closeBody()
+	if timedOut.Load() {
+		return fmt.Errorf("response body read timed out after %s: %w", cfg.ResponseBodyTimeout, context.DeadlineExceeded)
+	}
+	return err
+}
+
+func readBodyUpTo(body io.Reader, limit int64) (contents []byte, overflow bool, err error) {
+	contents, err = io.ReadAll(io.LimitReader(body, limit+1))
+	if int64(len(contents)) > limit {
+		return contents[:limit], true, nil
+	}
+	return contents, false, err
+}
+
+func decodeJSONUpTo(body io.Reader, limit int64, dst any) (overflow bool, err error) {
+	limited := &io.LimitedReader{R: body, N: limit + 1}
+	decodeErr := json.NewDecoder(limited).Decode(dst)
+	_, readErr := io.Copy(io.Discard, limited)
+	if limited.N == 0 {
+		return true, nil
+	}
+	if readErr != nil {
+		return false, fmt.Errorf("error reading response body: %w", readErr)
+	}
+	if decodeErr != nil {
+		return false, fmt.Errorf("error parsing response json: %w", decodeErr)
+	}
+	return false, nil
+}

--- a/internal/requestconfig/response.go
+++ b/internal/requestconfig/response.go
@@ -39,8 +39,8 @@ func (e *responseBodyLimitError) Error() string {
 
 func (e *responseBodyLimitError) Unwrap() error { return e.cause }
 
-func (cfg *RequestConfig) handleErrorResponse(res *http.Response, cancel context.CancelFunc) error {
-	return cfg.withResponseBodyTimeout(res, cancel, func(body io.Reader) error {
+func (cfg *RequestConfig) handleErrorResponse(res *http.Response, lifecycle *responseBodyLifecycle) error {
+	return cfg.withResponseBodyTimeout(lifecycle, func(body io.Reader) error {
 		contents, overflow, readErr := readBodyUpTo(body, cfg.MaxErrorResponseBodyBytes)
 		var compressedLimitErr *compressedResponseBodyLimitError
 		if readErr != nil && !errors.As(readErr, &compressedLimitErr) {
@@ -78,8 +78,8 @@ func (cfg *RequestConfig) handleErrorResponse(res *http.Response, cancel context
 	})
 }
 
-func (cfg *RequestConfig) handleSuccessResponse(res *http.Response, cancel context.CancelFunc) error {
-	return cfg.withResponseBodyTimeout(res, cancel, func(body io.Reader) error {
+func (cfg *RequestConfig) handleSuccessResponse(res *http.Response, lifecycle *responseBodyLifecycle) error {
+	return cfg.withResponseBodyTimeout(lifecycle, func(body io.Reader) error {
 		contentType := res.Header.Get("content-type")
 		mediaType, _, _ := mime.ParseMediaType(contentType)
 		isJSON := strings.Contains(mediaType, "application/json") || strings.HasSuffix(mediaType, "+json")
@@ -127,43 +127,63 @@ func (cfg *RequestConfig) handleSuccessResponse(res *http.Response, cancel conte
 	})
 }
 
+type responseBodyLifecycle struct {
+	body       io.ReadCloser
+	stop       func()
+	cancelOnce sync.Once
+}
+
+func newResponseBodyLifecycle(body io.ReadCloser, stop func()) *responseBodyLifecycle {
+	return &responseBodyLifecycle{body: body, stop: stop}
+}
+
+func (l *responseBodyLifecycle) stopAttempt() {
+	if l.stop != nil {
+		l.cancelOnce.Do(l.stop)
+	}
+}
+
+func (l *responseBodyLifecycle) Read(p []byte) (int, error) {
+	return l.body.Read(p)
+}
+
+func (l *responseBodyLifecycle) Close() error {
+	defer l.stopAttempt()
+	return l.body.Close()
+}
+
+func (l *responseBodyLifecycle) interrupt(interrupted chan<- struct{}) {
+	// Timeout must cancel first so transports whose Close does not interrupt
+	// Read can observe the request ending. Signal before Close because HTTP/2
+	// cleanup is allowed to block independently of the foreground timeout.
+	l.stopAttempt()
+	close(interrupted)
+	_ = l.body.Close()
+}
+
 func (cfg *RequestConfig) withResponseBodyTimeout(
-	res *http.Response,
-	cancel context.CancelFunc,
+	lifecycle *responseBodyLifecycle,
 	read func(io.Reader) error,
 ) error {
-	body := res.Body
-	var stopOnce sync.Once
-	stopRead := func() {
-		stopOnce.Do(func() {
-			if cancel != nil {
-				cancel()
-			}
-			_ = body.Close()
-		})
-	}
 	var timedOut atomic.Bool
 	var timer *time.Timer
-	var timeoutDone chan struct{}
+	var interrupted chan struct{}
 	if cfg.ResponseBodyTimeout > 0 {
-		timeoutDone = make(chan struct{})
+		interrupted = make(chan struct{})
 		timer = time.AfterFunc(cfg.ResponseBodyTimeout, func() {
-			defer close(timeoutDone)
 			timedOut.Store(true)
-			// Cancel first so supported custom transports whose Body.Close does
-			// not interrupt Read can observe the request lifecycle ending.
-			stopRead()
+			lifecycle.interrupt(interrupted)
 		})
 	}
 
-	err := read(body)
+	err := read(lifecycle.body)
 	if timer != nil && !timer.Stop() {
-		<-timeoutDone
+		<-interrupted
 	}
-	stopRead()
 	if timedOut.Load() {
 		return fmt.Errorf("response body read timed out after %s: %w", cfg.ResponseBodyTimeout, context.DeadlineExceeded)
 	}
+	_ = lifecycle.Close()
 	return err
 }
 

--- a/internal/requestconfig/response.go
+++ b/internal/requestconfig/response.go
@@ -18,8 +18,6 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-const defaultMaxErrorResponseBodyBytes int64 = 64 << 10
-
 type responseBodyLimitError struct {
 	limit      int64
 	statusCode int
@@ -43,9 +41,9 @@ func (cfg *RequestConfig) handleErrorResponse(res *http.Response, lifecycle *res
 			return readErr
 		}
 
-		// Keep only the bounded diagnostic body so Error.DumpResponse cannot make
-		// another unbounded copy. ContentLength describes the retained body when
-		// the server response was larger than the configured limit.
+		// Preserve the complete diagnostic body by default. An explicit limit
+		// retains only its bounded prefix, including for Error.DumpResponse.
+		// ContentLength describes that retained body after truncation.
 		res.Body = io.NopCloser(bytes.NewReader(contents))
 		if overflow || compressedLimitErr != nil {
 			res.ContentLength = int64(len(contents))
@@ -127,6 +125,7 @@ type responseBodyLifecycle struct {
 	body       io.ReadCloser
 	stop       func()
 	cancelOnce sync.Once
+	reachedEOF bool
 }
 
 func newResponseBodyLifecycle(body io.ReadCloser, stop func()) *responseBodyLifecycle {
@@ -140,7 +139,11 @@ func (l *responseBodyLifecycle) stopAttempt() {
 }
 
 func (l *responseBodyLifecycle) Read(p []byte) (int, error) {
-	return l.body.Read(p)
+	n, err := l.body.Read(p)
+	if err == io.EOF {
+		l.reachedEOF = true
+	}
+	return n, err
 }
 
 func (l *responseBodyLifecycle) Close() error {
@@ -177,19 +180,17 @@ func (cfg *RequestConfig) withResponseBodyTimeout(
 		})
 	}
 
-	err := read(lifecycle.body)
+	err := read(lifecycle)
 	if timer != nil && !timer.Stop() {
 		<-interrupted
 	}
 	if timedOut.Load() {
 		return fmt.Errorf("response body read timed out after %s: %w", cfg.ResponseBodyTimeout, context.DeadlineExceeded)
 	}
-	var bodyLimitErr *responseBodyLimitError
-	var compressedLimitErr *compressedResponseBodyLimitError
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) ||
-		errors.As(err, &bodyLimitErr) || errors.As(err, &compressedLimitErr) {
-		// Aborted reads can leave unread bytes, so HTTP/2 Close can block while
-		// resetting its stream. Return the established failure immediately.
+	if err != nil && !lifecycle.reachedEOF {
+		// Any failed read can leave unread bytes, so HTTP/2 Close can block
+		// while resetting its stream. Preserve the established failure without
+		// making foreground completion wait for transport cleanup.
 		lifecycle.abort()
 		return err
 	}

--- a/internal/requestconfig/response.go
+++ b/internal/requestconfig/response.go
@@ -211,21 +211,14 @@ func readBodyUpTo(body io.Reader, limit int64) (contents []byte, overflow bool, 
 }
 
 func decodeJSONUpTo(body io.Reader, limit int64, dst any) (overflow bool, err error) {
-	reader := body
-	var limited *io.LimitedReader
-	if limit > 0 {
-		limited = &io.LimitedReader{R: body, N: limit + 1}
-		reader = limited
-	}
-	decodeErr := json.NewDecoder(reader).Decode(dst)
-	_, readErr := io.Copy(io.Discard, reader)
-	if limited != nil && limited.N == 0 {
+	contents, overflow, readErr := readBodyUpTo(body, limit)
+	if overflow {
 		return true, nil
 	}
 	if readErr != nil {
 		return false, fmt.Errorf("error reading response body: %w", readErr)
 	}
-	if decodeErr != nil {
+	if decodeErr := json.NewDecoder(bytes.NewReader(contents)).Decode(dst); decodeErr != nil {
 		return false, fmt.Errorf("error parsing response json: %w", decodeErr)
 	}
 	return false, nil

--- a/internal/requestconfig/response.go
+++ b/internal/requestconfig/response.go
@@ -34,7 +34,7 @@ func (e *responseBodyLimitError) Error() string {
 func (e *responseBodyLimitError) Unwrap() error { return e.cause }
 
 func (cfg *RequestConfig) handleErrorResponse(res *http.Response, lifecycle *responseBodyLifecycle) error {
-	return cfg.withResponseBodyTimeout(lifecycle, func(body io.Reader) error {
+	return cfg.withResponseBodyTimeout(lifecycle, func(body *responseBodyLifecycle) error {
 		contents, overflow, readErr := readBodyUpTo(body, cfg.MaxErrorResponseBodyBytes)
 		var compressedLimitErr *compressedResponseBodyLimitError
 		if readErr != nil && !errors.As(readErr, &compressedLimitErr) {
@@ -73,7 +73,7 @@ func (cfg *RequestConfig) handleErrorResponse(res *http.Response, lifecycle *res
 }
 
 func (cfg *RequestConfig) handleSuccessResponse(res *http.Response, lifecycle *responseBodyLifecycle) error {
-	return cfg.withResponseBodyTimeout(lifecycle, func(body io.Reader) error {
+	return cfg.withResponseBodyTimeout(lifecycle, func(body *responseBodyLifecycle) error {
 		contentType := res.Header.Get("content-type")
 		mediaType, _, _ := mime.ParseMediaType(contentType)
 		isJSON := strings.Contains(mediaType, "application/json") || strings.HasSuffix(mediaType, "+json")
@@ -122,10 +122,11 @@ func (cfg *RequestConfig) handleSuccessResponse(res *http.Response, lifecycle *r
 }
 
 type responseBodyLifecycle struct {
-	body       io.ReadCloser
-	stop       func()
-	cancelOnce sync.Once
-	reachedEOF bool
+	body          io.ReadCloser
+	stop          func()
+	stopReadTimer func()
+	cancelOnce    sync.Once
+	reachedEOF    bool
 }
 
 func newResponseBodyLifecycle(body io.ReadCloser, stop func()) *responseBodyLifecycle {
@@ -142,8 +143,15 @@ func (l *responseBodyLifecycle) Read(p []byte) (int, error) {
 	n, err := l.body.Read(p)
 	if err == io.EOF {
 		l.reachedEOF = true
+		l.finishReading()
 	}
 	return n, err
+}
+
+func (l *responseBodyLifecycle) finishReading() {
+	if l.stopReadTimer != nil {
+		l.stopReadTimer()
+	}
 }
 
 func (l *responseBodyLifecycle) Close() error {
@@ -167,23 +175,27 @@ func (l *responseBodyLifecycle) abort() {
 
 func (cfg *RequestConfig) withResponseBodyTimeout(
 	lifecycle *responseBodyLifecycle,
-	read func(io.Reader) error,
+	read func(*responseBodyLifecycle) error,
 ) error {
 	var timedOut atomic.Bool
-	var timer *time.Timer
-	var interrupted chan struct{}
 	if cfg.ResponseBodyTimeout > 0 {
-		interrupted = make(chan struct{})
-		timer = time.AfterFunc(cfg.ResponseBodyTimeout, func() {
+		interrupted := make(chan struct{})
+		timer := time.AfterFunc(cfg.ResponseBodyTimeout, func() {
 			timedOut.Store(true)
 			lifecycle.interrupt(interrupted)
 		})
+		var stopOnce sync.Once
+		lifecycle.stopReadTimer = func() {
+			stopOnce.Do(func() {
+				if !timer.Stop() {
+					<-interrupted
+				}
+			})
+		}
 	}
 
 	err := read(lifecycle)
-	if timer != nil && !timer.Stop() {
-		<-interrupted
-	}
+	lifecycle.finishReading()
 	if timedOut.Load() {
 		return fmt.Errorf("response body read timed out after %s: %w", cfg.ResponseBodyTimeout, context.DeadlineExceeded)
 	}
@@ -198,7 +210,8 @@ func (cfg *RequestConfig) withResponseBodyTimeout(
 	return err
 }
 
-func readBodyUpTo(body io.Reader, limit int64) (contents []byte, overflow bool, err error) {
+func readBodyUpTo(body *responseBodyLifecycle, limit int64) (contents []byte, overflow bool, err error) {
+	defer body.finishReading()
 	if limit == 0 {
 		contents, err = io.ReadAll(body)
 		return contents, false, err
@@ -210,7 +223,7 @@ func readBodyUpTo(body io.Reader, limit int64) (contents []byte, overflow bool, 
 	return contents, false, err
 }
 
-func decodeJSONUpTo(body io.Reader, limit int64, dst any) (overflow bool, err error) {
+func decodeJSONUpTo(body *responseBodyLifecycle, limit int64, dst any) (overflow bool, err error) {
 	contents, overflow, readErr := readBodyUpTo(body, limit)
 	if overflow {
 		return true, nil

--- a/internal/requestconfig/response.go
+++ b/internal/requestconfig/response.go
@@ -190,9 +190,10 @@ func (cfg *RequestConfig) withResponseBodyTimeout(
 	}
 	var bodyLimitErr *responseBodyLimitError
 	var compressedLimitErr *compressedResponseBodyLimitError
-	if errors.As(err, &bodyLimitErr) || errors.As(err, &compressedLimitErr) {
-		// An oversized body still has unread bytes, so HTTP/2 Close can block
-		// while resetting its stream. Return the established limit immediately.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) ||
+		errors.As(err, &bodyLimitErr) || errors.As(err, &compressedLimitErr) {
+		// Aborted reads can leave unread bytes, so HTTP/2 Close can block while
+		// resetting its stream. Return the established failure immediately.
 		lifecycle.abort()
 		return err
 	}

--- a/internal/requestconfig/response.go
+++ b/internal/requestconfig/response.go
@@ -18,11 +18,7 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-const (
-	defaultMaxResponseBodyBytes      int64 = 64 << 20
-	defaultMaxErrorResponseBodyBytes int64 = 64 << 10
-	defaultResponseBodyTimeout             = 10 * time.Minute
-)
+const defaultMaxErrorResponseBodyBytes int64 = 64 << 10
 
 type responseBodyLimitError struct {
 	limit      int64
@@ -202,6 +198,10 @@ func (cfg *RequestConfig) withResponseBodyTimeout(
 }
 
 func readBodyUpTo(body io.Reader, limit int64) (contents []byte, overflow bool, err error) {
+	if limit == 0 {
+		contents, err = io.ReadAll(body)
+		return contents, false, err
+	}
 	contents, err = io.ReadAll(io.LimitReader(body, limit+1))
 	if int64(len(contents)) > limit {
 		return contents[:limit], true, nil
@@ -210,10 +210,15 @@ func readBodyUpTo(body io.Reader, limit int64) (contents []byte, overflow bool, 
 }
 
 func decodeJSONUpTo(body io.Reader, limit int64, dst any) (overflow bool, err error) {
-	limited := &io.LimitedReader{R: body, N: limit + 1}
-	decodeErr := json.NewDecoder(limited).Decode(dst)
-	_, readErr := io.Copy(io.Discard, limited)
-	if limited.N == 0 {
+	reader := body
+	var limited *io.LimitedReader
+	if limit > 0 {
+		limited = &io.LimitedReader{R: body, N: limit + 1}
+		reader = limited
+	}
+	decodeErr := json.NewDecoder(reader).Decode(dst)
+	_, readErr := io.Copy(io.Discard, reader)
+	if limited != nil && limited.N == 0 {
 		return true, nil
 	}
 	if readErr != nil {

--- a/option/requestoption.go
+++ b/option/requestoption.go
@@ -260,8 +260,12 @@ func WithResponseInto(dst **http.Response) RequestOption {
 }
 
 // WithMaxResponseBodyBytes returns a RequestOption that limits the number of
-// bytes buffered or decoded for a successful non-streaming response. The
-// default is 64 MiB. Raw *http.Response bodies are not subject to this limit.
+// bytes buffered or decoded for a successful non-streaming response. For
+// transparently decompressed gzip responses, the limit applies independently to
+// compressed wire bytes and decoded bytes. The default is 64 MiB for most
+// responses. Services documented to return larger payloads may apply a higher
+// finite default before client and request options. Raw *http.Response bodies
+// are not subject to this limit.
 //
 // WithMaxResponseBodyBytes panics unless maxBytes is between 1 and
 // [math.MaxInt64] - 1.
@@ -276,8 +280,9 @@ func WithMaxResponseBodyBytes(maxBytes int64) RequestOption {
 }
 
 // WithMaxErrorResponseBodyBytes returns a RequestOption that limits the number
-// of response-body bytes retained when the server returns an HTTP error. The
-// default is 64 KiB.
+// of response-body bytes retained when the server returns an HTTP error. For
+// transparently decompressed gzip responses, compressed wire bytes are bounded
+// by the same limit. The default is 64 KiB.
 //
 // WithMaxErrorResponseBodyBytes panics unless maxBytes is between 1 and
 // [math.MaxInt64] - 1.

--- a/option/requestoption.go
+++ b/option/requestoption.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/url"
 	"strings"
@@ -254,6 +255,54 @@ func WithResponseBodyInto(dst any) RequestOption {
 func WithResponseInto(dst **http.Response) RequestOption {
 	return requestconfig.RequestOptionFunc(func(r *requestconfig.RequestConfig) error {
 		r.ResponseInto = dst
+		return nil
+	})
+}
+
+// WithMaxResponseBodyBytes returns a RequestOption that limits the number of
+// bytes buffered or decoded for a successful non-streaming response. The
+// default is 64 MiB. Raw *http.Response bodies are not subject to this limit.
+//
+// WithMaxResponseBodyBytes panics unless maxBytes is between 1 and
+// [math.MaxInt64] - 1.
+func WithMaxResponseBodyBytes(maxBytes int64) RequestOption {
+	if maxBytes <= 0 || maxBytes == math.MaxInt64 {
+		panic("option: max response body bytes must be between 1 and math.MaxInt64 - 1")
+	}
+	return requestconfig.RequestOptionFunc(func(r *requestconfig.RequestConfig) error {
+		r.MaxResponseBodyBytes = maxBytes
+		return nil
+	})
+}
+
+// WithMaxErrorResponseBodyBytes returns a RequestOption that limits the number
+// of response-body bytes retained when the server returns an HTTP error. The
+// default is 64 KiB.
+//
+// WithMaxErrorResponseBodyBytes panics unless maxBytes is between 1 and
+// [math.MaxInt64] - 1.
+func WithMaxErrorResponseBodyBytes(maxBytes int64) RequestOption {
+	if maxBytes <= 0 || maxBytes == math.MaxInt64 {
+		panic("option: max error response body bytes must be between 1 and math.MaxInt64 - 1")
+	}
+	return requestconfig.RequestOptionFunc(func(r *requestconfig.RequestConfig) error {
+		r.MaxErrorResponseBodyBytes = maxBytes
+		return nil
+	})
+}
+
+// WithResponseBodyTimeout returns a RequestOption that bounds how long the
+// client spends reading a non-streaming response body after receiving response
+// headers. The default is 10 minutes. A zero duration disables this timeout.
+// Raw *http.Response bodies are not subject to this timeout.
+//
+// WithResponseBodyTimeout panics when dur is negative.
+func WithResponseBodyTimeout(dur time.Duration) RequestOption {
+	if dur < 0 {
+		panic("option: response body timeout cannot be negative")
+	}
+	return requestconfig.RequestOptionFunc(func(r *requestconfig.RequestConfig) error {
+		r.ResponseBodyTimeout = dur
 		return nil
 	})
 }

--- a/option/requestoption.go
+++ b/option/requestoption.go
@@ -262,10 +262,9 @@ func WithResponseInto(dst **http.Response) RequestOption {
 // WithMaxResponseBodyBytes returns a RequestOption that limits the number of
 // bytes buffered or decoded for a successful non-streaming response. For
 // transparently decompressed gzip responses, the limit applies independently to
-// compressed wire bytes and decoded bytes. The default is 64 MiB for most
-// responses. Services documented to return larger payloads may apply a higher
-// finite default before client and request options. Raw *http.Response bodies
-// are not subject to this limit.
+// compressed wire bytes and decoded bytes. Successful responses are unbounded
+// by default to preserve compatibility with large API payloads. Raw
+// *http.Response bodies are not subject to this limit.
 //
 // WithMaxResponseBodyBytes panics unless maxBytes is between 1 and
 // [math.MaxInt64] - 1.
@@ -298,8 +297,9 @@ func WithMaxErrorResponseBodyBytes(maxBytes int64) RequestOption {
 
 // WithResponseBodyTimeout returns a RequestOption that bounds how long the
 // client spends reading a non-streaming response body after receiving response
-// headers. The default is 10 minutes. A zero duration disables this timeout.
-// Raw *http.Response bodies are not subject to this timeout.
+// headers. The timeout is disabled by default, leaving the caller's context in
+// control. A zero duration also disables this timeout. Raw *http.Response bodies
+// are not subject to this timeout.
 //
 // WithResponseBodyTimeout panics when dur is negative.
 func WithResponseBodyTimeout(dur time.Duration) RequestOption {

--- a/option/requestoption.go
+++ b/option/requestoption.go
@@ -281,7 +281,8 @@ func WithMaxResponseBodyBytes(maxBytes int64) RequestOption {
 // WithMaxErrorResponseBodyBytes returns a RequestOption that limits the number
 // of response-body bytes retained when the server returns an HTTP error. For
 // transparently decompressed gzip responses, compressed wire bytes are bounded
-// by the same limit. The default is 64 KiB.
+// by the same limit. Error responses are unbounded by default to preserve
+// compatibility with complete structured errors and response diagnostics.
 //
 // WithMaxErrorResponseBodyBytes panics unless maxBytes is between 1 and
 // [math.MaxInt64] - 1.

--- a/response_compatibility_test.go
+++ b/response_compatibility_test.go
@@ -85,6 +85,36 @@ func TestExecutePreservesLargeBinaryDownloadsByDefault(t *testing.T) {
 	}
 }
 
+func TestExecutePreservesLargeStructuredErrorsByDefault(t *testing.T) {
+	const detailBytes = 96 << 10
+	detail := strings.Repeat("x", detailBytes)
+	errorJSON := `{"error":{"message":"request rejected","type":"invalid_request_error","diagnostic":"` + detail + `"}}`
+	client := newResponseLimitClient(
+		io.NopCloser(strings.NewReader(errorJSON)),
+		http.StatusBadRequest,
+		"application/json",
+	)
+
+	var response map[string]any
+	err := client.Get(context.Background(), "large-error", nil, &response)
+	apiErr, ok := err.(*openai.Error)
+	if !ok {
+		t.Fatalf("Get() error type = %T, want unwrapped *openai.Error", err)
+	}
+	if apiErr.Message != "request rejected" {
+		t.Fatalf("API error message = %q, want request rejected", apiErr.Message)
+	}
+	if got := apiErr.JSON.ExtraFields["diagnostic"].Raw(); got != `"`+detail+`"` {
+		t.Fatalf("diagnostic raw length = %d, want %d", len(got), len(detail)+2)
+	}
+	if !strings.Contains(apiErr.RawJSON(), detail) {
+		t.Fatal("RawJSON lost the complete oversized diagnostic")
+	}
+	if !bytes.Contains(apiErr.DumpResponse(true), []byte(errorJSON)) {
+		t.Fatal("DumpResponse lost the complete oversized error response")
+	}
+}
+
 func TestExecutePreservesDisabledCompressionBehindOpaqueTransport(t *testing.T) {
 	for _, customDoer := range []bool{false, true} {
 		name := "HTTP client transport"

--- a/response_compatibility_test.go
+++ b/response_compatibility_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -98,7 +99,7 @@ func TestExecutePreservesLargeStructuredErrorsByDefault(t *testing.T) {
 	var response map[string]any
 	err := client.Get(context.Background(), "large-error", nil, &response)
 	var apiErr *openai.Error
-	if !errors.As(err, &apiErr) || err != apiErr {
+	if reflect.TypeOf(err) != reflect.TypeOf(apiErr) || !errors.As(err, &apiErr) {
 		t.Fatalf("Get() error type = %T, want unwrapped *openai.Error", err)
 	}
 	if apiErr.Message != "request rejected" {
@@ -112,6 +113,83 @@ func TestExecutePreservesLargeStructuredErrorsByDefault(t *testing.T) {
 	}
 	if !bytes.Contains(apiErr.DumpResponse(true), []byte(errorJSON)) {
 		t.Fatal("DumpResponse lost the complete oversized error response")
+	}
+}
+
+func TestExecutePreservesOpaqueTransportCompressionWithoutApplicableLimit(t *testing.T) {
+	tests := []struct {
+		name         string
+		customDoer   bool
+		raw          bool
+		successLimit bool
+	}{
+		{name: "HTTP client typed response"},
+		{name: "custom doer typed response", customDoer: true},
+		{name: "HTTP client raw response", raw: true},
+		{name: "custom doer raw response", customDoer: true, raw: true},
+		{name: "HTTP client raw response with inapplicable success limit", raw: true, successLimit: true},
+		{name: "custom doer raw response with inapplicable success limit", customDoer: true, raw: true, successLimit: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			acceptEncoding := make(chan string, 1)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				acceptEncoding <- req.Header.Get("Accept-Encoding")
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("Content-Encoding", "gzip")
+				compressed := gzip.NewWriter(w)
+				if _, err := io.WriteString(compressed, "{}"); err != nil {
+					t.Errorf("write gzip response: %v", err)
+				}
+				if err := compressed.Close(); err != nil {
+					t.Errorf("close gzip response: %v", err)
+				}
+			}))
+			defer server.Close()
+
+			native := server.Client().Transport
+			httpClient := &http.Client{Transport: responseRoundTripperFunc(native.RoundTrip)}
+			var selectedClient option.HTTPClient = httpClient
+			if test.customDoer {
+				selectedClient = responseDoerFunc(httpClient.Do)
+			}
+			opts := []option.RequestOption{
+				option.WithAPIKey("test-key"),
+				option.WithBaseURL(server.URL + "/"),
+				option.WithMaxRetries(0),
+				option.WithHTTPClient(selectedClient),
+			}
+			if test.successLimit {
+				opts = append(opts, option.WithMaxResponseBodyBytes(1))
+			}
+			client := openai.NewClient(opts...)
+
+			if test.raw {
+				var raw *http.Response
+				if err := client.Get(context.Background(), "default-gzip", nil, &raw); err != nil {
+					t.Fatalf("Get() raw error = %v", err)
+				}
+				decoded, err := io.ReadAll(raw.Body)
+				if err != nil {
+					t.Fatalf("read raw response: %v", err)
+				}
+				if err := raw.Body.Close(); err != nil {
+					t.Fatalf("close raw response: %v", err)
+				}
+				if string(decoded) != "{}" {
+					t.Fatalf("raw decoded response = %q, want {}", decoded)
+				}
+			} else {
+				var response map[string]any
+				if err := client.Get(context.Background(), "default-gzip", nil, &response); err != nil {
+					t.Fatalf("Get() typed error = %v", err)
+				}
+			}
+			if got := <-acceptEncoding; got != "gzip" {
+				t.Fatalf("Accept-Encoding = %q, want native gzip preserved", got)
+			}
+		})
 	}
 }
 

--- a/response_compatibility_test.go
+++ b/response_compatibility_test.go
@@ -97,8 +97,8 @@ func TestExecutePreservesLargeStructuredErrorsByDefault(t *testing.T) {
 
 	var response map[string]any
 	err := client.Get(context.Background(), "large-error", nil, &response)
-	apiErr, ok := err.(*openai.Error)
-	if !ok {
+	var apiErr *openai.Error
+	if !errors.As(err, &apiErr) || err != apiErr {
 		t.Fatalf("Get() error type = %T, want unwrapped *openai.Error", err)
 	}
 	if apiErr.Message != "request rejected" {

--- a/response_compatibility_test.go
+++ b/response_compatibility_test.go
@@ -1,0 +1,106 @@
+package openai_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+	"github.com/openai/openai-go/v3/responses"
+)
+
+func TestResponsesPreservesLargeImageGenerationOutputsByDefault(t *testing.T) {
+	const imageCount = 3
+	const encodedImageBytes int64 = 24 << 20
+
+	parts := []io.Reader{strings.NewReader(`{"id":"resp_test","object":"response","output":[`)}
+	for i := 0; i < imageCount; i++ {
+		if i != 0 {
+			parts = append(parts, strings.NewReader(","))
+		}
+		parts = append(parts,
+			strings.NewReader(`{"id":"ig_test","type":"image_generation_call","status":"completed","result":"`),
+			io.LimitReader(repeatedByteReader('A'), encodedImageBytes),
+			strings.NewReader(`"}`),
+		)
+	}
+	parts = append(parts, strings.NewReader(`]}`))
+
+	client := newResponseLimitClient(
+		io.NopCloser(io.MultiReader(parts...)),
+		http.StatusOK,
+		"application/json",
+	)
+	var responseBody []byte
+	_, err := client.Responses.New(
+		context.Background(),
+		responses.ResponseNewParams{Model: "gpt-4o-mini"},
+		option.WithResponseBodyInto(&responseBody),
+	)
+	if err != nil {
+		t.Fatalf("Responses.New() error = %v, want large image-generation output preserved", err)
+	}
+	if int64(len(responseBody)) <= 64<<20 {
+		t.Fatalf("response length = %d, want more than the former 64 MiB default", len(responseBody))
+	}
+}
+
+func TestExecutePreservesLargeBinaryDownloadsByDefault(t *testing.T) {
+	const downloadBytes int64 = 64<<20 + 1
+	client := newResponseLimitClient(
+		io.NopCloser(io.LimitReader(repeatedByteReader('x'), downloadBytes)),
+		http.StatusOK,
+		"application/octet-stream",
+	)
+	var data []byte
+	err := client.Get(
+		context.Background(),
+		"files/file_test/content",
+		nil,
+		&data,
+		option.WithHeader("Accept", "application/binary"),
+	)
+	if err != nil {
+		t.Fatalf("Get() error = %v, want large binary download preserved", err)
+	}
+	if int64(len(data)) != downloadBytes {
+		t.Fatalf("download length = %d, want %d", len(data), downloadBytes)
+	}
+}
+
+func TestExecutePreservesDisabledCompressionBehindOpaqueTransport(t *testing.T) {
+	acceptEncoding := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		acceptEncoding <- req.Header.Get("Accept-Encoding")
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := io.WriteString(w, "{}"); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	transport := server.Client().Transport.(*http.Transport).Clone()
+	transport.DisableCompression = true
+	client := openai.NewClient(
+		option.WithAPIKey("test-key"),
+		option.WithBaseURL(server.URL+"/"),
+		option.WithMaxRetries(0),
+		option.WithMaxResponseBodyBytes(2),
+		option.WithHTTPClient(&http.Client{
+			Transport: responseRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				return transport.RoundTrip(req)
+			}),
+		}),
+	)
+	var response map[string]any
+	if err := client.Get(context.Background(), "wrapped", nil, &response); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if got := <-acceptEncoding; got != "" {
+		t.Fatalf("Accept-Encoding = %q, want wrapped disabled-compression policy preserved", got)
+	}
+}

--- a/response_compatibility_test.go
+++ b/response_compatibility_test.go
@@ -23,6 +23,213 @@ type managedCompressionRoundTripper struct {
 
 func (managedCompressionRoundTripper) CompressionDisabled() bool { return false }
 
+type responseReadResult struct {
+	contents string
+	err      error
+}
+
+func TestExecutePreservesJSONResponseReadErrors(t *testing.T) {
+	readFailure := errors.New("injected response read failure")
+	tests := []struct {
+		name  string
+		reads []responseReadResult
+		limit int64
+		want  error
+	}{
+		{
+			name:  "data and unexpected EOF with defaults",
+			reads: []responseReadResult{{contents: `{"ok":true}`, err: io.ErrUnexpectedEOF}},
+			want:  io.ErrUnexpectedEOF,
+		},
+		{
+			name:  "data and unexpected EOF with explicit limit",
+			reads: []responseReadResult{{contents: `{"ok":true}`, err: io.ErrUnexpectedEOF}},
+			limit: 64,
+			want:  io.ErrUnexpectedEOF,
+		},
+		{
+			name:  "data and custom error with defaults",
+			reads: []responseReadResult{{contents: `{"ok":true}`, err: readFailure}},
+			want:  readFailure,
+		},
+		{
+			name: "complete JSON followed by read error",
+			reads: []responseReadResult{
+				{contents: `{"ok":true}`},
+				{err: readFailure},
+			},
+			want: readFailure,
+		},
+		{
+			name:  "read error takes precedence over malformed JSON",
+			reads: []responseReadResult{{contents: `{"ok":`, err: readFailure}},
+			want:  readFailure,
+		},
+		{
+			name:  "data and ordinary EOF with defaults",
+			reads: []responseReadResult{{contents: `{"ok":true}`, err: io.EOF}},
+		},
+		{
+			name:  "data and ordinary EOF with explicit limit",
+			reads: []responseReadResult{{contents: `{"ok":true}`, err: io.EOF}},
+			limit: 64,
+		},
+		{
+			name:  "trailing data remains compatible",
+			reads: []responseReadResult{{contents: `{"ok":true} ignored trailing data`, err: io.EOF}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			reads := append([]responseReadResult(nil), test.reads...)
+			body := readerFunc(func(p []byte) (int, error) {
+				if len(reads) == 0 {
+					return 0, io.EOF
+				}
+				read := &reads[0]
+				n := copy(p, read.contents)
+				read.contents = read.contents[n:]
+				if len(read.contents) != 0 {
+					return n, nil
+				}
+				err := read.err
+				reads = reads[1:]
+				return n, err
+			})
+			var opts []option.RequestOption
+			if test.limit != 0 {
+				opts = append(opts, option.WithMaxResponseBodyBytes(test.limit))
+			}
+			client := newResponseLimitClient(
+				body,
+				http.StatusOK,
+				"application/json",
+				opts...,
+			)
+			var response struct {
+				OK bool `json:"ok"`
+			}
+
+			err := client.Get(context.Background(), "read-error", nil, &response)
+			if test.want != nil {
+				if !errors.Is(err, test.want) {
+					t.Fatalf("Get() error = %v, want wrapped %v", err, test.want)
+				}
+				if !strings.Contains(err.Error(), "error reading response body") {
+					t.Fatalf("Get() error = %v, want response body read error", err)
+				}
+				if response.OK {
+					t.Fatal("failed response mutated its destination")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Get() error = %v, want successful response", err)
+			}
+			if !response.OK {
+				t.Fatal("successful response did not populate its destination")
+			}
+		})
+	}
+}
+
+func TestResponsesPreservesJSONReadFailures(t *testing.T) {
+	readFailure := errors.New("injected response read failure")
+	read := false
+	body := readerFunc(func(p []byte) (int, error) {
+		if read {
+			return 0, io.EOF
+		}
+		read = true
+		return copy(p, `{"id":"resp_test","object":"response"}`), readFailure
+	})
+	client := newResponseLimitClient(body, http.StatusOK, "application/json")
+
+	response, err := client.Responses.New(
+		context.Background(),
+		responses.ResponseNewParams{Model: "gpt-4o-mini"},
+	)
+	if !errors.Is(err, readFailure) {
+		t.Fatalf("Responses.New() error = %v, want wrapped %v", err, readFailure)
+	}
+	if response != nil {
+		t.Fatal("failed response returned a partially decoded model")
+	}
+}
+
+func TestExecuteDoesNotPopulateOverflowingJSONResponse(t *testing.T) {
+	const completeJSON = `{"ok":true}`
+	client := newResponseLimitClient(
+		io.NopCloser(strings.NewReader(completeJSON+" trailing data")),
+		http.StatusOK,
+		"application/json",
+		option.WithMaxResponseBodyBytes(int64(len(completeJSON))),
+	)
+	var response struct {
+		OK bool `json:"ok"`
+	}
+
+	err := client.Get(context.Background(), "overflow", nil, &response)
+	if err == nil || !strings.Contains(err.Error(), "exceeded configured limit") {
+		t.Fatalf("Get() error = %v, want response body limit error", err)
+	}
+	if response.OK {
+		t.Fatal("oversized response mutated its destination")
+	}
+}
+
+func TestExecuteRejectsCorruptedGzipJSONResponse(t *testing.T) {
+	var compressed bytes.Buffer
+	writer := gzip.NewWriter(&compressed)
+	if _, err := io.WriteString(writer, `{"ok":true}`); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	compressed.Bytes()[compressed.Len()-8] ^= 0xff
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Encoding", "gzip")
+		if _, err := w.Write(compressed.Bytes()); err != nil {
+			t.Errorf("write corrupted gzip response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	for _, limit := range []int64{0, 256} {
+		name := "default transparent decompression"
+		if limit != 0 {
+			name = "explicitly bounded decompression"
+		}
+		t.Run(name, func(t *testing.T) {
+			opts := []option.RequestOption{
+				option.WithAPIKey("test-key"),
+				option.WithBaseURL(server.URL + "/"),
+				option.WithMaxRetries(0),
+				option.WithHTTPClient(server.Client()),
+			}
+			if limit != 0 {
+				opts = append(opts, option.WithMaxResponseBodyBytes(limit))
+			}
+			client := openai.NewClient(opts...)
+			var response struct {
+				OK bool `json:"ok"`
+			}
+
+			err := client.Get(context.Background(), "corrupted-gzip", nil, &response)
+			if !errors.Is(err, gzip.ErrChecksum) {
+				t.Fatalf("Get() error = %v, want wrapped gzip checksum failure", err)
+			}
+			if response.OK {
+				t.Fatal("corrupted gzip response mutated its destination")
+			}
+		})
+	}
+}
+
 func TestResponsesPreservesLargeImageGenerationOutputsByDefault(t *testing.T) {
 	const imageCount = 3
 	const encodedImageBytes int64 = 24 << 20

--- a/response_compatibility_test.go
+++ b/response_compatibility_test.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/option"
@@ -26,6 +27,83 @@ func (managedCompressionRoundTripper) CompressionDisabled() bool { return false 
 type responseReadResult struct {
 	contents string
 	err      error
+}
+
+type delayedJSONResponse struct {
+	started chan struct{}
+	release <-chan struct{}
+	decoded bool
+}
+
+func (response *delayedJSONResponse) UnmarshalJSON([]byte) error {
+	close(response.started)
+	<-response.release
+	response.decoded = true
+	return nil
+}
+
+func TestExecuteBodyTimeoutStopsBeforeJSONDecoding(t *testing.T) {
+	const bodyTimeout = 20 * time.Millisecond
+
+	for _, limit := range []int64{0, 64} {
+		name := "default body limit"
+		if limit != 0 {
+			name = "explicit body limit"
+		}
+		t.Run(name, func(t *testing.T) {
+			attemptContext := make(chan context.Context, 1)
+			opts := []option.RequestOption{
+				option.WithAPIKey("test-key"),
+				option.WithMaxRetries(0),
+				option.WithResponseBodyTimeout(bodyTimeout),
+				option.WithHTTPClient(responseDoerFunc(func(req *http.Request) (*http.Response, error) {
+					attemptContext <- req.Context()
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Header:     http.Header{"Content-Type": {"application/json"}},
+						Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+						Request:    req,
+					}, nil
+				})),
+			}
+			if limit != 0 {
+				opts = append(opts, option.WithMaxResponseBodyBytes(limit))
+			}
+			client := openai.NewClient(opts...)
+			release := make(chan struct{})
+			response := delayedJSONResponse{started: make(chan struct{}), release: release}
+			result := make(chan error, 1)
+			go func() {
+				result <- client.Get(context.Background(), "slow-json", nil, &response)
+			}()
+
+			select {
+			case <-response.started:
+			case <-time.After(time.Second):
+				close(release)
+				t.Fatal("JSON decoding did not start")
+			}
+			ctx := <-attemptContext
+			<-time.After(3 * bodyTimeout)
+			contextErrDuringDecode := ctx.Err()
+			close(release)
+
+			select {
+			case err := <-result:
+				if err != nil {
+					t.Fatalf("Get() error = %v, want JSON decoding after timely body read", err)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("Get() did not finish decoding")
+			}
+			if contextErrDuringDecode != nil {
+				t.Fatalf("attempt context during JSON decoding = %v, want active context", contextErrDuringDecode)
+			}
+			if !response.decoded {
+				t.Fatal("successful response did not populate its destination")
+			}
+		})
+	}
 }
 
 func TestExecutePreservesJSONResponseReadErrors(t *testing.T) {

--- a/response_compatibility_test.go
+++ b/response_compatibility_test.go
@@ -1,7 +1,10 @@
 package openai_test
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -12,6 +15,12 @@ import (
 	"github.com/openai/openai-go/v3/option"
 	"github.com/openai/openai-go/v3/responses"
 )
+
+type managedCompressionRoundTripper struct {
+	http.RoundTripper
+}
+
+func (managedCompressionRoundTripper) CompressionDisabled() bool { return false }
 
 func TestResponsesPreservesLargeImageGenerationOutputsByDefault(t *testing.T) {
 	const imageCount = 3
@@ -35,17 +44,21 @@ func TestResponsesPreservesLargeImageGenerationOutputsByDefault(t *testing.T) {
 		http.StatusOK,
 		"application/json",
 	)
-	var responseBody []byte
-	_, err := client.Responses.New(
+	response, err := client.Responses.New(
 		context.Background(),
 		responses.ResponseNewParams{Model: "gpt-4o-mini"},
-		option.WithResponseBodyInto(&responseBody),
 	)
 	if err != nil {
 		t.Fatalf("Responses.New() error = %v, want large image-generation output preserved", err)
 	}
-	if int64(len(responseBody)) <= 64<<20 {
-		t.Fatalf("response length = %d, want more than the former 64 MiB default", len(responseBody))
+	if len(response.Output) != imageCount {
+		t.Fatalf("image generation calls = %d, want %d", len(response.Output), imageCount)
+	}
+	for i, item := range response.Output {
+		image := item.AsImageGenerationCall()
+		if int64(len(image.Result)) != encodedImageBytes {
+			t.Fatalf("image %d result length = %d, want %d", i, len(image.Result), encodedImageBytes)
+		}
 	}
 }
 
@@ -100,7 +113,77 @@ func TestExecutePreservesDisabledCompressionBehindOpaqueTransport(t *testing.T) 
 	if err := client.Get(context.Background(), "wrapped", nil, &response); err != nil {
 		t.Fatalf("Get() error = %v", err)
 	}
-	if got := <-acceptEncoding; got != "" {
-		t.Fatalf("Accept-Encoding = %q, want wrapped disabled-compression policy preserved", got)
+	if got := <-acceptEncoding; got != "identity" {
+		t.Fatalf("Accept-Encoding = %q, want opaque transport compression safely disabled", got)
+	}
+}
+
+func TestExecuteOpaqueTransportCannotBypassCompressedWireLimit(t *testing.T) {
+	const wireLimit int64 = 64
+	var compressed bytes.Buffer
+	for i := 0; i < 8; i++ {
+		writer := gzip.NewWriter(&compressed)
+		if i == 0 {
+			if _, err := io.WriteString(writer, "{}"); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := writer.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if int64(compressed.Len()) <= wireLimit {
+		t.Fatalf("compressed fixture length = %d, want more than %d", compressed.Len(), wireLimit)
+	}
+
+	for _, status := range []int{http.StatusOK, http.StatusBadRequest} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			acceptEncoding := make(chan string, 1)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				encoding := req.Header.Get("Accept-Encoding")
+				acceptEncoding <- encoding
+				w.Header().Set("Content-Type", "application/json")
+				if strings.Contains(encoding, "gzip") {
+					w.Header().Set("Content-Encoding", "gzip")
+					w.WriteHeader(status)
+					if _, err := w.Write(compressed.Bytes()); err != nil {
+						t.Errorf("write compressed response: %v", err)
+					}
+					return
+				}
+				w.WriteHeader(status)
+				body := "{}"
+				if status >= http.StatusBadRequest {
+					body = `{"error":{"message":"bounded"}}`
+				}
+				if _, err := io.WriteString(w, body); err != nil {
+					t.Errorf("write response: %v", err)
+				}
+			}))
+			defer server.Close()
+
+			base := server.Client().Transport
+			client := openai.NewClient(
+				option.WithAPIKey("test-key"),
+				option.WithBaseURL(server.URL+"/"),
+				option.WithMaxRetries(0),
+				option.WithMaxResponseBodyBytes(wireLimit),
+				option.WithMaxErrorResponseBodyBytes(wireLimit),
+				option.WithHTTPClient(&http.Client{Transport: responseRoundTripperFunc(base.RoundTrip)}),
+			)
+			var response map[string]any
+			err := client.Get(context.Background(), "opaque", nil, &response)
+			if status >= http.StatusBadRequest {
+				var apiErr *openai.Error
+				if !errors.As(err, &apiErr) {
+					t.Fatalf("Get() error = %v, want preserved API error", err)
+				}
+			} else if err != nil {
+				t.Fatalf("Get() error = %v", err)
+			}
+			if got := <-acceptEncoding; got != "identity" {
+				t.Fatalf("Accept-Encoding = %q, want identity to prevent unaccounted native gzip", got)
+			}
+		})
 	}
 }

--- a/response_compatibility_test.go
+++ b/response_compatibility_test.go
@@ -86,35 +86,46 @@ func TestExecutePreservesLargeBinaryDownloadsByDefault(t *testing.T) {
 }
 
 func TestExecutePreservesDisabledCompressionBehindOpaqueTransport(t *testing.T) {
-	acceptEncoding := make(chan string, 1)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		acceptEncoding <- req.Header.Get("Accept-Encoding")
-		w.Header().Set("Content-Type", "application/json")
-		if _, err := io.WriteString(w, "{}"); err != nil {
-			t.Errorf("write response: %v", err)
+	for _, customDoer := range []bool{false, true} {
+		name := "HTTP client transport"
+		if customDoer {
+			name = "custom HTTP doer"
 		}
-	}))
-	defer server.Close()
+		t.Run(name, func(t *testing.T) {
+			acceptEncoding := make(chan string, 1)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				acceptEncoding <- req.Header.Get("Accept-Encoding")
+				w.Header().Set("Content-Type", "application/json")
+				if _, err := io.WriteString(w, "{}"); err != nil {
+					t.Errorf("write response: %v", err)
+				}
+			}))
+			defer server.Close()
 
-	transport := server.Client().Transport.(*http.Transport).Clone()
-	transport.DisableCompression = true
-	client := openai.NewClient(
-		option.WithAPIKey("test-key"),
-		option.WithBaseURL(server.URL+"/"),
-		option.WithMaxRetries(0),
-		option.WithMaxResponseBodyBytes(2),
-		option.WithHTTPClient(&http.Client{
-			Transport: responseRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-				return transport.RoundTrip(req)
-			}),
-		}),
-	)
-	var response map[string]any
-	if err := client.Get(context.Background(), "wrapped", nil, &response); err != nil {
-		t.Fatalf("Get() error = %v", err)
-	}
-	if got := <-acceptEncoding; got != "identity" {
-		t.Fatalf("Accept-Encoding = %q, want opaque transport compression safely disabled", got)
+			transport := server.Client().Transport.(*http.Transport).Clone()
+			transport.DisableCompression = true
+			httpClient := &http.Client{
+				Transport: responseRoundTripperFunc(transport.RoundTrip),
+			}
+			var selectedClient option.HTTPClient = httpClient
+			if customDoer {
+				selectedClient = responseDoerFunc(httpClient.Do)
+			}
+			client := openai.NewClient(
+				option.WithAPIKey("test-key"),
+				option.WithBaseURL(server.URL+"/"),
+				option.WithMaxRetries(0),
+				option.WithMaxResponseBodyBytes(2),
+				option.WithHTTPClient(selectedClient),
+			)
+			var response map[string]any
+			if err := client.Get(context.Background(), "wrapped", nil, &response); err != nil {
+				t.Fatalf("Get() error = %v", err)
+			}
+			if got := <-acceptEncoding; got != "identity" {
+				t.Fatalf("Accept-Encoding = %q, want opaque transport compression safely disabled", got)
+			}
+		})
 	}
 }
 

--- a/response_http2_test.go
+++ b/response_http2_test.go
@@ -2,6 +2,7 @@ package openai_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -31,6 +32,46 @@ func (b *stalledHTTP2ResponseBody) Close() error {
 	return err
 }
 
+func wrapStalledHTTP2ResponseBody(
+	req *http.Request,
+	res *http.Response,
+	release <-chan struct{},
+) (*stalledHTTP2ResponseBody, error) {
+	if res.ProtoMajor != 2 {
+		_ = res.Body.Close()
+		return nil, fmt.Errorf("response protocol = %s, want HTTP/2", res.Proto)
+	}
+	body := &stalledHTTP2ResponseBody{
+		ReadCloser:    res.Body,
+		attemptCtx:    req.Context(),
+		closeStarted:  make(chan struct{}),
+		releaseClose:  release,
+		closeFinished: make(chan struct{}),
+	}
+	res.Body = body
+	return body, nil
+}
+
+func newStalledHTTP2Server(t *testing.T, status int, release <-chan struct{}) *httptest.Server {
+	t.Helper()
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.ProtoMajor != 2 {
+			t.Errorf("request protocol = %s, want HTTP/2", req.Proto)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		if _, err := io.WriteString(w, `{"ok":true}`+strings.Repeat(" ", 256)); err != nil {
+			t.Errorf("write response: %v", err)
+			return
+		}
+		w.(http.Flusher).Flush()
+		<-release
+	}))
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	return server
+}
+
 func TestExecuteOverflowDoesNotWaitForStalledHTTP2Close(t *testing.T) {
 	for _, status := range []int{http.StatusOK, http.StatusBadRequest} {
 		t.Run(http.StatusText(status), func(t *testing.T) {
@@ -38,21 +79,7 @@ func TestExecuteOverflowDoesNotWaitForStalledHTTP2Close(t *testing.T) {
 			var releaseOnce sync.Once
 			release := func() { releaseOnce.Do(func() { close(releaseClose) }) }
 
-			server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-				if req.ProtoMajor != 2 {
-					t.Errorf("request protocol = %s, want HTTP/2", req.Proto)
-				}
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(status)
-				if _, err := io.WriteString(w, `{"ok":true}`+strings.Repeat(" ", 256)); err != nil {
-					t.Errorf("write response: %v", err)
-					return
-				}
-				w.(http.Flusher).Flush()
-				<-releaseClose
-			}))
-			server.EnableHTTP2 = true
-			server.StartTLS()
+			server := newStalledHTTP2Server(t, status, releaseClose)
 			defer func() {
 				release()
 				server.Close()
@@ -73,18 +100,10 @@ func TestExecuteOverflowDoesNotWaitForStalledHTTP2Close(t *testing.T) {
 						if err != nil {
 							return nil, err
 						}
-						if res.ProtoMajor != 2 {
-							_ = res.Body.Close()
-							return nil, fmt.Errorf("response protocol = %s, want HTTP/2", res.Proto)
+						body, err := wrapStalledHTTP2ResponseBody(req, res, releaseClose)
+						if err != nil {
+							return nil, err
 						}
-						body := &stalledHTTP2ResponseBody{
-							ReadCloser:    res.Body,
-							attemptCtx:    req.Context(),
-							closeStarted:  make(chan struct{}),
-							releaseClose:  releaseClose,
-							closeFinished: make(chan struct{}),
-						}
-						res.Body = body
 						bodyReady <- body
 						return res, nil
 					}),
@@ -139,6 +158,102 @@ func TestExecuteOverflowDoesNotWaitForStalledHTTP2Close(t *testing.T) {
 			}
 			if callerCtx.Err() != nil {
 				t.Fatalf("caller context ended before overflow returned: %v", callerCtx.Err())
+			}
+		})
+	}
+}
+
+func TestExecuteExpiredContextDoesNotWaitForStalledHTTP2Close(t *testing.T) {
+	tests := []struct {
+		name           string
+		requestTimeout bool
+		wantErr        error
+	}{
+		{name: "caller cancellation", wantErr: context.Canceled},
+		{name: "request timeout", requestTimeout: true, wantErr: context.DeadlineExceeded},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			releaseClose := make(chan struct{})
+			var releaseOnce sync.Once
+			release := func() { releaseOnce.Do(func() { close(releaseClose) }) }
+
+			server := newStalledHTTP2Server(t, http.StatusOK, releaseClose)
+			defer func() {
+				release()
+				server.Close()
+			}()
+
+			callerCtx, cancelCaller := context.WithTimeout(context.Background(), time.Second)
+			defer cancelCaller()
+			bodyReady := make(chan *stalledHTTP2ResponseBody, 1)
+			opts := []option.RequestOption{
+				option.WithAPIKey("test-key"),
+				option.WithBaseURL(server.URL + "/"),
+				option.WithMaxRetries(0),
+				option.WithHTTPClient(responseDoerFunc(func(req *http.Request) (*http.Response, error) {
+					res, err := server.Client().Transport.RoundTrip(req)
+					if err != nil {
+						return nil, err
+					}
+					body, err := wrapStalledHTTP2ResponseBody(req, res, releaseClose)
+					if err != nil {
+						return nil, err
+					}
+					bodyReady <- body
+					if test.requestTimeout {
+						<-req.Context().Done()
+					} else {
+						cancelCaller()
+					}
+					return res, nil
+				})),
+			}
+			if test.requestTimeout {
+				opts = append(opts, option.WithRequestTimeout(20*time.Millisecond))
+			}
+			client := openai.NewClient(opts...)
+
+			var response map[string]any
+			done := make(chan error, 1)
+			go func() {
+				done <- client.Get(callerCtx, "canceled", nil, &response)
+			}()
+
+			var body *stalledHTTP2ResponseBody
+			select {
+			case body = <-bodyReady:
+			case <-time.After(time.Second):
+				t.Fatal("HTTP/2 response was not received")
+			}
+			select {
+			case <-body.closeStarted:
+			case <-time.After(time.Second):
+				t.Fatal("expired request cleanup was not started")
+			}
+
+			var err error
+			returnedBeforeRelease := false
+			select {
+			case err = <-done:
+				returnedBeforeRelease = true
+			case <-time.After(250 * time.Millisecond):
+			}
+			release()
+			if !returnedBeforeRelease {
+				err = <-done
+			}
+			<-body.closeFinished
+
+			if !errors.Is(err, test.wantErr) {
+				t.Fatalf("Get() error = %v, want %v", err, test.wantErr)
+			}
+			if !returnedBeforeRelease {
+				t.Fatal("expired HTTP/2 request waited for a stalled body Close")
+			}
+			if test.requestTimeout && callerCtx.Err() != nil {
+				t.Fatalf("caller safety deadline expired before request timeout returned: %v", callerCtx.Err())
 			}
 		})
 	}

--- a/response_http2_test.go
+++ b/response_http2_test.go
@@ -120,7 +120,7 @@ func TestExecuteOverflowDoesNotWaitForStalledHTTP2Close(t *testing.T) {
 				}),
 			)
 
-			callerCtx, cancelCaller := context.WithTimeout(context.Background(), time.Second)
+			callerCtx, cancelCaller := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancelCaller()
 			var response map[string]any
 			done := make(chan error, 1)
@@ -198,7 +198,7 @@ func TestExecuteExpiredContextDoesNotWaitForStalledHTTP2Close(t *testing.T) {
 				server.Close()
 			}()
 
-			callerCtx, cancelCaller := context.WithTimeout(context.Background(), time.Second)
+			callerCtx, cancelCaller := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancelCaller()
 			bodyReady := make(chan *stalledHTTP2ResponseBody, 1)
 			opts := []option.RequestOption{
@@ -228,7 +228,7 @@ func TestExecuteExpiredContextDoesNotWaitForStalledHTTP2Close(t *testing.T) {
 				})),
 			}
 			if test.requestTimeout {
-				opts = append(opts, option.WithRequestTimeout(20*time.Millisecond))
+				opts = append(opts, option.WithRequestTimeout(500*time.Millisecond))
 			}
 			client := openai.NewClient(opts...)
 
@@ -241,12 +241,12 @@ func TestExecuteExpiredContextDoesNotWaitForStalledHTTP2Close(t *testing.T) {
 			var body *stalledHTTP2ResponseBody
 			select {
 			case body = <-bodyReady:
-			case <-time.After(time.Second):
+			case <-time.After(5 * time.Second):
 				t.Fatal("HTTP/2 response was not received")
 			}
 			select {
 			case <-body.closeStarted:
-			case <-time.After(time.Second):
+			case <-time.After(5 * time.Second):
 				t.Fatal("expired request cleanup was not started")
 			}
 
@@ -311,12 +311,12 @@ func TestExecuteUnownedResponseDoesNotWaitForStalledHTTP2Close(t *testing.T) {
 	var body *stalledHTTP2ResponseBody
 	select {
 	case body = <-bodyReady:
-	case <-time.After(time.Second):
+	case <-time.After(5 * time.Second):
 		t.Fatal("HTTP/2 response was not received")
 	}
 	select {
 	case <-body.closeStarted:
-	case <-time.After(time.Second):
+	case <-time.After(5 * time.Second):
 		t.Fatal("unowned response cleanup was not started")
 	}
 

--- a/response_http2_test.go
+++ b/response_http2_test.go
@@ -69,6 +69,9 @@ func newStalledHTTP2Server(t *testing.T, status int, release <-chan struct{}) *h
 			t.Errorf("request protocol = %s, want HTTP/2", req.Proto)
 		}
 		w.Header().Set("Content-Type", "application/json")
+		if status == http.StatusTooManyRequests {
+			w.Header().Set("Retry-After-Ms", "2000")
+		}
 		w.WriteHeader(status)
 		if _, err := io.WriteString(w, `{"ok":true}`+strings.Repeat(" ", 256)); err != nil {
 			t.Errorf("write response: %v", err)
@@ -341,5 +344,98 @@ func TestExecuteUnownedResponseDoesNotWaitForStalledHTTP2Close(t *testing.T) {
 	}
 	if !returnedBeforeRelease {
 		t.Fatal("unowned HTTP/2 response waited for a stalled body Close")
+	}
+}
+
+func TestExecuteRetryDoesNotWaitForStalledHTTP2Close(t *testing.T) {
+	tests := []struct {
+		name           string
+		requestTimeout bool
+	}{
+		{name: "caller deadline"},
+		{name: "request attempt deadline", requestTimeout: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			releaseClose := make(chan struct{})
+			var releaseOnce sync.Once
+			release := func() { releaseOnce.Do(func() { close(releaseClose) }) }
+			server := newStalledHTTP2Server(t, http.StatusTooManyRequests, releaseClose)
+			defer func() {
+				release()
+				server.Close()
+			}()
+
+			deadline := 500 * time.Millisecond
+			callerTimeout := deadline
+			if test.requestTimeout {
+				callerTimeout = 5 * time.Second
+			}
+			callerCtx, cancelCaller := context.WithTimeout(context.Background(), callerTimeout)
+			defer cancelCaller()
+			bodyReady := make(chan *stalledHTTP2ResponseBody, 1)
+			opts := []option.RequestOption{
+				option.WithAPIKey("test-key"),
+				option.WithBaseURL(server.URL + "/"),
+				option.WithMaxRetries(1),
+				option.WithMaxRetryDelay(2 * time.Second),
+				option.WithHTTPClient(responseDoerFunc(func(req *http.Request) (*http.Response, error) {
+					res, err := server.Client().Transport.RoundTrip(req)
+					if err != nil {
+						return nil, err
+					}
+					body, err := wrapStalledHTTP2ResponseBody(req, res, releaseClose)
+					if err != nil {
+						return nil, err
+					}
+					bodyReady <- body
+					return res, nil
+				})),
+			}
+			if test.requestTimeout {
+				opts = append(opts, option.WithRequestTimeout(deadline))
+			}
+			client := openai.NewClient(opts...)
+			done := make(chan error, 1)
+			go func() {
+				var response map[string]any
+				done <- client.Get(callerCtx, "retry", nil, &response)
+			}()
+
+			var body *stalledHTTP2ResponseBody
+			select {
+			case body = <-bodyReady:
+			case <-time.After(5 * time.Second):
+				t.Fatal("retryable HTTP/2 response was not received")
+			}
+			select {
+			case <-body.closeStarted:
+			case <-time.After(5 * time.Second):
+				t.Fatal("retry response cleanup was not started")
+			}
+
+			var err error
+			returnedBeforeRelease := false
+			select {
+			case err = <-done:
+				returnedBeforeRelease = true
+			case <-time.After(2 * deadline):
+			}
+			release()
+			if !returnedBeforeRelease {
+				err = <-done
+			}
+			<-body.closeFinished
+			if !errors.Is(err, context.DeadlineExceeded) {
+				t.Fatalf("Get() error = %v, want deadline exceeded", err)
+			}
+			if !returnedBeforeRelease {
+				t.Fatal("retry waited for a stalled HTTP/2 body Close")
+			}
+			if test.requestTimeout && callerCtx.Err() != nil {
+				t.Fatalf("retry wait ignored attempt deadline: %v", callerCtx.Err())
+			}
+		})
 	}
 }

--- a/response_http2_test.go
+++ b/response_http2_test.go
@@ -176,6 +176,105 @@ func TestExecuteOverflowDoesNotWaitForStalledHTTP2Close(t *testing.T) {
 	}
 }
 
+func TestExecuteMalformedGzipDoesNotWaitForStalledHTTP2Close(t *testing.T) {
+	releaseClose := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseClose) }) }
+
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.ProtoMajor != 2 {
+			t.Errorf("request protocol = %s, want HTTP/2", req.Proto)
+		}
+		if got := req.Header.Get("Accept-Encoding"); got != "gzip" {
+			t.Errorf("Accept-Encoding = %q, want gzip", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Encoding", "gzip")
+		if _, err := io.WriteString(w, "invalid gzip header"+strings.Repeat("x", 256)); err != nil {
+			t.Errorf("write malformed gzip response: %v", err)
+			return
+		}
+		w.(http.Flusher).Flush()
+		<-releaseClose
+	}))
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	defer func() {
+		release()
+		server.Close()
+	}()
+
+	bodyReady := make(chan *stalledHTTP2ResponseBody, 1)
+	nativeTransport := server.Client().Transport
+	transport := managedCompressionRoundTripper{RoundTripper: responseRoundTripperFunc(
+		func(req *http.Request) (*http.Response, error) {
+			res, err := nativeTransport.RoundTrip(req)
+			if err != nil {
+				return nil, err
+			}
+			body, err := wrapStalledHTTP2ResponseBody(req, res, releaseClose)
+			if err != nil {
+				return nil, err
+			}
+			bodyReady <- body
+			return res, nil
+		},
+	)}
+	client := openai.NewClient(
+		option.WithAPIKey("test-key"),
+		option.WithBaseURL(server.URL+"/"),
+		option.WithMaxRetries(0),
+		option.WithResponseBodyTimeout(20*time.Millisecond),
+		option.WithHTTPClient(&http.Client{Transport: transport}),
+	)
+
+	callerCtx, cancelCaller := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelCaller()
+	done := make(chan error, 1)
+	go func() {
+		var response map[string]any
+		done <- client.Get(callerCtx, "malformed-gzip", nil, &response)
+	}()
+
+	var body *stalledHTTP2ResponseBody
+	select {
+	case body = <-bodyReady:
+	case <-callerCtx.Done():
+		t.Fatal("malformed HTTP/2 response was not received")
+	}
+	select {
+	case <-body.closeStarted:
+	case <-callerCtx.Done():
+		t.Fatal("malformed HTTP/2 response cleanup was not started")
+	}
+
+	var err error
+	returnedBeforeRelease := false
+	select {
+	case err = <-done:
+		returnedBeforeRelease = true
+	case <-time.After(250 * time.Millisecond):
+	}
+	if returnedBeforeRelease && body.attemptCtx.Err() == nil {
+		t.Fatal("malformed gzip returned before canceling the HTTP/2 attempt")
+	}
+	release()
+	if !returnedBeforeRelease {
+		err = <-done
+	}
+	<-body.closeFinished
+
+	if err == nil || !strings.Contains(err.Error(), "gzip: invalid header") {
+		t.Fatalf("Get() error = %v, want malformed gzip error", err)
+	}
+	if !returnedBeforeRelease {
+		t.Fatal("malformed HTTP/2 gzip response waited for a stalled body Close")
+	}
+	if callerCtx.Err() != nil {
+		t.Fatalf("caller context ended before gzip error returned: %v", callerCtx.Err())
+	}
+}
+
 func TestExecuteExpiredContextDoesNotWaitForStalledHTTP2Close(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/response_http2_test.go
+++ b/response_http2_test.go
@@ -24,6 +24,16 @@ type stalledHTTP2ResponseBody struct {
 	closeFinished chan struct{}
 }
 
+type canceledHTTP2ResponseBody struct {
+	*stalledHTTP2ResponseBody
+	endAttempt func()
+}
+
+func (b *canceledHTTP2ResponseBody) Read([]byte) (int, error) {
+	b.endAttempt()
+	return 0, b.attemptCtx.Err()
+}
+
 func (b *stalledHTTP2ResponseBody) Close() error {
 	close(b.closeStarted)
 	<-b.releaseClose
@@ -167,10 +177,13 @@ func TestExecuteExpiredContextDoesNotWaitForStalledHTTP2Close(t *testing.T) {
 	tests := []struct {
 		name           string
 		requestTimeout bool
+		duringRead     bool
 		wantErr        error
 	}{
-		{name: "caller cancellation", wantErr: context.Canceled},
-		{name: "request timeout", requestTimeout: true, wantErr: context.DeadlineExceeded},
+		{name: "caller cancellation after response", wantErr: context.Canceled},
+		{name: "caller cancellation during read", duringRead: true, wantErr: context.Canceled},
+		{name: "request timeout after response", requestTimeout: true, wantErr: context.DeadlineExceeded},
+		{name: "request timeout during read", requestTimeout: true, duringRead: true, wantErr: context.DeadlineExceeded},
 	}
 
 	for _, test := range tests {
@@ -202,10 +215,14 @@ func TestExecuteExpiredContextDoesNotWaitForStalledHTTP2Close(t *testing.T) {
 						return nil, err
 					}
 					bodyReady <- body
+					endAttempt := cancelCaller
 					if test.requestTimeout {
-						<-req.Context().Done()
+						endAttempt = func() { <-req.Context().Done() }
+					}
+					if test.duringRead {
+						res.Body = &canceledHTTP2ResponseBody{stalledHTTP2ResponseBody: body, endAttempt: endAttempt}
 					} else {
-						cancelCaller()
+						endAttempt()
 					}
 					return res, nil
 				})),
@@ -256,5 +273,73 @@ func TestExecuteExpiredContextDoesNotWaitForStalledHTTP2Close(t *testing.T) {
 				t.Fatalf("caller safety deadline expired before request timeout returned: %v", callerCtx.Err())
 			}
 		})
+	}
+}
+
+func TestExecuteUnownedResponseDoesNotWaitForStalledHTTP2Close(t *testing.T) {
+	releaseClose := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseClose) }) }
+	server := newStalledHTTP2Server(t, http.StatusOK, releaseClose)
+	defer func() {
+		release()
+		server.Close()
+	}()
+
+	bodyReady := make(chan *stalledHTTP2ResponseBody, 1)
+	client := openai.NewClient(
+		option.WithAPIKey("test-key"),
+		option.WithBaseURL(server.URL+"/"),
+		option.WithMaxRetries(0),
+		option.WithHTTPClient(responseDoerFunc(func(req *http.Request) (*http.Response, error) {
+			res, err := server.Client().Transport.RoundTrip(req)
+			if err != nil {
+				return nil, err
+			}
+			body, err := wrapStalledHTTP2ResponseBody(req, res, releaseClose)
+			if err != nil {
+				return nil, err
+			}
+			bodyReady <- body
+			return res, nil
+		})),
+	)
+
+	done := make(chan error, 1)
+	go func() { done <- client.Get(context.Background(), "discard", nil, nil) }()
+
+	var body *stalledHTTP2ResponseBody
+	select {
+	case body = <-bodyReady:
+	case <-time.After(time.Second):
+		t.Fatal("HTTP/2 response was not received")
+	}
+	select {
+	case <-body.closeStarted:
+	case <-time.After(time.Second):
+		t.Fatal("unowned response cleanup was not started")
+	}
+
+	var err error
+	returnedBeforeRelease := false
+	select {
+	case err = <-done:
+		returnedBeforeRelease = true
+	case <-time.After(250 * time.Millisecond):
+	}
+	if returnedBeforeRelease && body.attemptCtx.Err() == nil {
+		t.Fatal("unowned response returned before canceling its attempt context")
+	}
+	release()
+	if !returnedBeforeRelease {
+		err = <-done
+	}
+	<-body.closeFinished
+
+	if err != nil {
+		t.Fatalf("Get() error = %v, want nil", err)
+	}
+	if !returnedBeforeRelease {
+		t.Fatal("unowned HTTP/2 response waited for a stalled body Close")
 	}
 }

--- a/response_http2_test.go
+++ b/response_http2_test.go
@@ -1,0 +1,145 @@
+package openai_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+)
+
+type stalledHTTP2ResponseBody struct {
+	io.ReadCloser
+	attemptCtx    context.Context
+	closeStarted  chan struct{}
+	releaseClose  <-chan struct{}
+	closeFinished chan struct{}
+}
+
+func (b *stalledHTTP2ResponseBody) Close() error {
+	close(b.closeStarted)
+	<-b.releaseClose
+	err := b.ReadCloser.Close()
+	close(b.closeFinished)
+	return err
+}
+
+func TestExecuteOverflowDoesNotWaitForStalledHTTP2Close(t *testing.T) {
+	for _, status := range []int{http.StatusOK, http.StatusBadRequest} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			releaseClose := make(chan struct{})
+			var releaseOnce sync.Once
+			release := func() { releaseOnce.Do(func() { close(releaseClose) }) }
+
+			server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				if req.ProtoMajor != 2 {
+					t.Errorf("request protocol = %s, want HTTP/2", req.Proto)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(status)
+				if _, err := io.WriteString(w, `{"ok":true}`+strings.Repeat(" ", 256)); err != nil {
+					t.Errorf("write response: %v", err)
+					return
+				}
+				w.(http.Flusher).Flush()
+				<-releaseClose
+			}))
+			server.EnableHTTP2 = true
+			server.StartTLS()
+			defer func() {
+				release()
+				server.Close()
+			}()
+
+			bodyReady := make(chan *stalledHTTP2ResponseBody, 1)
+			nativeTransport := server.Client().Transport
+			client := openai.NewClient(
+				option.WithAPIKey("test-key"),
+				option.WithBaseURL(server.URL+"/"),
+				option.WithMaxRetries(0),
+				option.WithMaxResponseBodyBytes(8),
+				option.WithMaxErrorResponseBodyBytes(8),
+				option.WithResponseBodyTimeout(20*time.Millisecond),
+				option.WithHTTPClient(&http.Client{
+					Transport: responseRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+						res, err := nativeTransport.RoundTrip(req)
+						if err != nil {
+							return nil, err
+						}
+						if res.ProtoMajor != 2 {
+							_ = res.Body.Close()
+							return nil, fmt.Errorf("response protocol = %s, want HTTP/2", res.Proto)
+						}
+						body := &stalledHTTP2ResponseBody{
+							ReadCloser:    res.Body,
+							attemptCtx:    req.Context(),
+							closeStarted:  make(chan struct{}),
+							releaseClose:  releaseClose,
+							closeFinished: make(chan struct{}),
+						}
+						res.Body = body
+						bodyReady <- body
+						return res, nil
+					}),
+				}),
+			)
+
+			callerCtx, cancelCaller := context.WithTimeout(context.Background(), time.Second)
+			defer cancelCaller()
+			var response map[string]any
+			done := make(chan error, 1)
+			go func() {
+				done <- client.Get(callerCtx, "overflow", nil, &response)
+			}()
+
+			var body *stalledHTTP2ResponseBody
+			select {
+			case body = <-bodyReady:
+			case <-callerCtx.Done():
+				t.Fatal("HTTP/2 response was not received")
+			}
+			select {
+			case <-body.closeStarted:
+			case <-callerCtx.Done():
+				t.Fatal("overflow response cleanup was not started")
+			}
+
+			var err error
+			returnedBeforeRelease := false
+			select {
+			case err = <-done:
+				returnedBeforeRelease = true
+			case <-time.After(250 * time.Millisecond):
+			}
+			if returnedBeforeRelease {
+				select {
+				case <-body.attemptCtx.Done():
+				default:
+					t.Fatal("overflow returned before canceling the HTTP/2 attempt")
+				}
+			}
+			release()
+			if !returnedBeforeRelease {
+				err = <-done
+			}
+			<-body.closeFinished
+
+			if err == nil || !strings.Contains(err.Error(), "exceeded configured limit of 8 bytes") {
+				t.Fatalf("Get() error = %v, want response body limit error", err)
+			}
+			if !returnedBeforeRelease {
+				t.Fatal("HTTP/2 response overflow waited for a stalled body Close")
+			}
+			if callerCtx.Err() != nil {
+				t.Fatalf("caller context ended before overflow returned: %v", callerCtx.Err())
+			}
+		})
+	}
+}

--- a/response_limits_test.go
+++ b/response_limits_test.go
@@ -113,14 +113,18 @@ func (b *contextResponseBody) closeCount() int {
 }
 
 type closeContextResponseBody struct {
-	ctx context.Context
-	err error
+	ctx    context.Context
+	reader io.Reader
+	err    error
 
 	closed             bool
 	contextDoneOnClose bool
 }
 
-func (b *closeContextResponseBody) Read([]byte) (int, error) {
+func (b *closeContextResponseBody) Read(p []byte) (int, error) {
+	if b.reader != nil {
+		return b.reader.Read(p)
+	}
 	return 0, io.EOF
 }
 
@@ -134,13 +138,19 @@ type closeContextResponseDoer struct {
 	ctx      context.Context
 	body     *closeContextResponseBody
 	closeErr error
+	status   int
+	contents string
 }
 
 func (d *closeContextResponseDoer) Do(req *http.Request) (*http.Response, error) {
 	d.ctx = req.Context()
-	d.body = &closeContextResponseBody{ctx: d.ctx, err: d.closeErr}
+	d.body = &closeContextResponseBody{ctx: d.ctx, reader: strings.NewReader(d.contents), err: d.closeErr}
+	status := d.status
+	if status == 0 {
+		status = http.StatusOK
+	}
 	return &http.Response{
-		StatusCode: http.StatusOK,
+		StatusCode: status,
 		Header:     http.Header{"Content-Type": {"application/json"}},
 		Body:       d.body,
 		Request:    req,
@@ -155,6 +165,37 @@ func newCloseContextResponseClient(closeErr error) (openai.Client, *closeContext
 		option.WithHTTPClient(doer),
 	)
 	return client, doer
+}
+
+type blockingCloseContextResponseBody struct {
+	ctx           context.Context
+	releaseClose  chan struct{}
+	closeFinished chan struct{}
+	closeOnce     sync.Once
+
+	contextDoneOnClose bool
+}
+
+func newBlockingCloseContextResponseBody(ctx context.Context) *blockingCloseContextResponseBody {
+	return &blockingCloseContextResponseBody{
+		ctx:           ctx,
+		releaseClose:  make(chan struct{}),
+		closeFinished: make(chan struct{}),
+	}
+}
+
+func (b *blockingCloseContextResponseBody) Read([]byte) (int, error) {
+	<-b.ctx.Done()
+	return 0, b.ctx.Err()
+}
+
+func (b *blockingCloseContextResponseBody) Close() error {
+	b.closeOnce.Do(func() {
+		b.contextDoneOnClose = b.ctx.Err() != nil
+		<-b.releaseClose
+		close(b.closeFinished)
+	})
+	return nil
 }
 
 type repeatedByteReader byte
@@ -486,6 +527,70 @@ func TestExecuteRawResponseClosesBodyBeforeCancelingAttemptContext(t *testing.T)
 	}
 }
 
+func TestExecuteRawReadAllRetainsAttemptContextUntilClose(t *testing.T) {
+	client, doer := newCloseContextResponseClient(nil)
+	doer.contents = `{}`
+
+	var raw *http.Response
+	if err := client.Get(context.Background(), "test", nil, &raw); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.ReadAll(raw.Body); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-doer.ctx.Done():
+		t.Fatal("attempt context canceled at EOF before raw body Close")
+	default:
+	}
+	if err := raw.Body.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if doer.body.contextDoneOnClose {
+		t.Fatal("attempt context was canceled before the underlying body was closed")
+	}
+	select {
+	case <-doer.ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("attempt context was not canceled after raw body Close")
+	}
+}
+
+func TestExecuteClosesConsumedBodyBeforeCancelingAttemptContext(t *testing.T) {
+	for _, status := range []int{http.StatusOK, http.StatusBadRequest} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			closeErr := errors.New("close failed")
+			client, doer := newCloseContextResponseClient(closeErr)
+			doer.status = status
+			if status == http.StatusOK {
+				doer.contents = `{}`
+			} else {
+				doer.contents = `{"error":{"message":"bad"}}`
+			}
+
+			var response map[string]any
+			err := client.Get(context.Background(), "test", nil, &response)
+			if status == http.StatusOK && err != nil {
+				t.Fatal(err)
+			}
+			if status != http.StatusOK && err == nil {
+				t.Fatal("Get() error = nil, want API error")
+			}
+			if !doer.body.closed {
+				t.Fatal("consumed response body was not closed")
+			}
+			if doer.body.contextDoneOnClose {
+				t.Fatal("attempt context was canceled before the consumed body was closed")
+			}
+			select {
+			case <-doer.ctx.Done():
+			case <-time.After(time.Second):
+				t.Fatal("attempt context was not canceled after a failed body Close")
+			}
+		})
+	}
+}
+
 func TestExecuteClosesSuccessResponseWithoutOwner(t *testing.T) {
 	client, doer := newCloseContextResponseClient(nil)
 
@@ -617,6 +722,56 @@ func TestExecuteBodyTimeoutCancelsCustomTransportContext(t *testing.T) {
 				t.Fatal("response body timeout did not cancel the custom transport request context")
 			}
 		})
+	}
+}
+
+func TestExecuteBodyTimeoutDoesNotWaitForBlockingClose(t *testing.T) {
+	bodyReady := make(chan *blockingCloseContextResponseBody, 1)
+	client := openai.NewClient(
+		option.WithAPIKey("test-key"),
+		option.WithMaxRetries(0),
+		option.WithResponseBodyTimeout(10*time.Millisecond),
+		option.WithHTTPClient(&http.Client{
+			Transport: responseRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				body := newBlockingCloseContextResponseBody(req.Context())
+				bodyReady <- body
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": {"application/json"}},
+					Body:       body,
+					Request:    req,
+				}, nil
+			}),
+		}),
+	)
+	var response map[string]any
+	done := make(chan error, 1)
+	go func() {
+		done <- client.Get(context.Background(), "test", nil, &response)
+	}()
+	body := <-bodyReady
+
+	var err error
+	returnedBeforeRelease := false
+	select {
+	case err = <-done:
+		returnedBeforeRelease = true
+	case <-time.After(250 * time.Millisecond):
+	}
+	close(body.releaseClose)
+	if !returnedBeforeRelease {
+		err = <-done
+	}
+	<-body.closeFinished
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Get() error = %v, want context deadline exceeded", err)
+	}
+	if !returnedBeforeRelease {
+		t.Fatal("response body timeout waited for blocking Close")
+	}
+	if !body.contextDoneOnClose {
+		t.Fatal("timeout Close began before the attempt context was canceled")
 	}
 }
 

--- a/response_limits_test.go
+++ b/response_limits_test.go
@@ -635,21 +635,49 @@ func TestExecuteClosesConsumedBodyBeforeCancelingAttemptContext(t *testing.T) {
 }
 
 func TestExecuteClosesSuccessResponseWithoutOwner(t *testing.T) {
-	client, doer := newCloseContextResponseClient(nil)
+	bodyReady := make(chan *blockingCloseContextResponseBody, 1)
+	client := openai.NewClient(
+		option.WithAPIKey("test-key"),
+		option.WithMaxRetries(0),
+		option.WithHTTPClient(responseDoerFunc(func(req *http.Request) (*http.Response, error) {
+			body := newBlockingCloseContextResponseBody(req.Context())
+			bodyReady <- body
+			return &http.Response{
+				StatusCode:    http.StatusOK,
+				ContentLength: 0,
+				Header:        http.Header{"Content-Type": {"application/json"}},
+				Body:          body,
+				Request:       req,
+			}, nil
+		})),
+	)
+	done := make(chan error, 1)
+	go func() {
+		done <- client.Get(context.Background(), "test", nil, nil)
+	}()
+	body := <-bodyReady
 
-	if err := client.Get(context.Background(), "test", nil, nil); err != nil {
+	var err error
+	returnedBeforeRelease := false
+	select {
+	case err = <-done:
+		returnedBeforeRelease = true
+	case <-time.After(250 * time.Millisecond):
+	}
+	close(body.releaseClose)
+	if !returnedBeforeRelease {
+		err = <-done
+	}
+	<-body.closeFinished
+
+	if err != nil {
 		t.Fatal(err)
 	}
-	if !doer.body.closed {
-		t.Fatal("unowned success response body was not closed")
+	if !returnedBeforeRelease {
+		t.Fatal("unowned empty response waited for blocking Close")
 	}
-	if doer.body.contextDoneOnClose {
-		t.Fatal("attempt context was canceled before the unowned body was closed")
-	}
-	select {
-	case <-doer.ctx.Done():
-	case <-time.After(time.Second):
-		t.Fatal("unowned success response did not end the attempt context lifecycle")
+	if !body.contextDoneOnClose {
+		t.Fatal("unowned empty response Close began before the attempt context was canceled")
 	}
 }
 

--- a/response_limits_test.go
+++ b/response_limits_test.go
@@ -34,6 +34,8 @@ type delegatingResponseDoer struct {
 	*http.Client
 }
 
+func (*delegatingResponseDoer) CompressionDisabled() bool { return false }
+
 type countingResponseBody struct {
 	reader        io.Reader
 	endless       bool

--- a/response_limits_test.go
+++ b/response_limits_test.go
@@ -1,6 +1,8 @@
 package openai_test
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"errors"
 	"io"
@@ -19,6 +21,12 @@ import (
 type responseDoerFunc func(*http.Request) (*http.Response, error)
 
 func (f responseDoerFunc) Do(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type responseRoundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f responseRoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
 }
 
@@ -79,6 +87,40 @@ func (b *blockingResponseBody) closeCount() int {
 	return b.closes
 }
 
+type contextResponseBody struct {
+	ctx context.Context
+	mu  sync.Mutex
+
+	closes int
+}
+
+func (b *contextResponseBody) Read([]byte) (int, error) {
+	<-b.ctx.Done()
+	return 0, b.ctx.Err()
+}
+
+func (b *contextResponseBody) Close() error {
+	b.mu.Lock()
+	b.closes++
+	b.mu.Unlock()
+	return nil
+}
+
+func (b *contextResponseBody) closeCount() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.closes
+}
+
+type repeatedByteReader byte
+
+func (b repeatedByteReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = byte(b)
+	}
+	return len(p), nil
+}
+
 func newResponseLimitClient(body io.ReadCloser, status int, contentType string, opts ...option.RequestOption) openai.Client {
 	opts = append([]option.RequestOption{
 		option.WithAPIKey("test-key"),
@@ -118,6 +160,59 @@ func TestExecuteBoundsTypedSuccessResponse(t *testing.T) {
 	}
 	if !body.closed {
 		t.Fatal("response body was not closed")
+	}
+}
+
+func TestExecuteBoundsCompressedWireResponse(t *testing.T) {
+	const wireLimit = 64
+	var compressed bytes.Buffer
+	for i := 0; i < 32; i++ {
+		zw := gzip.NewWriter(&compressed)
+		if i == 0 {
+			if _, err := io.WriteString(zw, "{}"); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := zw.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if compressed.Len() <= wireLimit {
+		t.Fatalf("compressed fixture length = %d, want more than wire limit", compressed.Len())
+	}
+
+	for _, status := range []int{http.StatusOK, http.StatusBadRequest} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if got := r.Header.Get("Accept-Encoding"); got != "gzip" {
+					t.Errorf("Accept-Encoding = %q, want gzip", got)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("Content-Encoding", "gzip")
+				w.WriteHeader(status)
+				_, _ = w.Write(compressed.Bytes())
+			}))
+			defer server.Close()
+
+			client := openai.NewClient(
+				option.WithAPIKey("test-key"),
+				option.WithBaseURL(server.URL+"/"),
+				option.WithMaxRetries(0),
+				option.WithMaxResponseBodyBytes(wireLimit),
+				option.WithMaxErrorResponseBodyBytes(wireLimit),
+			)
+			var response map[string]any
+			err := client.Get(context.Background(), "compressed", nil, &response)
+			if err == nil || !strings.Contains(err.Error(), "compressed response body exceeded configured limit of 64 bytes") {
+				t.Fatalf("Get() error = %v, want compressed response body limit error", err)
+			}
+			if status >= http.StatusBadRequest {
+				var apiErr *openai.Error
+				if !errors.As(err, &apiErr) {
+					t.Fatalf("errors.As(%T, *openai.Error) = false", err)
+				}
+			}
+		})
 	}
 }
 
@@ -239,6 +334,89 @@ func TestExecuteLeavesRawSuccessResponseStreaming(t *testing.T) {
 	}
 }
 
+func TestExecutePreservesTransparentGzipForRawResponse(t *testing.T) {
+	var compressed bytes.Buffer
+	zw := gzip.NewWriter(&compressed)
+	if _, err := io.WriteString(zw, `{"ok":true}`); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Encoding", "gzip")
+		_, _ = w.Write(compressed.Bytes())
+	}))
+	defer server.Close()
+
+	client := openai.NewClient(
+		option.WithAPIKey("test-key"),
+		option.WithBaseURL(server.URL+"/"),
+		option.WithMaxRetries(0),
+		option.WithMaxResponseBodyBytes(1),
+	)
+	var raw *http.Response
+	if err := client.Get(context.Background(), "compressed", nil, &raw); err != nil {
+		t.Fatal(err)
+	}
+	if !raw.Uncompressed {
+		t.Fatal("raw response was not marked as transparently decompressed")
+	}
+	if got := raw.Header.Get("Content-Encoding"); got != "" {
+		t.Fatalf("Content-Encoding = %q, want removed after transparent decompression", got)
+	}
+	if raw.ContentLength != -1 {
+		t.Fatalf("ContentLength = %d, want -1 after transparent decompression", raw.ContentLength)
+	}
+	contents, err := io.ReadAll(raw.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(contents), `{"ok":true}`; got != want {
+		t.Fatalf("raw body = %q, want %q", got, want)
+	}
+	if err := raw.Body.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestExecuteRawResponseOwnsAttemptContextLifecycle(t *testing.T) {
+	var attemptCtx context.Context
+	body := &countingResponseBody{reader: strings.NewReader("{}")}
+	client := openai.NewClient(
+		option.WithAPIKey("test-key"),
+		option.WithMaxRetries(0),
+		option.WithHTTPClient(responseDoerFunc(func(req *http.Request) (*http.Response, error) {
+			attemptCtx = req.Context()
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": {"application/json"}},
+				Body:       body,
+				Request:    req,
+			}, nil
+		})),
+	)
+	var raw *http.Response
+	if err := client.Get(context.Background(), "test", nil, &raw); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-attemptCtx.Done():
+		t.Fatal("attempt context canceled before raw response ownership ended")
+	default:
+	}
+	if err := raw.Body.Close(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-attemptCtx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("raw response close did not end the attempt context lifecycle")
+	}
+}
+
 func TestExecuteTimesOutNonStreamingResponseBodies(t *testing.T) {
 	for _, status := range []int{http.StatusOK, http.StatusBadRequest} {
 		t.Run(http.StatusText(status), func(t *testing.T) {
@@ -266,6 +444,52 @@ func TestExecuteTimesOutNonStreamingResponseBodies(t *testing.T) {
 			case <-time.After(time.Second):
 				_ = body.Close()
 				t.Fatal("Execute() did not enforce the response body timeout")
+			}
+		})
+	}
+}
+
+func TestExecuteBodyTimeoutCancelsCustomTransportContext(t *testing.T) {
+	for _, status := range []int{http.StatusOK, http.StatusBadRequest} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			callerCtx, cancelCaller := context.WithCancel(context.Background())
+			defer cancelCaller()
+
+			var body *contextResponseBody
+			client := openai.NewClient(
+				option.WithAPIKey("test-key"),
+				option.WithMaxRetries(0),
+				option.WithResponseBodyTimeout(10*time.Millisecond),
+				option.WithHTTPClient(&http.Client{
+					Transport: responseRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+						body = &contextResponseBody{ctx: req.Context()}
+						return &http.Response{
+							StatusCode: status,
+							Header:     http.Header{"Content-Type": {"application/json"}},
+							Body:       body,
+							Request:    req,
+						}, nil
+					}),
+				}),
+			)
+			var response map[string]any
+			done := make(chan error, 1)
+			go func() {
+				done <- client.Get(callerCtx, "test", nil, &response)
+			}()
+
+			select {
+			case err := <-done:
+				if !errors.Is(err, context.DeadlineExceeded) {
+					t.Fatalf("Get() error = %v, want context deadline exceeded", err)
+				}
+				if body.closeCount() != 1 {
+					t.Fatalf("response body close count = %d, want 1", body.closeCount())
+				}
+			case <-time.After(250 * time.Millisecond):
+				cancelCaller()
+				<-done
+				t.Fatal("response body timeout did not cancel the custom transport request context")
 			}
 		})
 	}
@@ -315,5 +539,84 @@ func TestExecuteTimeoutInterruptsSlowHTTPResponse(t *testing.T) {
 		release()
 		<-done
 		t.Fatal("response body timeout did not interrupt a stalled standard HTTP response")
+	}
+}
+
+func TestImagesGenerateAllowsDocumented4KBase64Response(t *testing.T) {
+	const (
+		imageCount     = 3
+		rawImageBytes  = int64(3840 * 2160 * 3)
+		base64Bytes    = 4 * ((rawImageBytes + 2) / 3)
+		responseHeader = `{"created":0,"data":[`
+		imagePrefix    = `{"b64_json":"`
+		imageSuffix    = `"}`
+		responseFooter = `]}`
+	)
+
+	parts := []io.Reader{strings.NewReader(responseHeader)}
+	expectedBytes := int64(len(responseHeader) + len(responseFooter))
+	for i := 0; i < imageCount; i++ {
+		if i != 0 {
+			parts = append(parts, strings.NewReader(","))
+			expectedBytes++
+		}
+		parts = append(
+			parts,
+			strings.NewReader(imagePrefix),
+			io.LimitReader(repeatedByteReader('A'), base64Bytes),
+			strings.NewReader(imageSuffix),
+		)
+		expectedBytes += int64(len(imagePrefix)+len(imageSuffix)) + base64Bytes
+	}
+	parts = append(parts, strings.NewReader(responseFooter))
+
+	client := openai.NewClient(
+		option.WithAPIKey("test-key"),
+		option.WithMaxRetries(0),
+		option.WithHTTPClient(responseDoerFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": {"application/json"}},
+				Body:       io.NopCloser(io.MultiReader(parts...)),
+				Request:    req,
+			}, nil
+		})),
+	)
+	var rawResponse []byte
+	_, err := client.Images.Generate(
+		context.Background(),
+		openai.ImageGenerateParams{
+			Prompt: "synthetic compatibility fixture",
+			Model:  openai.ImageModelGPTImage2,
+			N:      openai.Int(imageCount),
+			Size:   openai.ImageGenerateParamsSize("3840x2160"),
+		},
+		option.WithResponseBodyInto(&rawResponse),
+	)
+	if err != nil {
+		t.Fatalf("Images.Generate() error = %v, want documented multi-image response to fit the endpoint policy", err)
+	}
+	if int64(len(rawResponse)) != expectedBytes {
+		t.Fatalf("response bytes = %d, want %d", len(rawResponse), expectedBytes)
+	}
+}
+
+func TestImagesGenerateRespectsClientResponseLimitOverride(t *testing.T) {
+	client := openai.NewClient(
+		option.WithAPIKey("test-key"),
+		option.WithMaxRetries(0),
+		option.WithMaxResponseBodyBytes(4),
+		option.WithHTTPClient(responseDoerFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": {"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"data":[]}`)),
+				Request:    req,
+			}, nil
+		})),
+	)
+	_, err := client.Images.Generate(context.Background(), openai.ImageGenerateParams{Prompt: "test"})
+	if err == nil || !strings.Contains(err.Error(), "configured limit of 4 bytes") {
+		t.Fatalf("Images.Generate() error = %v, want client response limit override", err)
 	}
 }

--- a/response_limits_test.go
+++ b/response_limits_test.go
@@ -112,6 +112,51 @@ func (b *contextResponseBody) closeCount() int {
 	return b.closes
 }
 
+type closeContextResponseBody struct {
+	ctx context.Context
+	err error
+
+	closed             bool
+	contextDoneOnClose bool
+}
+
+func (b *closeContextResponseBody) Read([]byte) (int, error) {
+	return 0, io.EOF
+}
+
+func (b *closeContextResponseBody) Close() error {
+	b.closed = true
+	b.contextDoneOnClose = b.ctx.Err() != nil
+	return b.err
+}
+
+type closeContextResponseDoer struct {
+	ctx      context.Context
+	body     *closeContextResponseBody
+	closeErr error
+}
+
+func (d *closeContextResponseDoer) Do(req *http.Request) (*http.Response, error) {
+	d.ctx = req.Context()
+	d.body = &closeContextResponseBody{ctx: d.ctx, err: d.closeErr}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": {"application/json"}},
+		Body:       d.body,
+		Request:    req,
+	}, nil
+}
+
+func newCloseContextResponseClient(closeErr error) (openai.Client, *closeContextResponseDoer) {
+	doer := &closeContextResponseDoer{closeErr: closeErr}
+	client := openai.NewClient(
+		option.WithAPIKey("test-key"),
+		option.WithMaxRetries(0),
+		option.WithHTTPClient(doer),
+	)
+	return client, doer
+}
+
 type repeatedByteReader byte
 
 func (b repeatedByteReader) Read(p []byte) (int, error) {
@@ -414,6 +459,86 @@ func TestExecuteRawResponseOwnsAttemptContextLifecycle(t *testing.T) {
 	case <-attemptCtx.Done():
 	case <-time.After(time.Second):
 		t.Fatal("raw response close did not end the attempt context lifecycle")
+	}
+}
+
+func TestExecuteRawResponseClosesBodyBeforeCancelingAttemptContext(t *testing.T) {
+	closeErr := errors.New("close failed")
+	client, doer := newCloseContextResponseClient(closeErr)
+
+	var raw *http.Response
+	if err := client.Get(context.Background(), "test", nil, &raw); err != nil {
+		t.Fatal(err)
+	}
+	if err := raw.Body.Close(); !errors.Is(err, closeErr) {
+		t.Fatalf("raw response Close() error = %v, want %v", err, closeErr)
+	}
+	if !doer.body.closed {
+		t.Fatal("raw response Close() did not close the underlying body")
+	}
+	if doer.body.contextDoneOnClose {
+		t.Fatal("attempt context was canceled before the underlying body was closed")
+	}
+	select {
+	case <-doer.ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("attempt context was not canceled after a failed underlying Close")
+	}
+}
+
+func TestExecuteClosesSuccessResponseWithoutOwner(t *testing.T) {
+	client, doer := newCloseContextResponseClient(nil)
+
+	if err := client.Get(context.Background(), "test", nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	if !doer.body.closed {
+		t.Fatal("unowned success response body was not closed")
+	}
+	if doer.body.contextDoneOnClose {
+		t.Fatal("attempt context was canceled before the unowned body was closed")
+	}
+	select {
+	case <-doer.ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("unowned success response did not end the attempt context lifecycle")
+	}
+}
+
+func TestExecuteResponseIntoOwnsSuccessBody(t *testing.T) {
+	client, doer := newCloseContextResponseClient(nil)
+
+	var raw *http.Response
+	if err := client.Get(
+		context.Background(),
+		"test",
+		nil,
+		nil,
+		option.WithResponseInto(&raw),
+	); err != nil {
+		t.Fatal(err)
+	}
+	if doer.body.closed {
+		t.Fatal("caller-owned response body was closed before handoff")
+	}
+	select {
+	case <-doer.ctx.Done():
+		t.Fatal("attempt context canceled before ResponseInto ownership ended")
+	default:
+	}
+	if err := raw.Body.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if !doer.body.closed {
+		t.Fatal("ResponseInto body Close() did not close the underlying body")
+	}
+	if doer.body.contextDoneOnClose {
+		t.Fatal("attempt context was canceled before the ResponseInto body was closed")
+	}
+	select {
+	case <-doer.ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("ResponseInto body close did not end the attempt context lifecycle")
 	}
 }
 

--- a/response_limits_test.go
+++ b/response_limits_test.go
@@ -30,6 +30,10 @@ func (f responseRoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, 
 	return f(req)
 }
 
+type delegatingResponseDoer struct {
+	*http.Client
+}
+
 type countingResponseBody struct {
 	reader  io.Reader
 	endless bool
@@ -91,7 +95,9 @@ type contextResponseBody struct {
 	ctx context.Context
 	mu  sync.Mutex
 
-	closes int
+	closes    int
+	closed    chan struct{}
+	closeOnce sync.Once
 }
 
 func (b *contextResponseBody) Read([]byte) (int, error) {
@@ -103,6 +109,7 @@ func (b *contextResponseBody) Close() error {
 	b.mu.Lock()
 	b.closes++
 	b.mu.Unlock()
+	b.closeOnce.Do(func() { close(b.closed) })
 	return nil
 }
 
@@ -280,23 +287,51 @@ func TestExecuteBoundsCompressedWireResponse(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := openai.NewClient(
-				option.WithAPIKey("test-key"),
-				option.WithBaseURL(server.URL+"/"),
-				option.WithMaxRetries(0),
-				option.WithMaxResponseBodyBytes(wireLimit),
-				option.WithMaxErrorResponseBodyBytes(wireLimit),
-			)
-			var response map[string]any
-			err := client.Get(context.Background(), "compressed", nil, &response)
-			if err == nil || !strings.Contains(err.Error(), "compressed response body exceeded configured limit of 64 bytes") {
-				t.Fatalf("Get() error = %v, want compressed response body limit error", err)
+			clients := []struct {
+				name string
+				opts []option.RequestOption
+			}{
+				{name: "native client"},
+				{
+					name: "delegating doer",
+					opts: []option.RequestOption{
+						option.WithHTTPClient(&delegatingResponseDoer{Client: &http.Client{}}),
+					},
+				},
+				{
+					name: "delegating doer replaces compression-disabled client",
+					opts: []option.RequestOption{
+						option.WithHTTPClient(&http.Client{
+							Transport: &http.Transport{DisableCompression: true},
+						}),
+						option.WithHTTPClient(&delegatingResponseDoer{Client: &http.Client{}}),
+					},
+				},
 			}
-			if status >= http.StatusBadRequest {
-				var apiErr *openai.Error
-				if !errors.As(err, &apiErr) {
-					t.Fatalf("errors.As(%T, *openai.Error) = false", err)
-				}
+			for _, test := range clients {
+				t.Run(test.name, func(t *testing.T) {
+					opts := []option.RequestOption{
+						option.WithAPIKey("test-key"),
+						option.WithBaseURL(server.URL + "/"),
+						option.WithMaxRetries(0),
+						option.WithMaxResponseBodyBytes(wireLimit),
+						option.WithMaxErrorResponseBodyBytes(wireLimit),
+					}
+					opts = append(opts, test.opts...)
+
+					client := openai.NewClient(opts...)
+					var response map[string]any
+					err := client.Get(context.Background(), "compressed", nil, &response)
+					if err == nil || !strings.Contains(err.Error(), "compressed response body exceeded configured limit of 64 bytes") {
+						t.Fatalf("Get() error = %v, want compressed response body limit error", err)
+					}
+					if status >= http.StatusBadRequest {
+						var apiErr *openai.Error
+						if !errors.As(err, &apiErr) {
+							t.Fatalf("errors.As(%T, *openai.Error) = false", err)
+						}
+					}
+				})
 			}
 		})
 	}
@@ -692,7 +727,7 @@ func TestExecuteBodyTimeoutCancelsCustomTransportContext(t *testing.T) {
 				option.WithResponseBodyTimeout(10*time.Millisecond),
 				option.WithHTTPClient(&http.Client{
 					Transport: responseRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-						body = &contextResponseBody{ctx: req.Context()}
+						body = &contextResponseBody{ctx: req.Context(), closed: make(chan struct{})}
 						return &http.Response{
 							StatusCode: status,
 							Header:     http.Header{"Content-Type": {"application/json"}},
@@ -712,6 +747,11 @@ func TestExecuteBodyTimeoutCancelsCustomTransportContext(t *testing.T) {
 			case err := <-done:
 				if !errors.Is(err, context.DeadlineExceeded) {
 					t.Fatalf("Get() error = %v, want context deadline exceeded", err)
+				}
+				select {
+				case <-body.closed:
+				case <-time.After(time.Second):
+					t.Fatal("timed out waiting for response body cleanup")
 				}
 				if body.closeCount() != 1 {
 					t.Fatalf("response body close count = %d, want 1", body.closeCount())

--- a/response_limits_test.go
+++ b/response_limits_test.go
@@ -35,10 +35,11 @@ type delegatingResponseDoer struct {
 }
 
 type countingResponseBody struct {
-	reader  io.Reader
-	endless bool
-	reads   int
-	closed  bool
+	reader        io.Reader
+	endless       bool
+	reads         int
+	closed        bool
+	closeFinished chan struct{}
 }
 
 func (b *countingResponseBody) Read(p []byte) (int, error) {
@@ -58,6 +59,9 @@ func (b *countingResponseBody) Read(p []byte) (int, error) {
 
 func (b *countingResponseBody) Close() error {
 	b.closed = true
+	if b.closeFinished != nil {
+		close(b.closeFinished)
+	}
 	return nil
 }
 
@@ -231,7 +235,7 @@ func newResponseLimitClient(body io.ReadCloser, status int, contentType string, 
 }
 
 func TestExecuteBoundsTypedSuccessResponse(t *testing.T) {
-	body := &countingResponseBody{endless: true}
+	body := &countingResponseBody{endless: true, closeFinished: make(chan struct{})}
 	client := newResponseLimitClient(body, http.StatusOK, "application/json")
 	var response struct {
 		OK bool `json:"ok"`
@@ -251,7 +255,9 @@ func TestExecuteBoundsTypedSuccessResponse(t *testing.T) {
 	if body.reads != 9 {
 		t.Fatalf("response bytes read = %d, want 9", body.reads)
 	}
-	if !body.closed {
+	select {
+	case <-body.closeFinished:
+	case <-time.After(time.Second):
 		t.Fatal("response body was not closed")
 	}
 }

--- a/response_limits_test.go
+++ b/response_limits_test.go
@@ -1,0 +1,319 @@
+package openai_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+)
+
+type responseDoerFunc func(*http.Request) (*http.Response, error)
+
+func (f responseDoerFunc) Do(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type countingResponseBody struct {
+	reader  io.Reader
+	endless bool
+	reads   int
+	closed  bool
+}
+
+func (b *countingResponseBody) Read(p []byte) (int, error) {
+	var n int
+	var err error
+	if b.endless {
+		for i := range p {
+			p[i] = 'x'
+		}
+		n = len(p)
+	} else {
+		n, err = b.reader.Read(p)
+	}
+	b.reads += n
+	return n, err
+}
+
+func (b *countingResponseBody) Close() error {
+	b.closed = true
+	return nil
+}
+
+type blockingResponseBody struct {
+	closed chan struct{}
+	once   sync.Once
+	mu     sync.Mutex
+	closes int
+}
+
+func newBlockingResponseBody() *blockingResponseBody {
+	return &blockingResponseBody{closed: make(chan struct{})}
+}
+
+func (b *blockingResponseBody) Read([]byte) (int, error) {
+	<-b.closed
+	return 0, errors.New("response body closed")
+}
+
+func (b *blockingResponseBody) Close() error {
+	b.mu.Lock()
+	b.closes++
+	b.mu.Unlock()
+	b.once.Do(func() { close(b.closed) })
+	return nil
+}
+
+func (b *blockingResponseBody) closeCount() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.closes
+}
+
+func newResponseLimitClient(body io.ReadCloser, status int, contentType string, opts ...option.RequestOption) openai.Client {
+	opts = append([]option.RequestOption{
+		option.WithAPIKey("test-key"),
+		option.WithMaxRetries(0),
+		option.WithHTTPClient(responseDoerFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: status,
+				Header:     http.Header{"Content-Type": {contentType}},
+				Body:       body,
+				Request:    req,
+			}, nil
+		})),
+	}, opts...)
+	return openai.NewClient(opts...)
+}
+
+func TestExecuteBoundsTypedSuccessResponse(t *testing.T) {
+	body := &countingResponseBody{endless: true}
+	client := newResponseLimitClient(body, http.StatusOK, "application/json")
+	var response struct {
+		OK bool `json:"ok"`
+	}
+
+	err := client.Execute(
+		context.Background(),
+		http.MethodGet,
+		"test",
+		nil,
+		&response,
+		option.WithMaxResponseBodyBytes(8),
+	)
+	if err == nil || !strings.Contains(err.Error(), "exceeded configured limit of 8 bytes") {
+		t.Fatalf("Execute() error = %v, want response body limit error", err)
+	}
+	if body.reads != 9 {
+		t.Fatalf("response bytes read = %d, want 9", body.reads)
+	}
+	if !body.closed {
+		t.Fatal("response body was not closed")
+	}
+}
+
+func TestExecuteBoundsErrorResponseRequestedAsRaw(t *testing.T) {
+	errorJSON := `{"error":{"message":"bad","type":"invalid_request_error","param":"p","code":"c"}}`
+	body := &countingResponseBody{reader: strings.NewReader(errorJSON + strings.Repeat(" ", 1024))}
+	client := newResponseLimitClient(body, http.StatusBadRequest, "application/json")
+	var raw *http.Response
+
+	err := client.Execute(
+		context.Background(),
+		http.MethodGet,
+		"test",
+		nil,
+		&raw,
+		option.WithMaxErrorResponseBodyBytes(int64(len(errorJSON))),
+	)
+	if err == nil || !strings.Contains(err.Error(), "exceeded configured limit") {
+		t.Fatalf("Execute() error = %v, want error response body limit error", err)
+	}
+	var apiErr *openai.Error
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("errors.As(%T, *openai.Error) = false", err)
+	}
+	if apiErr.StatusCode != http.StatusBadRequest {
+		t.Fatalf("API error status = %d, want %d", apiErr.StatusCode, http.StatusBadRequest)
+	}
+	if raw != apiErr.Response {
+		t.Fatal("raw response and API error response differ")
+	}
+	retained, readErr := io.ReadAll(raw.Body)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(retained) != errorJSON {
+		t.Fatalf("retained error body = %q, want %q", retained, errorJSON)
+	}
+	if body.reads != len(errorJSON)+1 {
+		t.Fatalf("response bytes read = %d, want %d", body.reads, len(errorJSON)+1)
+	}
+}
+
+func TestExecutePreservesOrdinaryAPIError(t *testing.T) {
+	errorJSON := `{"error":{"message":"bad","type":"invalid_request_error","param":"p","code":"c"}}`
+	body := &countingResponseBody{reader: strings.NewReader(errorJSON)}
+	client := newResponseLimitClient(body, http.StatusBadRequest, "application/json")
+	var response map[string]any
+
+	err := client.Execute(context.Background(), http.MethodGet, "test", nil, &response)
+	var apiErr *openai.Error
+	if reflect.TypeOf(err) != reflect.TypeOf(apiErr) {
+		t.Fatalf("Execute() error type = %T, want *openai.Error", err)
+	}
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("errors.As(%T, *openai.Error) = false", err)
+	}
+	if apiErr.StatusCode != http.StatusBadRequest {
+		t.Fatalf("API error status = %d, want %d", apiErr.StatusCode, http.StatusBadRequest)
+	}
+	retained, readErr := io.ReadAll(apiErr.Response.Body)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(retained) != errorJSON {
+		t.Fatalf("retained error body = %q, want %q", retained, errorJSON)
+	}
+}
+
+func TestExecuteAllowsMethodResponseLimitOverride(t *testing.T) {
+	body := &countingResponseBody{reader: strings.NewReader(`{"ok":true}`)}
+	client := newResponseLimitClient(
+		body,
+		http.StatusOK,
+		"application/json",
+		option.WithMaxResponseBodyBytes(4),
+	)
+	var response struct {
+		OK bool `json:"ok"`
+	}
+
+	err := client.Execute(
+		context.Background(),
+		http.MethodGet,
+		"test",
+		nil,
+		&response,
+		option.WithMaxResponseBodyBytes(64),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !response.OK {
+		t.Fatal("typed response was not decoded")
+	}
+}
+
+func TestExecuteLeavesRawSuccessResponseStreaming(t *testing.T) {
+	body := &countingResponseBody{endless: true}
+	client := newResponseLimitClient(
+		body,
+		http.StatusOK,
+		"application/octet-stream",
+		option.WithMaxResponseBodyBytes(1),
+		option.WithResponseBodyTimeout(time.Nanosecond),
+	)
+	var raw *http.Response
+
+	if err := client.Execute(context.Background(), http.MethodGet, "test", nil, &raw); err != nil {
+		t.Fatal(err)
+	}
+	if body.reads != 0 {
+		t.Fatalf("response bytes read = %d, want 0", body.reads)
+	}
+	if body.closed {
+		t.Fatal("raw response body was closed before handoff")
+	}
+	if err := raw.Body.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestExecuteTimesOutNonStreamingResponseBodies(t *testing.T) {
+	for _, status := range []int{http.StatusOK, http.StatusBadRequest} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			body := newBlockingResponseBody()
+			client := newResponseLimitClient(
+				body,
+				status,
+				"application/json",
+				option.WithResponseBodyTimeout(10*time.Millisecond),
+			)
+			var response map[string]any
+			done := make(chan error, 1)
+			go func() {
+				done <- client.Execute(context.Background(), http.MethodGet, "test", nil, &response)
+			}()
+
+			select {
+			case err := <-done:
+				if !errors.Is(err, context.DeadlineExceeded) {
+					t.Fatalf("Execute() error = %v, want context deadline exceeded", err)
+				}
+				if body.closeCount() != 1 {
+					t.Fatalf("response body close count = %d, want 1", body.closeCount())
+				}
+			case <-time.After(time.Second):
+				_ = body.Close()
+				t.Fatal("Execute() did not enforce the response body timeout")
+			}
+		})
+	}
+}
+
+func TestExecuteTimeoutInterruptsSlowHTTPResponse(t *testing.T) {
+	headersSent := make(chan struct{})
+	releaseBody := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseBody) }) }
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		close(headersSent)
+		<-releaseBody
+		_, _ = io.WriteString(w, `{"ok":true}`)
+	}))
+	defer func() {
+		release()
+		server.Close()
+	}()
+
+	client := openai.NewClient(
+		option.WithAPIKey("test-key"),
+		option.WithBaseURL(server.URL+"/"),
+		option.WithMaxRetries(0),
+		option.WithResponseBodyTimeout(10*time.Millisecond),
+	)
+	var response struct {
+		OK bool `json:"ok"`
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- client.Get(context.Background(), "slow", nil, &response)
+	}()
+	<-headersSent
+
+	select {
+	case err := <-done:
+		release()
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("Get() error = %v, want context deadline exceeded", err)
+		}
+	case <-time.After(time.Second):
+		release()
+		<-done
+		t.Fatal("response body timeout did not interrupt a stalled standard HTTP response")
+	}
+}

--- a/response_limits_test.go
+++ b/response_limits_test.go
@@ -880,11 +880,9 @@ func TestImagesGenerateAllowsDocumented4KBase64Response(t *testing.T) {
 	)
 
 	parts := []io.Reader{strings.NewReader(responseHeader)}
-	expectedBytes := int64(len(responseHeader) + len(responseFooter))
 	for i := 0; i < imageCount; i++ {
 		if i != 0 {
 			parts = append(parts, strings.NewReader(","))
-			expectedBytes++
 		}
 		parts = append(
 			parts,
@@ -892,7 +890,6 @@ func TestImagesGenerateAllowsDocumented4KBase64Response(t *testing.T) {
 			io.LimitReader(repeatedByteReader('A'), base64Bytes),
 			strings.NewReader(imageSuffix),
 		)
-		expectedBytes += int64(len(imagePrefix)+len(imageSuffix)) + base64Bytes
 	}
 	parts = append(parts, strings.NewReader(responseFooter))
 
@@ -908,8 +905,7 @@ func TestImagesGenerateAllowsDocumented4KBase64Response(t *testing.T) {
 			}, nil
 		})),
 	)
-	var rawResponse []byte
-	_, err := client.Images.Generate(
+	response, err := client.Images.Generate(
 		context.Background(),
 		openai.ImageGenerateParams{
 			Prompt: "synthetic compatibility fixture",
@@ -917,13 +913,17 @@ func TestImagesGenerateAllowsDocumented4KBase64Response(t *testing.T) {
 			N:      openai.Int(imageCount),
 			Size:   openai.ImageGenerateParamsSize("3840x2160"),
 		},
-		option.WithResponseBodyInto(&rawResponse),
 	)
 	if err != nil {
 		t.Fatalf("Images.Generate() error = %v, want documented multi-image response to fit the endpoint policy", err)
 	}
-	if int64(len(rawResponse)) != expectedBytes {
-		t.Fatalf("response bytes = %d, want %d", len(rawResponse), expectedBytes)
+	if len(response.Data) != imageCount {
+		t.Fatalf("generated images = %d, want %d", len(response.Data), imageCount)
+	}
+	for i, image := range response.Data {
+		if int64(len(image.B64JSON)) != base64Bytes {
+			t.Fatalf("image %d base64 length = %d, want %d", i, len(image.B64JSON), base64Bytes)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- add explicitly opt-in success-response and API-error size limits plus an opt-in non-streaming body-read timeout; preserve historically unbounded successful payloads, complete structured errors, caller-controlled lifetimes, and raw streaming by default
- enforce independently bounded decoded and compressed wire bytes only when the relevant limit applies, with max+1 overflow detection and bounded error diagnostics when explicitly configured
- preserve native, wrapped, opaque, Azure, and custom-doer compression policies; avoid changing default or raw-stream gzip negotiation and isolate Azure loopback transport caches by compression policy
- retain provider authentication, workload-identity replay, SDK-owned Azure retries, retry deadlines, and cancellation-first nonblocking HTTP/2 cleanup for overflow, cancellation, retries, and malformed response reads
- preserve upstream generated-code ownership without generated image-service exceptions

## Review fixes

- exercise genuine >64 MiB typed image/Responses payloads, large binary downloads, and >64 KiB complete structured API errors with exact error identity, extra fields, RawJSON, and DumpResponse
- cover opaque HTTP transports and custom doers, typed/raw responses, inapplicable raw-response success limits, concatenated gzip wire accounting, and Azure API-key/token HTTPS and hardened-loopback compression policies
- prove malformed gzip, overflow, caller/attempt cancellation, unread responses, and retry cleanup return promptly even when a real HTTP/2 response Close is blocked
- repeat independent fresh-agent whole-PR generalized and thermo-nuclear review until two fresh reviewers independently report no actionable findings

## Validation

- complete root test suites on supported Go 1.25 and Go 1.26
- complete race suite plus repeated focused Go 1.26 HTTP/2, retry, authentication, Azure, and gzip race coverage
- six cross-platform/module lint passes, go vet, all four module-tidy checks, both Go-version examples, and both external-consumer suites
- root and examples reachable-vulnerability scans; main-enforced Castiron generated/custom-code budget
- exact-commit Codex Security diff scan e70a9c6e-ec6e-43cc-97ee-893bc50ba6e0: all 13 changed files covered, zero findings

SDK CODEOWNER review is required because this changes shared transport, Azure authentication, and JSON decoding behavior.