### PR TITLE
fix(ssestream): finalize stream resources promptly

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ stream := client.Responses.NewStreaming(ctx, responses.ResponseNewParams{
 		OfString: openai.String("Write a haiku about programming"),
 	},
 })
+defer func() { _ = stream.Close() }()
 
 for stream.Next() {
 	event := stream.Current()

--- a/examples/bedrock-runtime/main.go
+++ b/examples/bedrock-runtime/main.go
@@ -41,6 +41,7 @@ func main() {
 	}
 	if os.Getenv("BEDROCK_STREAM") == "1" {
 		stream := client.Chat.Completions.NewStreaming(ctx, params)
+		defer func() { _ = stream.Close() }()
 		for stream.Next() {
 			if choices := stream.Current().Choices; len(choices) != 0 {
 				fmt.Print(choices[0].Delta.Content)

--- a/examples/chat-completion-accumulating/main.go
+++ b/examples/chat-completion-accumulating/main.go
@@ -34,6 +34,7 @@ func main() {
 	}
 
 	stream := client.Chat.Completions.NewStreaming(ctx, params)
+	defer func() { _ = stream.Close() }()
 	acc := openai.ChatCompletionAccumulator{}
 
 	for stream.Next() {

--- a/examples/chat-completion-streaming/main.go
+++ b/examples/chat-completion-streaming/main.go
@@ -24,6 +24,7 @@ func main() {
 		Seed:  openai.Int(0),
 		Model: openai.ChatModelGPT4o,
 	})
+	defer func() { _ = stream.Close() }()
 
 	for stream.Next() {
 		evt := stream.Current()

--- a/examples/image-streaming/main.go
+++ b/examples/image-streaming/main.go
@@ -23,6 +23,7 @@ func main() {
 		Size:          openai.ImageGenerateParamsSize1024x1024,
 		PartialImages: openai.Int(3),
 	})
+	defer func() { _ = stream.Close() }()
 
 	for stream.Next() {
 		event := stream.Current()

--- a/examples/responses-streaming/main.go
+++ b/examples/responses-streaming/main.go
@@ -17,6 +17,7 @@ func main() {
 		Input: responses.ResponseNewParamsInputUnion{OfString: openai.String(question)},
 		Model: openai.ChatModelGPT4,
 	})
+	defer func() { _ = stream.Close() }()
 
 	var completeText string
 

--- a/packages/ssestream/ssestream.go
+++ b/packages/ssestream/ssestream.go
@@ -152,6 +152,7 @@ type Stream[T any] struct {
 	decoder             Decoder
 	cur                 T
 	err                 error
+	closeErr            error
 	done                bool
 	synthesizeEventData bool
 }
@@ -174,6 +175,8 @@ func NewStreamWithSynthesizeEventData[T any](decoder Decoder, err error) *Stream
 // Next returns false if the stream has ended or an error occurred.
 // Call Stream.Current() to get the current value.
 // Call Stream.Err() to get the error.
+// The stream closes automatically when it reaches a terminal event or error.
+// Call Stream.Close() if iteration stops before Next returns false.
 //
 //		for stream.Next() {
 //			data := stream.Current()
@@ -184,60 +187,52 @@ func NewStreamWithSynthesizeEventData[T any](decoder Decoder, err error) *Stream
 //	 	}
 func (s *Stream[T]) Next() bool {
 	if s.err != nil {
+		return s.finish(s.err)
+	}
+	if s.done || s.decoder == nil {
 		return false
 	}
 
-	for s.decoder.Next() {
-		if s.done {
-			continue
-		}
-
-		if bytes.HasPrefix(s.decoder.Event().Data, []byte("[DONE]")) {
-			// In this case we don't break because we still want to iterate through the full stream.
-			s.done = true
-			continue
-		}
-
-		ep := gjson.GetBytes(s.decoder.Event().Data, "error")
-		if ep.Exists() {
-			s.err = &StreamError{
-				Message: fmt.Sprintf("received error while streaming: %s", ep.String()),
-				Event:   s.decoder.Event(),
-			}
-			return false
-		}
-		var nxt T
-		data := s.decoder.Event().Data
-		if s.decoder.Event().Type != "" && strings.HasPrefix(s.decoder.Event().Type, "thread.") {
-			synthesized := map[string]any{
-				"event": s.decoder.Event().Type,
-				"data":  json.RawMessage(data),
-			}
-			data, s.err = shimjson.Marshal(synthesized)
-			if s.err != nil {
-				return false
-			}
-		} else if s.synthesizeEventData {
-			synthesized := map[string]any{
-				"event": s.decoder.Event().Type,
-				"data":  json.RawMessage(data),
-			}
-			data, s.err = shimjson.Marshal(synthesized)
-			if s.err != nil {
-				return false
-			}
-		}
-		s.err = json.Unmarshal(data, &nxt)
-		if s.err != nil {
-			return false
-		}
-		s.cur = nxt
-		return true
+	if !s.decoder.Next() {
+		// decoder.Next() may be false because of an error
+		return s.finish(s.decoder.Err())
 	}
 
-	// decoder.Next() may be false because of an error
-	s.err = s.decoder.Err()
+	event := s.decoder.Event()
+	if bytes.HasPrefix(event.Data, []byte("[DONE]")) {
+		return s.finish(nil)
+	}
 
+	ep := gjson.GetBytes(event.Data, "error")
+	if ep.Exists() {
+		return s.finish(&StreamError{
+			Message: fmt.Sprintf("received error while streaming: %s", ep.String()),
+			Event:   event,
+		})
+	}
+	var nxt T
+	data := event.Data
+	if s.synthesizeEventData || strings.HasPrefix(event.Type, "thread.") {
+		synthesized := map[string]any{
+			"event": event.Type,
+			"data":  json.RawMessage(data),
+		}
+		var err error
+		data, err = shimjson.Marshal(synthesized)
+		if err != nil {
+			return s.finish(err)
+		}
+	}
+	if err := json.Unmarshal(data, &nxt); err != nil {
+		return s.finish(err)
+	}
+	s.cur = nxt
+	return true
+}
+
+func (s *Stream[T]) finish(err error) bool {
+	s.err = err
+	_ = s.Close()
 	return false
 }
 
@@ -249,10 +244,15 @@ func (s *Stream[T]) Err() error {
 	return s.err
 }
 
+// Close releases the stream's decoder. Repeated calls return the first close
+// result without closing the decoder again.
 func (s *Stream[T]) Close() error {
-	if s.decoder == nil {
-		// already closed
-		return nil
+	s.done = true
+	decoder := s.decoder
+	if decoder == nil {
+		return s.closeErr
 	}
-	return s.decoder.Close()
+	s.decoder = nil
+	s.closeErr = decoder.Close()
+	return s.closeErr
 }

--- a/packages/ssestream/ssestream.go
+++ b/packages/ssestream/ssestream.go
@@ -9,6 +9,8 @@ import (
 	"mime"
 	"net/http"
 	"strings"
+	"sync"
+	"sync/atomic"
 
 	shimjson "github.com/openai/openai-go/v3/internal/encoding/json"
 	"github.com/tidwall/gjson"
@@ -153,7 +155,8 @@ type Stream[T any] struct {
 	cur                 T
 	err                 error
 	closeErr            error
-	done                bool
+	closeOnce           sync.Once
+	done                atomic.Bool
 	synthesizeEventData bool
 }
 
@@ -189,16 +192,17 @@ func (s *Stream[T]) Next() bool {
 	if s.err != nil {
 		return s.finish(s.err)
 	}
-	if s.done || s.decoder == nil {
+	decoder := s.decoder
+	if s.done.Load() || decoder == nil {
 		return false
 	}
 
-	if !s.decoder.Next() {
+	if !decoder.Next() {
 		// decoder.Next() may be false because of an error
-		return s.finish(s.decoder.Err())
+		return s.finish(decoder.Err())
 	}
 
-	event := s.decoder.Event()
+	event := decoder.Event()
 	if bytes.HasPrefix(event.Data, []byte("[DONE]")) {
 		return s.finish(nil)
 	}
@@ -247,12 +251,11 @@ func (s *Stream[T]) Err() error {
 // Close releases the stream's decoder. Repeated calls return the first close
 // result without closing the decoder again.
 func (s *Stream[T]) Close() error {
-	s.done = true
-	decoder := s.decoder
-	if decoder == nil {
-		return s.closeErr
-	}
-	s.decoder = nil
-	s.closeErr = decoder.Close()
+	s.closeOnce.Do(func() {
+		s.done.Store(true)
+		if s.decoder != nil {
+			s.closeErr = s.decoder.Close()
+		}
+	})
 	return s.closeErr
 }

--- a/packages/ssestream/ssestream_test.go
+++ b/packages/ssestream/ssestream_test.go
@@ -1,6 +1,7 @@
 package ssestream
 
 import (
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -276,9 +277,12 @@ func TestNewDecoderDoesNotCollapseUnsupportedExtendedParameters(t *testing.T) {
 }
 
 type testDecoder struct {
-	events  []Event
-	current Event
-	next    int
+	events     []Event
+	current    Event
+	next       int
+	err        error
+	closeErr   error
+	closeCalls int
 }
 
 func (d *testDecoder) Next() bool {
@@ -291,8 +295,195 @@ func (d *testDecoder) Next() bool {
 }
 
 func (d *testDecoder) Event() Event { return d.current }
-func (d *testDecoder) Close() error { return nil }
-func (d *testDecoder) Err() error   { return nil }
+func (d *testDecoder) Close() error {
+	d.closeCalls++
+	return d.closeErr
+}
+func (d *testDecoder) Err() error { return d.err }
+
+type terminalDecoder struct {
+	continued  chan struct{}
+	release    chan struct{}
+	nextCalls  int
+	closeCalls int
+}
+
+func newTerminalDecoder() *terminalDecoder {
+	return &terminalDecoder{
+		continued: make(chan struct{}),
+		release:   make(chan struct{}),
+	}
+}
+
+func (d *terminalDecoder) Next() bool {
+	d.nextCalls++
+	if d.nextCalls == 1 {
+		return true
+	}
+	close(d.continued)
+	<-d.release
+	return false
+}
+
+func (d *terminalDecoder) Event() Event { return Event{Data: []byte("[DONE]\n")} }
+func (d *terminalDecoder) Close() error {
+	d.closeCalls++
+	return nil
+}
+func (d *terminalDecoder) Err() error { return nil }
+
+func TestStreamStopsAndClosesAtDoneWithoutWaitingForEOF(t *testing.T) {
+	decoder := newTerminalDecoder()
+	stream := NewStream[map[string]any](decoder, nil)
+	result := make(chan bool, 1)
+
+	go func() {
+		result <- stream.Next()
+	}()
+
+	select {
+	case got := <-result:
+		if got {
+			t.Fatal("terminal event unexpectedly produced a stream value")
+		}
+	case <-decoder.continued:
+		close(decoder.release)
+		<-result
+		t.Fatal("stream continued reading after the terminal event")
+	}
+
+	if decoder.nextCalls != 1 {
+		t.Fatalf("decoder.Next called %d times, want 1", decoder.nextCalls)
+	}
+	if decoder.closeCalls != 1 {
+		t.Fatalf("decoder.Close called %d times, want 1", decoder.closeCalls)
+	}
+	if err := stream.Err(); err != nil {
+		t.Fatalf("stream ended with error: %v", err)
+	}
+}
+
+type closeTrackingReadCloser struct {
+	io.Reader
+	closeCalls int
+}
+
+func (r *closeTrackingReadCloser) Close() error {
+	r.closeCalls++
+	return nil
+}
+
+func TestStreamClosesResponseBodyAtDone(t *testing.T) {
+	body := &closeTrackingReadCloser{
+		Reader: strings.NewReader("data: [DONE]\n\n"),
+	}
+	stream := NewStream[map[string]any](NewDecoder(&http.Response{
+		Header: http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:   body,
+	}), nil)
+
+	if stream.Next() {
+		t.Fatal("terminal event unexpectedly produced a stream value")
+	}
+	if body.closeCalls != 1 {
+		t.Fatalf("response body Close called %d times, want 1", body.closeCalls)
+	}
+	if err := stream.Close(); err != nil {
+		t.Fatalf("second stream.Close returned error: %v", err)
+	}
+	if body.closeCalls != 1 {
+		t.Fatalf("response body Close called %d times after repeated close, want 1", body.closeCalls)
+	}
+}
+
+func TestStreamClosesOnUnrecoverableErrorsAndEOF(t *testing.T) {
+	tests := map[string]struct {
+		decoder    *testDecoder
+		initialErr error
+		checkErr   func(*testing.T, error)
+	}{
+		"stream error": {
+			decoder: &testDecoder{events: []Event{{Data: []byte(`{"error":{"message":"bad"}}`)}}},
+			checkErr: func(t *testing.T, err error) {
+				t.Helper()
+				var streamErr *StreamError
+				if !errors.As(err, &streamErr) {
+					t.Fatalf("stream error = %v, want *StreamError", err)
+				}
+			},
+		},
+		"decode error": {
+			decoder: &testDecoder{events: []Event{{Data: []byte(`not json`)}}},
+			checkErr: func(t *testing.T, err error) {
+				t.Helper()
+				var syntaxErr *json.SyntaxError
+				if !errors.As(err, &syntaxErr) {
+					t.Fatalf("stream error = %v, want *json.SyntaxError", err)
+				}
+			},
+		},
+		"decoder error": {
+			decoder: &testDecoder{err: errTestReader},
+			checkErr: func(t *testing.T, err error) {
+				t.Helper()
+				if !errors.Is(err, errTestReader) {
+					t.Fatalf("stream error = %v, want %v", err, errTestReader)
+				}
+			},
+		},
+		"initial error": {
+			decoder:    &testDecoder{},
+			initialErr: errTestReader,
+			checkErr: func(t *testing.T, err error) {
+				t.Helper()
+				if !errors.Is(err, errTestReader) {
+					t.Fatalf("stream error = %v, want %v", err, errTestReader)
+				}
+			},
+		},
+		"EOF": {
+			decoder: &testDecoder{},
+			checkErr: func(t *testing.T, err error) {
+				t.Helper()
+				if err != nil {
+					t.Fatalf("stream ended with error: %v", err)
+				}
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			stream := NewStream[map[string]any](test.decoder, test.initialErr)
+
+			if stream.Next() {
+				t.Fatal("terminal stream state unexpectedly produced a value")
+			}
+			test.checkErr(t, stream.Err())
+			if test.decoder.closeCalls != 1 {
+				t.Fatalf("decoder.Close called %d times, want 1", test.decoder.closeCalls)
+			}
+		})
+	}
+}
+
+func TestStreamCloseIsIdempotent(t *testing.T) {
+	errClose := errors.New("test close error")
+	decoder := &testDecoder{closeErr: errClose}
+	stream := NewStream[map[string]any](decoder, nil)
+
+	for range 2 {
+		if err := stream.Close(); !errors.Is(err, errClose) {
+			t.Fatalf("stream.Close error = %v, want %v", err, errClose)
+		}
+	}
+	if decoder.closeCalls != 1 {
+		t.Fatalf("decoder.Close called %d times, want 1", decoder.closeCalls)
+	}
+	if stream.Next() {
+		t.Fatal("closed stream unexpectedly produced a value")
+	}
+}
 
 func TestSynthesizedStreamPreservesCustomEventsWithoutData(t *testing.T) {
 	decoder := &testDecoder{events: []Event{{Type: "custom.heartbeat"}}}

--- a/packages/ssestream/ssestream_test.go
+++ b/packages/ssestream/ssestream_test.go
@@ -7,7 +7,10 @@ import (
 	"net/http"
 	"reflect"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestStreamSkipsEventsWithoutData(t *testing.T) {
@@ -482,6 +485,73 @@ func TestStreamCloseIsIdempotent(t *testing.T) {
 	}
 	if stream.Next() {
 		t.Fatal("closed stream unexpectedly produced a value")
+	}
+}
+
+type blockingReadCloser struct {
+	readStarted chan struct{}
+	closed      chan struct{}
+	readOnce    sync.Once
+	closeOnce   sync.Once
+	closeCalls  atomic.Int32
+}
+
+func newBlockingReadCloser() *blockingReadCloser {
+	return &blockingReadCloser{
+		readStarted: make(chan struct{}),
+		closed:      make(chan struct{}),
+	}
+}
+
+func (r *blockingReadCloser) Read([]byte) (int, error) {
+	r.readOnce.Do(func() { close(r.readStarted) })
+	<-r.closed
+	return 0, io.ErrClosedPipe
+}
+
+func (r *blockingReadCloser) Close() error {
+	r.closeCalls.Add(1)
+	r.closeOnce.Do(func() { close(r.closed) })
+	return nil
+}
+
+func TestStreamCloseInterruptsBlockedNext(t *testing.T) {
+	body := newBlockingReadCloser()
+	stream := NewStream[map[string]any](NewDecoder(&http.Response{
+		Header: http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:   body,
+	}), nil)
+	nextResult := make(chan bool, 1)
+
+	go func() {
+		nextResult <- stream.Next()
+	}()
+
+	<-body.readStarted
+	if err := stream.Close(); err != nil {
+		t.Fatalf("stream.Close returned error: %v", err)
+	}
+
+	select {
+	case got := <-nextResult:
+		if got {
+			t.Fatal("interrupted stream unexpectedly produced a value")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("stream.Next remained blocked after Close")
+	}
+
+	if !errors.Is(stream.Err(), io.ErrClosedPipe) {
+		t.Fatalf("stream error = %v, want %v", stream.Err(), io.ErrClosedPipe)
+	}
+	if got := body.closeCalls.Load(); got != 1 {
+		t.Fatalf("response body Close called %d times, want 1", got)
+	}
+	if err := stream.Close(); err != nil {
+		t.Fatalf("second stream.Close returned error: %v", err)
+	}
+	if got := body.closeCalls.Load(); got != 1 {
+		t.Fatalf("response body Close called %d times after repeated close, want 1", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- stop stream iteration at terminal markers and release the decoder
- make stream cleanup idempotent while preserving close errors
- close streams immediately in streaming examples

## Testing

- `go test -race ./packages/ssestream -count=20`
- `SKIP_MOCK_TESTS=true go test ./...`
- `go -C examples test ./...`
- `go -C internal/testdata/consumer test -mod=readonly ./...`
- `./scripts/check-go-mod`
- `./scripts/lint`
