### PR TITLE
refactor(webhooks): isolate verification helpers

### DIFF
--- a/webhooks/webhook.go
+++ b/webhooks/webhook.go
@@ -3,17 +3,8 @@
 package webhooks
 
 import (
-	"crypto/hmac"
-	"crypto/sha256"
-	"crypto/subtle"
-	"encoding/base64"
 	"encoding/json"
-	"errors"
-	"fmt"
 	"net/http"
-	"slices"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/openai/openai-go/v3/internal/apijson"
@@ -44,51 +35,20 @@ func NewWebhookService(opts ...option.RequestOption) (r WebhookService) {
 
 // Validates that the given payload was sent by OpenAI and parses the payload.
 func (r *WebhookService) Unwrap(body []byte, headers http.Header, opts ...option.RequestOption) (*UnwrapWebhookEventUnion, error) {
-	// Always perform signature verification
-	err := r.VerifySignature(body, headers, opts...)
-	if err != nil {
-		return nil, err
-	}
-
-	res := &UnwrapWebhookEventUnion{}
-	err = res.UnmarshalJSON(body)
-	if err != nil {
-		return res, err
-	}
-	return res, nil
+	return unwrapWebhook(r, body, headers, opts...)
 }
 
 // UnwrapWithTolerance validates that the given payload was sent by OpenAI using custom tolerance, then parses the payload.
 // tolerance specifies the maximum age of the webhook.
 func (r *WebhookService) UnwrapWithTolerance(body []byte, headers http.Header, tolerance time.Duration, opts ...option.RequestOption) (*UnwrapWebhookEventUnion, error) {
-	err := r.VerifySignatureWithTolerance(body, headers, tolerance, opts...)
-	if err != nil {
-		return nil, err
-	}
-
-	res := &UnwrapWebhookEventUnion{}
-	err = res.UnmarshalJSON(body)
-	if err != nil {
-		return res, err
-	}
-	return res, nil
+	return unwrapWebhookWithTolerance(r, body, headers, tolerance, opts...)
 }
 
 // UnwrapWithToleranceAndTime validates that the given payload was sent by OpenAI using custom tolerance and time, then parses the payload.
 // tolerance specifies the maximum age of the webhook.
 // now allows specifying the current time for testing purposes.
 func (r *WebhookService) UnwrapWithToleranceAndTime(body []byte, headers http.Header, tolerance time.Duration, now time.Time, opts ...option.RequestOption) (*UnwrapWebhookEventUnion, error) {
-	err := r.VerifySignatureWithToleranceAndTime(body, headers, tolerance, now, opts...)
-	if err != nil {
-		return nil, err
-	}
-
-	res := &UnwrapWebhookEventUnion{}
-	err = res.UnmarshalJSON(body)
-	if err != nil {
-		return res, err
-	}
-	return res, nil
+	return unwrapWebhookWithToleranceAndTime(r, body, headers, tolerance, now, opts...)
 }
 
 // VerifySignature validates whether or not the webhook payload was sent by OpenAI.
@@ -110,85 +70,7 @@ func (r *WebhookService) VerifySignatureWithTolerance(body []byte, headers http.
 // tolerance specifies the maximum age of the webhook.
 // now allows specifying the current time for testing purposes.
 func (r *WebhookService) VerifySignatureWithToleranceAndTime(body []byte, headers http.Header, tolerance time.Duration, now time.Time, opts ...option.RequestOption) error {
-	cfg, err := requestconfig.PreRequestOptions(slices.Concat(r.Options, opts)...)
-	if err != nil {
-		return err
-	}
-	webhookSecret := cfg.WebhookSecret
-
-	if webhookSecret == "" {
-		return errors.New("webhook secret must be provided either in the method call or configured on the client")
-	}
-	decodedSecret, err := decodeWebhookSecret(webhookSecret)
-	if err != nil {
-		return err
-	}
-
-	if headers == nil {
-		return errors.New("headers are required for webhook verification")
-	}
-
-	// Extract required headers
-	signatureHeader := headers.Get("webhook-signature")
-	if signatureHeader == "" {
-		return errors.New("missing required webhook-signature header")
-	}
-
-	timestampHeader := headers.Get("webhook-timestamp")
-	if timestampHeader == "" {
-		return errors.New("missing required webhook-timestamp header")
-	}
-
-	webhookID := headers.Get("webhook-id")
-	if webhookID == "" {
-		return errors.New("missing required webhook-id header")
-	}
-
-	// Validate timestamp to prevent replay attacks
-	timestampSeconds, err := strconv.ParseInt(timestampHeader, 10, 64)
-	if err != nil {
-		return errors.New("invalid webhook timestamp format")
-	}
-
-	nowUnix := now.Unix()
-	toleranceSeconds := int64(tolerance.Seconds())
-
-	if nowUnix-timestampSeconds > toleranceSeconds {
-		return errors.New("webhook timestamp is too old")
-	}
-
-	if timestampSeconds > nowUnix+toleranceSeconds {
-		return errors.New("webhook timestamp is too new")
-	}
-
-	// Extract signatures from v1,<base64> format
-	// The signature header can have multiple values, separated by spaces.
-	// Each value is in the format v1,<base64>. We should accept if any match.
-	var signatures []string
-	for _, part := range strings.Fields(signatureHeader) {
-		if strings.HasPrefix(part, "v1,") {
-			signatures = append(signatures, part[3:])
-		} else {
-			signatures = append(signatures, part)
-		}
-	}
-
-	// Create the signed payload: {webhook_id}.{timestamp}.{payload}
-	signedPayload := fmt.Sprintf("%s.%s.%s", webhookID, timestampHeader, string(body))
-
-	// Compute HMAC-SHA256 signature
-	h := hmac.New(sha256.New, decodedSecret)
-	h.Write([]byte(signedPayload))
-	expectedSignature := base64.StdEncoding.EncodeToString(h.Sum(nil))
-
-	// Accept if any signature matches using timing-safe comparison
-	for _, signature := range signatures {
-		if subtle.ConstantTimeCompare([]byte(expectedSignature), []byte(signature)) == 1 {
-			return nil
-		}
-	}
-
-	return errors.New("webhook signature verification failed")
+	return verifyWebhookSignatureWithToleranceAndTime(r, body, headers, tolerance, now, opts...)
 }
 
 // Sent when a batch API request has been cancelled.

--- a/webhooks/webhook_helpers.go
+++ b/webhooks/webhook_helpers.go
@@ -1,0 +1,143 @@
+package webhooks
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net/http"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/openai/openai-go/v3/internal/requestconfig"
+	"github.com/openai/openai-go/v3/option"
+)
+
+func unwrapWebhook(r *WebhookService, body []byte, headers http.Header, opts ...option.RequestOption) (*UnwrapWebhookEventUnion, error) {
+	// Always perform signature verification
+	err := r.VerifySignature(body, headers, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	res := &UnwrapWebhookEventUnion{}
+	err = res.UnmarshalJSON(body)
+	if err != nil {
+		return res, err
+	}
+	return res, nil
+}
+
+func unwrapWebhookWithTolerance(r *WebhookService, body []byte, headers http.Header, tolerance time.Duration, opts ...option.RequestOption) (*UnwrapWebhookEventUnion, error) {
+	err := r.VerifySignatureWithTolerance(body, headers, tolerance, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	res := &UnwrapWebhookEventUnion{}
+	err = res.UnmarshalJSON(body)
+	if err != nil {
+		return res, err
+	}
+	return res, nil
+}
+
+func unwrapWebhookWithToleranceAndTime(r *WebhookService, body []byte, headers http.Header, tolerance time.Duration, now time.Time, opts ...option.RequestOption) (*UnwrapWebhookEventUnion, error) {
+	err := r.VerifySignatureWithToleranceAndTime(body, headers, tolerance, now, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	res := &UnwrapWebhookEventUnion{}
+	err = res.UnmarshalJSON(body)
+	if err != nil {
+		return res, err
+	}
+	return res, nil
+}
+
+func verifyWebhookSignatureWithToleranceAndTime(r *WebhookService, body []byte, headers http.Header, tolerance time.Duration, now time.Time, opts ...option.RequestOption) error {
+	cfg, err := requestconfig.PreRequestOptions(slices.Concat(r.Options, opts)...)
+	if err != nil {
+		return err
+	}
+	webhookSecret := cfg.WebhookSecret
+
+	if webhookSecret == "" {
+		return errors.New("webhook secret must be provided either in the method call or configured on the client")
+	}
+	decodedSecret, err := decodeWebhookSecret(webhookSecret)
+	if err != nil {
+		return err
+	}
+
+	if headers == nil {
+		return errors.New("headers are required for webhook verification")
+	}
+
+	// Extract required headers
+	signatureHeader := headers.Get("webhook-signature")
+	if signatureHeader == "" {
+		return errors.New("missing required webhook-signature header")
+	}
+
+	timestampHeader := headers.Get("webhook-timestamp")
+	if timestampHeader == "" {
+		return errors.New("missing required webhook-timestamp header")
+	}
+
+	webhookID := headers.Get("webhook-id")
+	if webhookID == "" {
+		return errors.New("missing required webhook-id header")
+	}
+
+	// Validate timestamp to prevent replay attacks
+	timestampSeconds, err := strconv.ParseInt(timestampHeader, 10, 64)
+	if err != nil {
+		return errors.New("invalid webhook timestamp format")
+	}
+
+	nowUnix := now.Unix()
+	toleranceSeconds := int64(tolerance.Seconds())
+
+	if nowUnix-timestampSeconds > toleranceSeconds {
+		return errors.New("webhook timestamp is too old")
+	}
+
+	if timestampSeconds > nowUnix+toleranceSeconds {
+		return errors.New("webhook timestamp is too new")
+	}
+
+	// Extract signatures from v1,<base64> format
+	// The signature header can have multiple values, separated by spaces.
+	// Each value is in the format v1,<base64>. We should accept if any match.
+	var signatures []string
+	for _, part := range strings.Fields(signatureHeader) {
+		if strings.HasPrefix(part, "v1,") {
+			signatures = append(signatures, part[3:])
+		} else {
+			signatures = append(signatures, part)
+		}
+	}
+
+	// Create the signed payload: {webhook_id}.{timestamp}.{payload}
+	signedPayload := fmt.Sprintf("%s.%s.%s", webhookID, timestampHeader, string(body))
+
+	// Compute HMAC-SHA256 signature
+	h := hmac.New(sha256.New, decodedSecret)
+	h.Write([]byte(signedPayload))
+	expectedSignature := base64.StdEncoding.EncodeToString(h.Sum(nil))
+
+	// Accept if any signature matches using timing-safe comparison
+	for _, signature := range signatures {
+		if subtle.ConstantTimeCompare([]byte(expectedSignature), []byte(signature)) == 1 {
+			return nil
+		}
+	}
+
+	return errors.New("webhook signature verification failed")
+}

--- a/webhooks/webhook_helpers_test.go
+++ b/webhooks/webhook_helpers_test.go
@@ -1,0 +1,151 @@
+package webhooks_test
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"reflect"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/openai/openai-go/v3/option"
+	"github.com/openai/openai-go/v3/webhooks"
+)
+
+const webhookHelperSecret = "synthetic-webhook-helper-secret"
+
+func signedWebhookHelperHeaders(t *testing.T, body []byte, timestamp int64) http.Header {
+	t.Helper()
+	timestampString := strconv.FormatInt(timestamp, 10)
+	h := hmac.New(sha256.New, []byte(webhookHelperSecret))
+	if _, err := h.Write([]byte("wh_helper." + timestampString + "." + string(body))); err != nil {
+		t.Fatal(err)
+	}
+	return http.Header{
+		"Webhook-Id":        {"wh_helper"},
+		"Webhook-Timestamp": {timestampString},
+		"Webhook-Signature": {"v1," + base64.StdEncoding.EncodeToString(h.Sum(nil))},
+	}
+}
+
+func TestWebhookUnwrapHelpersVerifyBeforeDecode(t *testing.T) {
+	service := webhooks.NewWebhookService(option.WithWebhookSecret(webhookHelperSecret))
+	now := time.Now()
+	tests := []struct {
+		name string
+		call func([]byte, http.Header) (*webhooks.UnwrapWebhookEventUnion, error)
+	}{
+		{"Unwrap", func(body []byte, headers http.Header) (*webhooks.UnwrapWebhookEventUnion, error) {
+			return service.Unwrap(body, headers)
+		}},
+		{"UnwrapWithTolerance", func(body []byte, headers http.Header) (*webhooks.UnwrapWebhookEventUnion, error) {
+			return service.UnwrapWithTolerance(body, headers, 5*time.Minute)
+		}},
+		{"UnwrapWithToleranceAndTime", func(body []byte, headers http.Header) (*webhooks.UnwrapWebhookEventUnion, error) {
+			return service.UnwrapWithToleranceAndTime(body, headers, 5*time.Minute, now)
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Run("valid raw body", func(t *testing.T) {
+				body := []byte(`{"id": "evt_helper", "object": "event", "created_at": 1700000000, "type": "response.completed", "data": {"id": "resp_helper"}}`)
+				headers := signedWebhookHelperHeaders(t, body, now.Unix())
+				originalBody, originalHeaders := bytes.Clone(body), headers.Clone()
+				result, err := test.call(body, headers)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if result == nil || result.ID != "evt_helper" || result.Type != "response.completed" || result.Data.ID != "resp_helper" || result.RawJSON() != string(body) {
+					t.Fatalf("unexpected decoded event: %#v", result)
+				}
+				if !bytes.Equal(body, originalBody) || !reflect.DeepEqual(headers, originalHeaders) {
+					t.Fatal("unwrap mutated the caller's body or headers")
+				}
+			})
+			t.Run("invalid signature and payload shape", func(t *testing.T) {
+				body := []byte(`[]`)
+				headers := signedWebhookHelperHeaders(t, []byte(`{}`), now.Unix())
+				result, err := test.call(body, headers)
+				if result != nil || err == nil || err.Error() != "webhook signature verification failed" {
+					t.Fatalf("result = %#v, error = %v; want verification failure before parsing", result, err)
+				}
+			})
+			t.Run("valid signature and invalid payload shape", func(t *testing.T) {
+				body := []byte(`[]`)
+				headers := signedWebhookHelperHeaders(t, body, now.Unix())
+				if err := service.VerifySignatureWithToleranceAndTime(body, headers, 5*time.Minute, now); err != nil {
+					t.Fatalf("raw array payload should still have a valid signature: %v", err)
+				}
+				result, err := test.call(body, headers)
+				var typeError *json.UnmarshalTypeError
+				if result == nil || !errors.As(err, &typeError) {
+					t.Fatalf("result = %#v, error = %v; want allocated result and JSON type error", result, err)
+				}
+			})
+		})
+	}
+}
+
+func TestWebhookSignatureHelperValidationOrder(t *testing.T) {
+	body := []byte(`{}`)
+	now := time.Unix(1700000000, 0)
+	for _, test := range []struct {
+		name    string
+		secret  string
+		headers http.Header
+		wantErr string
+	}{
+		{"missing secret", "", nil, "webhook secret must be provided either in the method call or configured on the client"},
+		{"invalid secret before headers", "whsec_", nil, "invalid webhook secret: decoded secret must be at least 24 bytes"},
+		{"nil headers", webhookHelperSecret, nil, "headers are required for webhook verification"},
+		{"missing signature", webhookHelperSecret, http.Header{}, "missing required webhook-signature header"},
+		{"missing timestamp", webhookHelperSecret, http.Header{"Webhook-Signature": {"invalid"}}, "missing required webhook-timestamp header"},
+		{"missing id before timestamp parsing", webhookHelperSecret, http.Header{"Webhook-Signature": {"invalid"}, "Webhook-Timestamp": {"invalid"}}, "missing required webhook-id header"},
+		{"invalid timestamp before signature", webhookHelperSecret, http.Header{"Webhook-Signature": {"invalid"}, "Webhook-Timestamp": {"invalid"}, "Webhook-Id": {"wh_helper"}}, "invalid webhook timestamp format"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			service := webhooks.NewWebhookService(option.WithWebhookSecret(test.secret))
+			err := service.VerifySignatureWithToleranceAndTime(body, test.headers, time.Minute, now)
+			if err == nil || err.Error() != test.wantErr {
+				t.Fatalf("error = %v, want %q", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestWebhookSignatureHelperToleranceBoundaries(t *testing.T) {
+	service := webhooks.NewWebhookService(option.WithWebhookSecret(webhookHelperSecret))
+	body := []byte(`{}`)
+	now := time.Unix(1700000000, 750000000)
+	for _, test := range []struct {
+		name      string
+		offset    int64
+		tolerance time.Duration
+		wantErr   string
+	}{
+		{"zero tolerance", 0, 0, ""},
+		{"old boundary", -5, 5 * time.Second, ""},
+		{"future boundary", 5, 5 * time.Second, ""},
+		{"too old", -6, 5 * time.Second, "webhook timestamp is too old"},
+		{"too new", 6, 5 * time.Second, "webhook timestamp is too new"},
+		{"fractional tolerance boundary", -1, 1500 * time.Millisecond, ""},
+		{"fractional tolerance truncation", -2, 1500 * time.Millisecond, "webhook timestamp is too old"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			headers := signedWebhookHelperHeaders(t, body, now.Unix()+test.offset)
+			err := service.VerifySignatureWithToleranceAndTime(body, headers, test.tolerance, now)
+			if test.wantErr == "" {
+				if err != nil {
+					t.Fatal(err)
+				}
+			} else if err == nil || err.Error() != test.wantErr {
+				t.Fatalf("error = %v, want %q", err, test.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Move handwritten webhook verification and decoding out of generated
`webhooks/webhook.go` to reduce the custom patch carried through regeneration.
The four substantive bodies move verbatim into same-package helpers; all six
public method signatures and the two existing thin verification wrappers remain
unchanged.

Preserve verification before decoding, raw signed bytes, effective request-secret
precedence, secret validation, timestamp tolerances, signature formats,
constant-time comparison, and exact error/return behavior. Generated event types
and the existing secret decoder are unchanged.

This is SDK-only work. No schema/compiler change, generated companion,
generation-metadata edit, API-reference change, dependency change, or quality-gate
change is needed. Every existing test is retained unchanged.

## Custom-code measurement

- Verified public generated snapshot at public base
  `6dfcd9b01bc201830df3aff3820a1664ea05e21b`.
- Mixed files: **16 → 16**.
- `webhooks/webhook.go`: **+152/-2 → +39/-7**.
- All other 15 customizations are unchanged.

## Validation

- Full existing and new webhook tests pass before extraction; three new test
  functions lock verification-before-decoding, result/error shape, caller-input
  preservation, error ordering, and timestamp boundaries.
- Post-extraction webhook race suite passes ten repetitions.
- Exact-source proof verifies all four bodies, all six public signatures, and
  every unrelated declaration and existing test are unchanged.
- Full pinned lint/build: zero findings; all four modules are tidy.
- Root, examples, and external-consumer tests pass on Go 1.26.7 and 1.25.13.
- Official breaking-change detection and pinned root/examples `govulncheck` pass.
- Finalized exact-range security review covers all three changed files and
  supporting secret/option/decoder paths: no findings or in-scope gaps.
