### PR TITLE
chore(shared): restore generated alias placement

### DIFF
--- a/shared/shared.go
+++ b/shared/shared.go
@@ -13,6 +13,8 @@ import (
 
 // aliased to make [param.APIUnion] private when embedding
 type paramUnion = param.APIUnion
+
+// aliased to make [param.APIObject] private when embedding
 type paramObj = param.APIObject
 
 // AllModels also accepts any [string] or [ChatModel]
@@ -42,9 +44,6 @@ const (
 )
 
 type ChatModel = string
-type ResponsesModel = string
-
-// aliased to make [param.APIObject] private when embedding
 
 const (
 	ChatModelGPT5_6Sol                        ChatModel = "gpt-5.6-sol"
@@ -1201,6 +1200,7 @@ func (r *ResponseFormatTextParam) UnmarshalJSON(data []byte) error {
 }
 
 // ResponsesModel also accepts any [string] or [ChatModel]
+type ResponsesModel = string
 
 const (
 	ResponsesModelO1Pro                        ResponsesModel = "o1-pro"


### PR DESCRIPTION
## Summary

Restore the generated locations of the private `paramObj` comment and the
public `ResponsesModel` string alias. This removes equivalent declaration-order
and comment drift from `shared/shared.go` without changing any exported type,
constant, JSON shape, or runtime behavior.

The compatibility-critical `ResponseFormatJSONSchemaJSONSchemaParam.Schema any`
customization remains unchanged. No tests are moved, removed, or rewritten.
Generation metadata, API-reference artifacts, dependencies, and workflows are
unchanged.

## Custom-code measurement

The public reporter verifies the same generated snapshot on both sides:
`d3deddb23e455d920842ad491f01a799e2400d7f`.

- Mixed files: **16 → 16**.
- `shared/shared.go`: **+4/-4 → +1/-1**.
- Full mixed-file patch: **+477/-120 → +474/-117**.
- All other 15 customizations are byte-for-byte unchanged.

## Validation

- Exact-source comparison against public main and the verified generated
  snapshot; only the reviewed alias/comment relocation is present.
- Full pinned `scripts/lint`, including builds, test compilation, all three
  module analyzers, and the Windows example lane: zero issues.
- `scripts/check-go-mod`: all four modules tidy.
- Full root tests against Steady 0.22.1 on Go 1.26.3 and Go 1.25.11.
- Examples and external-consumer tests on both Go versions.
- `scripts/detect-breaking-changes` against the public base in an isolated
  worktree.
- Custom-code reporter regressions: 17 run, 1 skipped, no failures.

Local executable builds used `GOFLAGS=-buildvcs=false` because this environment
exposes a non-repository home `.git` directory. This disables binary VCS
stamping only; no analyzer, test, or compatibility check was disabled.
