### PR TITLE
refactor(vector-stores): isolate file orchestration

### DIFF
--- a/vectorstorefile.go
+++ b/vectorstorefile.go
@@ -62,11 +62,7 @@ func (r *VectorStoreFileService) New(ctx context.Context, vectorStoreID string, 
 // Polls the API and blocks until the task is complete.
 // Default polling interval is 1 second.
 func (r *VectorStoreFileService) NewAndPoll(ctx context.Context, vectorStoreId string, body VectorStoreFileNewParams, pollIntervalMs int, opts ...option.RequestOption) (res *VectorStoreFile, err error) {
-	file, err := r.New(ctx, vectorStoreId, body, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return r.PollStatus(ctx, vectorStoreId, file.ID, pollIntervalMs, opts...)
+	return newVectorStoreFileAndPoll(r, ctx, vectorStoreId, body, pollIntervalMs, opts...)
 }
 
 // Upload a file to the `files` API and then attach it to the given vector store.
@@ -74,24 +70,13 @@ func (r *VectorStoreFileService) NewAndPoll(ctx context.Context, vectorStoreId s
 // Note the file will be asynchronously processed (you can use the alternative
 // polling helper method to wait for processing to complete).
 func (r *VectorStoreFileService) Upload(ctx context.Context, vectorStoreID string, body FileNewParams, opts ...option.RequestOption) (*VectorStoreFile, error) {
-	filesService := NewFileService(r.Options...)
-	fileObj, err := filesService.New(ctx, body, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return r.New(ctx, vectorStoreID, VectorStoreFileNewParams{
-		FileID: fileObj.ID,
-	}, opts...)
+	return uploadVectorStoreFile(r, ctx, vectorStoreID, body, opts...)
 }
 
 // Add a file to a vector store and poll until processing is complete.
 // Default polling interval is 1 second.
 func (r *VectorStoreFileService) UploadAndPoll(ctx context.Context, vectorStoreID string, body FileNewParams, pollIntervalMs int, opts ...option.RequestOption) (*VectorStoreFile, error) {
-	res, err := r.Upload(ctx, vectorStoreID, body, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return r.PollStatus(ctx, vectorStoreID, res.ID, pollIntervalMs, opts...)
+	return uploadVectorStoreFileAndPoll(r, ctx, vectorStoreID, body, pollIntervalMs, opts...)
 }
 
 // Retrieves a vector store file.

--- a/vectorstorefile_helpers.go
+++ b/vectorstorefile_helpers.go
@@ -1,0 +1,34 @@
+package openai
+
+import (
+	"context"
+
+	"github.com/openai/openai-go/v3/option"
+)
+
+func newVectorStoreFileAndPoll(r *VectorStoreFileService, ctx context.Context, vectorStoreId string, body VectorStoreFileNewParams, pollIntervalMs int, opts ...option.RequestOption) (res *VectorStoreFile, err error) {
+	file, err := r.New(ctx, vectorStoreId, body, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return r.PollStatus(ctx, vectorStoreId, file.ID, pollIntervalMs, opts...)
+}
+
+func uploadVectorStoreFile(r *VectorStoreFileService, ctx context.Context, vectorStoreID string, body FileNewParams, opts ...option.RequestOption) (*VectorStoreFile, error) {
+	filesService := NewFileService(r.Options...)
+	fileObj, err := filesService.New(ctx, body, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return r.New(ctx, vectorStoreID, VectorStoreFileNewParams{
+		FileID: fileObj.ID,
+	}, opts...)
+}
+
+func uploadVectorStoreFileAndPoll(r *VectorStoreFileService, ctx context.Context, vectorStoreID string, body FileNewParams, pollIntervalMs int, opts ...option.RequestOption) (*VectorStoreFile, error) {
+	res, err := r.Upload(ctx, vectorStoreID, body, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return r.PollStatus(ctx, vectorStoreID, res.ID, pollIntervalMs, opts...)
+}

--- a/vectorstorefile_helpers_test.go
+++ b/vectorstorefile_helpers_test.go
@@ -1,0 +1,257 @@
+package openai_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	openai "github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+)
+
+type vectorFileDoer func(*http.Request) (*http.Response, error)
+
+func (f vectorFileDoer) Do(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type vectorFileContextKey struct{}
+
+type vectorFileHelperCase struct {
+	name       string
+	stages     []string
+	attachment string
+	call       func(context.Context, *openai.VectorStoreFileService, ...option.RequestOption) (*openai.VectorStoreFile, error)
+}
+
+func vectorFileHelperCases() []vectorFileHelperCase {
+	upload := func() openai.FileNewParams {
+		return openai.FileNewParams{
+			File:    strings.NewReader("synthetic file contents"),
+			Purpose: openai.FilePurposeAssistants,
+		}
+	}
+	return []vectorFileHelperCase{
+		{
+			name:       "new and poll",
+			stages:     []string{"attach", "poll"},
+			attachment: `{"file_id":"file_existing","attributes":{"tag":"kept"}}`,
+			call: func(ctx context.Context, service *openai.VectorStoreFileService, opts ...option.RequestOption) (*openai.VectorStoreFile, error) {
+				return service.NewAndPoll(ctx, "vs_test", openai.VectorStoreFileNewParams{
+					FileID: "file_existing",
+					Attributes: map[string]openai.VectorStoreFileNewParamsAttributeUnion{
+						"tag": {OfString: openai.String("kept")},
+					},
+				}, 7, opts...)
+			},
+		},
+		{
+			name:       "upload",
+			stages:     []string{"upload", "attach"},
+			attachment: `{"file_id":"file_uploaded"}`,
+			call: func(ctx context.Context, service *openai.VectorStoreFileService, opts ...option.RequestOption) (*openai.VectorStoreFile, error) {
+				return service.Upload(ctx, "vs_test", upload(), opts...)
+			},
+		},
+		{
+			name:       "upload and poll",
+			stages:     []string{"upload", "attach", "poll"},
+			attachment: `{"file_id":"file_uploaded"}`,
+			call: func(ctx context.Context, service *openai.VectorStoreFileService, opts ...option.RequestOption) (*openai.VectorStoreFile, error) {
+				return service.UploadAndPoll(ctx, "vs_test", upload(), 7, opts...)
+			},
+		},
+	}
+}
+
+func vectorFileStage(t *testing.T, req *http.Request) string {
+	t.Helper()
+	switch req.Method + " " + req.URL.Path {
+	case "POST /v1/files":
+		return "upload"
+	case "POST /v1/vector_stores/vs_test/files":
+		return "attach"
+	case "GET /v1/vector_stores/vs_test/files/file_attached":
+		return "poll"
+	default:
+		t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+		return ""
+	}
+}
+
+func vectorFileResponse(req *http.Request, body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": {"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    req,
+	}
+}
+
+func vectorFileResponseBody(stage string) string {
+	switch stage {
+	case "upload":
+		return `{"id":"file_uploaded"}`
+	case "attach":
+		return `{"id":"file_attached","status":"in_progress"}`
+	default:
+		return `{"id":"file_attached","status":"completed"}`
+	}
+}
+
+func vectorFileService(doer vectorFileDoer) openai.VectorStoreFileService {
+	return openai.NewVectorStoreFileService(
+		option.WithBaseURL("https://vector-files.example/v1"),
+		option.WithAPIKey("synthetic-key"),
+		option.WithMaxRetries(0),
+		option.WithHTTPClient(doer),
+		option.WithHeader("X-Service", "kept"),
+		option.WithHeader("X-Precedence", "service"),
+	)
+}
+
+func TestVectorStoreFileHelperRequests(t *testing.T) {
+	for _, test := range vectorFileHelperCases() {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.WithValue(context.Background(), vectorFileContextKey{}, "kept")
+			var stages []string
+			service := vectorFileService(func(req *http.Request) (*http.Response, error) {
+				stage := vectorFileStage(t, req)
+				stages = append(stages, stage)
+				if req.Context().Value(vectorFileContextKey{}) != "kept" {
+					t.Error("request lost the caller context")
+				}
+				for key, want := range map[string]string{
+					"Authorization": "Bearer synthetic-key",
+					"X-Service":     "kept",
+					"X-Precedence":  "method",
+					"X-Call":        "kept",
+				} {
+					if got := req.Header.Get(key); got != want {
+						t.Errorf("%s on %s = %q, want %q", key, stage, got, want)
+					}
+				}
+				if stage == "upload" {
+					checkVectorFileUpload(t, req)
+				} else if got := req.Header.Get("OpenAI-Beta"); got != "assistants=v2" {
+					t.Errorf("beta header on %s = %q", stage, got)
+				}
+				if stage == "attach" {
+					var got, want any
+					if err := json.NewDecoder(req.Body).Decode(&got); err != nil {
+						t.Fatal(err)
+					}
+					if err := json.Unmarshal([]byte(test.attachment), &want); err != nil {
+						t.Fatal(err)
+					}
+					if !reflect.DeepEqual(got, want) {
+						t.Errorf("attachment = %#v, want %#v", got, want)
+					}
+				}
+				if stage == "poll" {
+					if got := req.Header.Get("X-Stainless-Poll-Helper"); got != "true" {
+						t.Errorf("poll helper header = %q", got)
+					}
+					if got := req.Header.Get("X-Stainless-Poll-Interval"); got != "7" {
+						t.Errorf("poll interval header = %q", got)
+					}
+				}
+				return vectorFileResponse(req, vectorFileResponseBody(stage)), nil
+			})
+			result, err := test.call(ctx, &service,
+				option.WithHeader("X-Precedence", "method"),
+				option.WithHeader("X-Call", "kept"),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantStatus := openai.VectorStoreFileStatusCompleted
+			if test.name == "upload" {
+				wantStatus = openai.VectorStoreFileStatusInProgress
+			}
+			if result == nil || result.ID != "file_attached" || result.Status != wantStatus {
+				t.Fatalf("result = %#v, want file_attached/%s", result, wantStatus)
+			}
+			if !reflect.DeepEqual(stages, test.stages) {
+				t.Fatalf("request stages = %v, want %v", stages, test.stages)
+			}
+		})
+	}
+}
+
+func checkVectorFileUpload(t *testing.T, req *http.Request) {
+	t.Helper()
+	mediaType, params, err := mime.ParseMediaType(req.Header.Get("Content-Type"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mediaType != "multipart/form-data" {
+		t.Fatalf("upload content type = %q", mediaType)
+	}
+	reader := multipart.NewReader(req.Body, params["boundary"])
+	fields := map[string]string{}
+	for {
+		part, err := reader.NextPart()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		data, readErr := io.ReadAll(part)
+		if err := part.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		fields[part.FormName()] = string(data)
+	}
+	want := map[string]string{
+		"file":    "synthetic file contents",
+		"purpose": "assistants",
+	}
+	if !reflect.DeepEqual(fields, want) {
+		t.Errorf("upload fields = %#v, want %#v", fields, want)
+	}
+}
+
+func TestVectorStoreFileHelperErrors(t *testing.T) {
+	for _, test := range vectorFileHelperCases() {
+		for failIndex, failStage := range test.stages {
+			t.Run(test.name+"/"+failStage, func(t *testing.T) {
+				failure := errors.New("synthetic transport failure")
+				var stages []string
+				service := vectorFileService(func(req *http.Request) (*http.Response, error) {
+					stage := vectorFileStage(t, req)
+					stages = append(stages, stage)
+					if stage == failStage {
+						return nil, failure
+					}
+					return vectorFileResponse(req, vectorFileResponseBody(stage)), nil
+				})
+				result, err := test.call(context.Background(), &service)
+				if result != nil || !errors.Is(err, failure) {
+					t.Fatalf("result = %#v, error = %v; want nil and original failure", result, err)
+				}
+				wantError := failure.Error()
+				if failStage == "poll" {
+					wantError = "vector store file poll: received " + wantError
+				}
+				if err.Error() != wantError {
+					t.Errorf("error = %q, want %q", err.Error(), wantError)
+				}
+				if want := test.stages[:failIndex+1]; !reflect.DeepEqual(stages, want) {
+					t.Fatalf("request stages = %v, want %v", stages, want)
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Move the handwritten vector-store file orchestration into
`vectorstorefile_helpers.go`. The existing `NewAndPoll`, `Upload`, and
`UploadAndPoll` methods retain their exact exported signatures and delegate to
the SDK-owned implementations.

The implementation bodies are unchanged. This preserves request order,
contexts, service/method options, multipart uploads, returned IDs, polling
headers, and error propagation. The existing polling implementation is untouched.
No compiler, schema, configuration, API-reference, generation metadata,
dependency, or workflow change is needed.

## Custom-code measurement

The public reporter verifies the same generated snapshot on both sides:
`d3deddb23e455d920842ad491f01a799e2400d7f`.

- Mixed files: **16 → 16**.
- `vectorstorefile.go`: **+39/-0 → +24/-0**.
- Full mixed-file patch: **+477/-120 → +462/-120**.
- All other 15 customizations are unchanged.

## Regression coverage

No existing handwritten or generated tests are moved, replaced, or deleted.
The new SDK-owned tests passed against both the original and extracted
implementations:

- `TestVectorStoreFileHelperRequests`: new-and-poll, upload, and
  upload-and-poll; exact request sequence, context, option precedence,
  multipart fields, attachment JSON, returned IDs/status, and polling headers.
- `TestVectorStoreFileHelperErrors`: attach/poll failures for new-and-poll;
  upload/attach failures for upload; upload/attach/poll failures for
  upload-and-poll. Each case checks the original error chain/message and that
  no later request runs.

## Validation

- Exact-source comparison proves all three method signatures and implementation
  bodies are preserved.
- Full pinned `scripts/lint`: zero issues.
- `scripts/check-go-mod`: all four modules tidy.
- Full root tests against Steady 0.22.1 on Go 1.26.3 and Go 1.25.11.
- Examples and external-consumer tests on both Go versions.
- Official `scripts/detect-breaking-changes` in an isolated worktree.
- Pinned `govulncheck` with Go 1.26.7: no vulnerabilities in root or examples.
- Independent exact-range Go correctness, compatibility, and ownership review:
  no findings.
- Finalized exact-range security review: all three changed files covered,
  no findings or deferred work.

Local executable builds used `GOFLAGS=-buildvcs=false` to avoid the environment's
non-repository home `.git` directory; no source-analysis or test gate was
disabled.
