### PR TITLE
refactor(chat): reuse generated assistant constructor

### DIFF
--- a/chatcompletion.go
+++ b/chatcompletion.go
@@ -2847,14 +2847,7 @@ func (r *ChatCompletionMessageFunctionToolCallFunctionParam) UnmarshalJSON(data 
 }
 
 func AssistantMessage[T string | []ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion](content T) ChatCompletionMessageParamUnion {
-	var assistant ChatCompletionAssistantMessageParam
-	switch v := any(content).(type) {
-	case string:
-		assistant.Content.OfString = param.NewOpt(v)
-	case []ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion:
-		assistant.Content.OfArrayOfContentParts = v
-	}
-	return ChatCompletionMessageParamUnion{OfAssistant: &assistant}
+	return ChatCompletionMessageParamOfAssistant(content)
 }
 
 func DeveloperMessage[T string | []ChatCompletionContentPartTextParam](content T) ChatCompletionMessageParamUnion {

--- a/chatcompletion_constructors_test.go
+++ b/chatcompletion_constructors_test.go
@@ -1,0 +1,101 @@
+package openai_test
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	openai "github.com/openai/openai-go/v3"
+)
+
+func checkAssistantMessageConstructor[T string | []openai.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion](
+	t *testing.T,
+	content T,
+	wantContent openai.ChatCompletionAssistantMessageParamContentUnion,
+	wantJSON string,
+) {
+	t.Helper()
+	got := openai.AssistantMessage(content)
+	generated := openai.ChatCompletionMessageParamOfAssistant(content)
+	if !reflect.DeepEqual(got, generated) {
+		t.Errorf("compatibility constructor = %#v, generated constructor = %#v", got, generated)
+	}
+	if got.OfAssistant == nil {
+		t.Fatal("assistant variant is nil")
+	}
+	if !reflect.DeepEqual(got.OfAssistant.Content, wantContent) {
+		t.Errorf("content = %#v, want %#v", got.OfAssistant.Content, wantContent)
+	}
+	if got.OfDeveloper != nil || got.OfSystem != nil || got.OfUser != nil || got.OfTool != nil || got.OfFunction != nil {
+		t.Error("constructor populated another message variant")
+	}
+	data, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var actual, expected any
+	if err := json.Unmarshal(data, &actual); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal([]byte(wantJSON), &expected); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("JSON = %s, want %s", data, wantJSON)
+	}
+}
+
+func TestAssistantMessageConstructorStrings(t *testing.T) {
+	for _, test := range []struct {
+		name, content, wantJSON string
+	}{
+		{"text", "hello", `{"content":"hello","role":"assistant"}`},
+		{"empty text", "", `{"content":"","role":"assistant"}`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			checkAssistantMessageConstructor(t, test.content,
+				openai.ChatCompletionAssistantMessageParamContentUnion{
+					OfString: openai.String(test.content),
+				}, test.wantJSON)
+		})
+	}
+}
+
+func TestAssistantMessageConstructorContentParts(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		content  []openai.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion
+		wantJSON string
+	}{
+		{"nil", nil, `{"role":"assistant"}`},
+		{"empty", []openai.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion{}, `{"content":[],"role":"assistant"}`},
+		{
+			"text and refusal",
+			[]openai.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion{
+				{OfText: &openai.ChatCompletionContentPartTextParam{Text: "hello"}},
+				{OfRefusal: &openai.ChatCompletionContentPartRefusalParam{Refusal: "no"}},
+			},
+			`{"content":[{"text":"hello","type":"text"},{"refusal":"no","type":"refusal"}],"role":"assistant"}`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			checkAssistantMessageConstructor(t, test.content,
+				openai.ChatCompletionAssistantMessageParamContentUnion{
+					OfArrayOfContentParts: test.content,
+				}, test.wantJSON)
+		})
+	}
+}
+
+func TestAssistantMessageConstructorRetainsContentSlice(t *testing.T) {
+	content := []openai.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion{
+		{OfText: &openai.ChatCompletionContentPartTextParam{Text: "before"}},
+	}
+	got := openai.AssistantMessage(content)
+	refusal := &openai.ChatCompletionContentPartRefusalParam{Refusal: "after"}
+	content[0] = openai.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion{OfRefusal: refusal}
+	if got.OfAssistant == nil || len(got.OfAssistant.Content.OfArrayOfContentParts) != 1 ||
+		got.OfAssistant.Content.OfArrayOfContentParts[0].OfRefusal != refusal {
+		t.Fatalf("constructor did not retain the caller's content slice: %#v", got)
+	}
+}


### PR DESCRIPTION
## Summary

Have the existing `AssistantMessage` compatibility helper delegate to
`ChatCompletionMessageParamOfAssistant`, which Castiron already generates.
The two original bodies are identical.

Both public names, generic constraints, signatures, return types, content
presence, JSON behavior, and slice aliasing are preserved. The message
conversion helpers are untouched. No compiler, schema, configuration,
API-reference, generation metadata, dependency, or workflow change is needed.

## Custom-code measurement

The public reporter verifies the same generated snapshot on both sides:
`d3deddb23e455d920842ad491f01a799e2400d7f`.

- Mixed files: **16 → 16**.
- `chatcompletion.go`: **+64/-0 → +57/-0**.
- Full mixed-file patch: **+477/-120 → +470/-120**.
- All other 15 customizations are unchanged.

## Regression coverage

No existing tests are moved, replaced, or deleted. The new SDK-owned tests
passed against both the original and delegated implementation:

- `TestAssistantMessageConstructorStrings`: nonempty and empty strings, the
  selected union field, and exact JSON values.
- `TestAssistantMessageConstructorContentParts`: nil and empty slices,
  text/refusal parts, omission versus an empty JSON array, and both public
  constructor names.
- `TestAssistantMessageConstructorRetainsContentSlice`: the original
  caller-owned slice aliasing behavior.

## Validation

- Exact-source proof: original bodies identical, public signature and all
  unrelated source unchanged.
- Full pinned `scripts/lint`: zero issues.
- `scripts/check-go-mod`: all four modules tidy.
- Full root tests against Steady 0.22.1 on Go 1.26.7 and Go 1.25.13.
- Examples and external-consumer tests on both Go versions.
- Official `scripts/detect-breaking-changes` in an isolated worktree.
- Pinned `govulncheck` on Go 1.26.7: no vulnerabilities in root or examples.
- Independent exact-range Go compatibility, typing, ownership, and regression
  review: no findings.

Local executable builds used `GOFLAGS=-buildvcs=false` to avoid the environment's
non-repository home `.git` directory; no source-analysis or test gate was
disabled.
