### PR TITLE
refactor(responses): isolate output text aggregation

### DIFF
--- a/responses/response.go
+++ b/responses/response.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/url"
 	"slices"
-	"strings"
 
 	"github.com/openai/openai-go/v3/internal/apijson"
 	"github.com/openai/openai-go/v3/internal/apiquery"
@@ -3782,15 +3781,7 @@ type Response struct {
 }
 
 func (r Response) OutputText() string {
-	var outputText strings.Builder
-	for _, item := range r.Output {
-		for _, content := range item.Content {
-			if content.Type == "output_text" {
-				outputText.WriteString(content.Text)
-			}
-		}
-	}
-	return outputText.String()
+	return responseOutputText(r)
 }
 
 // Returns the unmodified JSON received from the API

--- a/responses/response_helpers.go
+++ b/responses/response_helpers.go
@@ -1,0 +1,15 @@
+package responses
+
+import "strings"
+
+func responseOutputText(r Response) string {
+	var outputText strings.Builder
+	for _, item := range r.Output {
+		for _, content := range item.Content {
+			if content.Type == "output_text" {
+				outputText.WriteString(content.Text)
+			}
+		}
+	}
+	return outputText.String()
+}

--- a/responses/response_helpers_test.go
+++ b/responses/response_helpers_test.go
@@ -1,0 +1,71 @@
+package responses_test
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/openai/openai-go/v3/responses"
+)
+
+func TestResponseOutputTextAggregation(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		output []responses.ResponseOutputItemUnion
+		want   string
+	}{
+		{"nil output", nil, ""},
+		{"empty output", []responses.ResponseOutputItemUnion{}, ""},
+		{"nil and empty content", []responses.ResponseOutputItemUnion{{}, {Content: []responses.ResponseOutputMessageContentUnion{}}}, ""},
+		{
+			"only output text in item and content order",
+			[]responses.ResponseOutputItemUnion{
+				{Type: "message", Content: []responses.ResponseOutputMessageContentUnion{
+					{Type: "output_text", Text: "α\n"},
+					{Type: "refusal", Refusal: "no", Text: "not copied"},
+					{Type: "output_text", Text: ""},
+					{Type: "future", Text: "not copied"},
+					{Text: "not copied"},
+					{Type: "output_text", Text: "β"},
+				}},
+				{},
+				{Type: "message", Content: []responses.ResponseOutputMessageContentUnion{{Type: "output_text", Text: "!"}}},
+			},
+			"α\nβ!",
+		},
+		{
+			"content on manually constructed item without message discriminator",
+			[]responses.ResponseOutputItemUnion{{Content: []responses.ResponseOutputMessageContentUnion{{Type: "output_text", Text: "kept"}}}},
+			"kept",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			response := responses.Response{Output: test.output}
+			if got := response.OutputText(); got != test.want {
+				t.Fatalf("OutputText() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestResponseOutputTextUsesCurrentFields(t *testing.T) {
+	const body = `{"output":[{"type":"message","content":[{"type":"output_text","text":"original"},{"type":"output_text","text":"removed"}]}]}`
+	var response responses.Response
+	if err := json.Unmarshal([]byte(body), &response); err != nil {
+		t.Fatal(err)
+	}
+	if len(response.Output) != 1 || len(response.Output[0].Content) != 2 || response.RawJSON() != body {
+		t.Fatal("fixture did not decode with response metadata")
+	}
+	response.Output[0].Content[0].Text = "edited"
+	response.Output[0].Content[1].Type = "refusal"
+	wantContent := append([]responses.ResponseOutputMessageContentUnion(nil), response.Output[0].Content...)
+	for range 2 {
+		if got := response.OutputText(); got != "edited" {
+			t.Fatalf("OutputText() = %q, want current text field", got)
+		}
+	}
+	if !reflect.DeepEqual(response.Output[0].Content, wantContent) || response.RawJSON() != body {
+		t.Fatal("OutputText mutated the input or response metadata")
+	}
+}


### PR DESCRIPTION
## Summary

Move the existing `Response.OutputText` implementation verbatim into an SDK-owned
same-package helper, leaving its public method as a typed delegate. This reduces
the handwritten patch in generated `responses/response.go` without changing
aggregation order, content-type filtering, separator-free concatenation, or
current-field behavior for decoded and manually constructed responses.

The `strings` import moves with its sole use. Every other declaration and existing
test is unchanged. This is SDK-only work: no compiler/config change, generated
companion, metadata edit, API-reference change, or dependency change is needed.

## Custom-code measurement

- Verified public generated snapshot at public base
  `6dfcd9b01bc201830df3aff3820a1664ea05e21b`.
- Mixed files: **16 → 16**.
- `responses/response.go`: **+57/-64 → +48/-64**.
- All other 15 customizations are unchanged.

## Validation

- Two new behavior-lock test functions pass before and after extraction: nil and
  empty collections, accepted/rejected content, Unicode/newlines, multiple output
  items, missing item discriminator, edited fields overriding stale metadata,
  repeatability, and input preservation.
- Focused post-extraction race tests pass ten repetitions.
- Exact-source comparison proves the body and public signature are unchanged.
- Full pinned lint/build: zero findings; all four modules are tidy.
- Root, examples, and external-consumer tests pass on Go 1.26.7 and 1.25.13.
- Official breaking-change detection and pinned root/examples `govulncheck` pass.
- Independent exact-range SDK review: no validated findings.
