### PR TITLE
ci: check custom-code budgets against main's policy

### DIFF
--- a/.github/workflows/castiron-custom-code-comment.yml
+++ b/.github/workflows/castiron-custom-code-comment.yml
@@ -13,9 +13,168 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  compute:
+    name: Compute trusted custom-code report
+    if: contains(fromJSON('["pull_request", "merge_group"]'), github.event.workflow_run.event) && github.event.workflow_run.path == '.github/workflows/castiron-custom-code.yml'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: read
+    outputs:
+      number: ${{ steps.report.outputs.number }}
+      artifact-id: ${{ steps.artifact.outputs.artifact-id }}
+      artifact-run-attempt: ${{ github.run_attempt }}
+      base-sha: ${{ steps.budget.outputs.base_sha }}
+      head-sha: ${{ steps.budget.outputs.head_sha }}
+      isolation: ${{ steps.budget.outputs.isolation }}
+      budget: ${{ steps.budget.outputs.budget }}
+    steps:
+      - name: Check out the trusted reporter
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Compute from the current pull request Git objects
+        id: report
+        if: github.event.workflow_run.event == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GIT_CONFIG_COUNT: '2'
+          GIT_CONFIG_KEY_0: credential.helper
+          GIT_CONFIG_VALUE_0: ''
+          GIT_CONFIG_KEY_1: credential.https://github.com.helper
+          GIT_CONFIG_VALUE_1: '!gh auth git-credential'
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+        run: |
+          python3 -I scripts/castiron/custom_code_report.py trusted-report \
+            --repo "$RUNNER_TEMP/castiron-objects.git" \
+            --repository "$REPOSITORY" --run-id "$RUN_ID" --run-attempt "$RUN_ATTEMPT" \
+            --out "$RUNNER_TEMP/castiron-custom-code"
+          if test -f "$RUNNER_TEMP/castiron-custom-code/context.json"; then
+            number=$(jq -er '.pr' "$RUNNER_TEMP/castiron-custom-code/context.json")
+            printf 'number=%s\n' "$number" >> "$GITHUB_OUTPUT"
+            cat "$RUNNER_TEMP/castiron-custom-code/summary.md" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload the trusted report and patch
+        id: artifact
+        if: steps.report.outputs.number != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: castiron-custom-code-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/castiron-custom-code/
+          if-no-files-found: error
+          retention-days: 7
+
+      # The prior step's report was computed here from
+      # Git objects by main's reporter, not downloaded from the candidate run.
+      - name: Evaluate main's custom-code budget
+        id: budget
+        if: always()
+        continue-on-error: true # A budget failure must not suppress the existing report comment.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          SOURCE_EVENT: ${{ github.event.workflow_run.event }}
+          GIT_CONFIG_COUNT: '2'
+          GIT_CONFIG_KEY_0: credential.helper
+          GIT_CONFIG_VALUE_0: ''
+          GIT_CONFIG_KEY_1: credential.https://github.com.helper
+          GIT_CONFIG_VALUE_1: '!gh auth git-credential'
+        run: |
+          trusted_sha=$(git rev-parse HEAD)
+          reuse=()
+          if [[ "$SOURCE_EVENT" == pull_request ]]; then
+            reuse=(--trusted-report-dir "$RUNNER_TEMP/castiron-custom-code")
+          fi
+          python3 -I scripts/castiron/custom_code_budget.py github \
+            --repository "$REPOSITORY" --event-path "$GITHUB_EVENT_PATH" \
+            --trusted-sha "$trusted_sha" --repo "$RUNNER_TEMP/castiron-objects.git" \
+            "${reuse[@]}" --out "$RUNNER_TEMP/custom-code-budget"
+
+      - name: Add the budget to the run summary
+        if: always()
+        run: |
+          if test -f "$RUNNER_TEMP/custom-code-budget/summary.md"; then
+            cat "$RUNNER_TEMP/custom-code-budget/summary.md" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload trusted budget measurements
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: custom-code-budget-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/custom-code-budget/
+          if-no-files-found: error
+          retention-days: 7
+
+  budget-status:
+    name: Publish custom-code budget checks
+    needs: compute
+    if: always() && !cancelled() && needs.compute.result != 'skipped'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: read
+      statuses: write
+    steps:
+      # This workflow definition is from main. No candidate checkout/artifacts.
+      - name: Publish exact-head statuses after checking freshness
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          BASE_SHA: ${{ needs.compute.outputs.base-sha }}
+          HEAD_SHA: ${{ needs.compute.outputs.head-sha }}
+          ISOLATION_RESULT: ${{ needs.compute.outputs.isolation }}
+          BUDGET_RESULT: ${{ needs.compute.outputs.budget }}
+        with:
+          script: |
+            const event = context.payload.workflow_run;
+            const {data: run} = await github.rest.actions.getWorkflowRun({...context.repo, run_id: event.id});
+            if (run.head_sha !== event.head_sha || run.run_attempt !== event.run_attempt ||
+                run.status !== 'completed' || run.path.split('@', 1)[0] !== '.github/workflows/castiron-custom-code.yml' ||
+                run.repository.full_name !== `${context.repo.owner}/${context.repo.repo}`) return;
+            const head = run.head_sha;
+            if (!/^[0-9a-f]{40}$/.test(head)) throw new Error('Invalid candidate SHA');
+            const {data: main} = await github.rest.git.getRef({...context.repo, ref: 'heads/main'});
+            const base = main.object.sha;
+            if (run.event === 'pull_request') {
+              const pulls = run.pull_requests.length ? run.pull_requests : await github.paginate(
+                github.rest.repos.listPullRequestsAssociatedWithCommit, {...context.repo, commit_sha: head});
+              const current = [];
+              for (const pull of pulls) {
+                const {data: pr} = await github.rest.pulls.get({...context.repo, pull_number: pull.number});
+                if (pr.state === 'open' && pr.head.sha === head && pr.base.sha === base &&
+                    pr.base.ref === 'main' && pr.base.repo.full_name === `${context.repo.owner}/${context.repo.repo}`) current.push(pr);
+              }
+              if (current.length !== 1) return;
+            } else if (run.event !== 'merge_group' || !run.head_branch.startsWith('gh-readonly-queue/main/')) {
+              return;
+            }
+            const fresh = base === process.env.BASE_SHA && head === process.env.HEAD_SHA;
+            const url = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            for (const [name, result] of [
+              ['Castiron / budget-only change', process.env.ISOLATION_RESULT],
+              ['Castiron / custom-code budget', process.env.BUDGET_RESULT],
+            ]) {
+              const state = fresh && result === 'success' ? 'success' : 'failure';
+              const description = !fresh ? 'Evaluation unavailable or base changed; rerun against current main.'
+                : state === 'success' ? 'Passed against main policy. See the trusted run summary.'
+                : 'Budget check failed. See the trusted run summary.';
+              await github.rest.repos.createCommitStatus({...context.repo, sha: head, context: name,
+                state, description, target_url: url});
+            }
+
   comment:
     name: Update custom-code comment
-    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.path == '.github/workflows/castiron-custom-code.yml'
+    needs: compute
+    if: always() && !cancelled() && github.event.workflow_run.event == 'pull_request' && (needs.compute.result == 'failure' || needs.compute.outputs.number != '')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -29,40 +188,31 @@ jobs:
           ref: ${{ github.workflow_sha }}
           persist-credentials: false
 
-      - name: Download the completed run's report
+      - name: Download this workflow's trusted report
+        if: needs.compute.result == 'success'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          github-token: ${{ github.token }}
-          run-id: ${{ github.event.workflow_run.id }}
-          name: castiron-custom-code-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}
+          artifact-ids: ${{ needs.compute.outputs.artifact-id }}
+          merge-multiple: true
           path: ${{ runner.temp }}/castiron-custom-code
-
-      - name: Validate report context
-        id: context
-        env:
-          REPOSITORY: ${{ github.repository }}
-          RUN_ID: ${{ github.event.workflow_run.id }}
-          RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
-        run: |
-          number=$(jq -er --arg repository "$REPOSITORY" --argjson run "$RUN_ID" \
-            --argjson attempt "$RUN_ATTEMPT" \
-            'select(.repository == $repository and .run == $run and .attempt == $attempt) | .pr | select(type == "number" and . > 0 and . == floor)' \
-            "$RUNNER_TEMP/castiron-custom-code/context.json")
-          printf 'number=%s\n' "$number" >> "$GITHUB_OUTPUT"
 
       - name: Create or update the single report comment
         id: publish
+        if: needs.compute.result == 'success'
         env:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
-          PR_NUMBER: ${{ steps.context.outputs.number }}
+          PR_NUMBER: ${{ needs.compute.outputs.number }}
           RUN_ID: ${{ github.event.workflow_run.id }}
           RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          ARTIFACT_RUN_ID: ${{ github.run_id }}
+          ARTIFACT_RUN_ATTEMPT: ${{ needs.compute.outputs.artifact-run-attempt }}
         run: |
           python3 -I scripts/castiron/custom_code_report.py comment \
             --report "$RUNNER_TEMP/castiron-custom-code/report.json" \
             --repository "$REPOSITORY" --pr "$PR_NUMBER" --run-id "$RUN_ID" \
-            --run-attempt "$RUN_ATTEMPT"
+            --run-attempt "$RUN_ATTEMPT" \
+            --artifact-run-id "$ARTIFACT_RUN_ID" --artifact-run-attempt "$ARTIFACT_RUN_ATTEMPT"
 
       - name: Publish a trusted failure status
         if: always() && !cancelled() && steps.publish.outcome != 'success'

--- a/.github/workflows/castiron-custom-code.yml
+++ b/.github/workflows/castiron-custom-code.yml
@@ -3,20 +3,32 @@ name: Castiron custom code
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, edited]
+  # Notify the existing trusted handler for queue candidates.
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read
 
 concurrency:
-  group: castiron-custom-code-${{ github.event.pull_request.number }}
+  group: castiron-custom-code-${{ github.event.pull_request.number || github.event.merge_group.head_ref }}
   cancel-in-progress: false
 
 env:
-  REPORTER_SHA256: 73ecd6290e9803b0d0a93af4ca4dccdbf8648cbd5c0cce51ea65fce28c7da79f
+  REPORTER_SHA256: b971c18701081ff47e7a5f935fd1fe9cd5f58b3d8f570a4daede62c5611e3fc9
 
 jobs:
+  queue-signal:
+    if: github.event_name == 'merge_group'
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    permissions: {}
+    steps:
+      - run: echo 'The workflow_run handler on main evaluates this candidate independently.'
+
   report:
+    if: github.event_name == 'pull_request'
     name: Castiron / baseline consistency
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -44,8 +56,8 @@ jobs:
       - name: Verify the reporter matches its generated workflow
         run: printf '%s  %s\n' "$REPORTER_SHA256" scripts/castiron/custom_code_report.py | sha256sum --check --strict
 
-      - name: Test hash mismatch and snapshot isolation
-        run: python3 -m unittest discover -s scripts/castiron -p test_custom_code_report.py
+      - name: Test snapshot isolation and the custom-code budget
+        run: python3 -m unittest discover -s scripts/castiron -p 'test_custom_code*.py'
 
       - name: Validate the codegen hash and report custom code
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,16 @@ changing generated files. Handwritten policy, automation, tests, and examples
 should remain small and should not alter exported SDK APIs unless the change
 explicitly requires it.
 
+## Custom-code budget
+
+Follow [the custom-code guidance](scripts/castiron/CUSTOM_CODE.md). Budget changes
+belong in a separate PR containing only `.castiron-ratchet.json`, with an explicit justification
+in the PR description. Increases require a **human approving review** before merging.
+Agents may investigate and draft proposals, but must not approve budget increases
+(including through a human's credentials) or bypass the gate. Do not weaken
+counting, broaden exclusions, or alter generation metadata to make a change pass.
+The checker and effective budget come from main, not the PR. Keep default CODEOWNERS.
+
 ## Security requirements
 
 - Never commit, print, or upload API keys, bearer tokens, cloud credentials,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,23 @@ Most of the SDK is generated code. Modifications to code will be persisted betwe
 result in merge conflicts between manual patches and changes from the generator. The generator will never
 modify the contents of the `lib/` and `examples/` directories.
 
+## Custom-code budget
+
+The custom-code budget counts additions plus deletions in the remaining patch
+against verified generated output. `.castiron-ratchet.json` defines this repository's
+ceiling. CI uses the checker and budget on main, not the PR's proposed versions.
+
+Budget changes must be in a separate PR modifying **only `.castiron-ratchet.json`**.
+Justify the current usage, proposed ceiling, and why fixing generation is not
+appropriate in the PR description. Increases require a **human approving review**
+and must merge before an SDK change relies on them. Agents may draft proposals,
+but must not approve increases or bypass the gate. Keep default CODEOWNERS.
+Lower the ceiling after cleanup while retaining headroom; decreases must still
+fit the measured usage.
+
+See [custom-code technical details](scripts/castiron/CUSTOM_CODE.md) for accounting,
+local checks, trusted CI, and activation instructions.
+
 ## Security requirements
 
 - Never commit API keys, access tokens, Azure or AWS credentials, signing

--- a/scripts/castiron/CUSTOM_CODE.md
+++ b/scripts/castiron/CUSTOM_CODE.md
@@ -1,0 +1,117 @@
+# Custom code
+
+The custom-code reporter measures the SDK's remaining customization of generated
+files. The budget gate checks that measurement against the repository's policy.
+See [CONTRIBUTING.md](../../CONTRIBUTING.md#custom-code-budget) for budget changes
+and human review, and [AGENTS.md](../../AGENTS.md#custom-code-budget) for agent rules.
+
+## What is counted
+
+The budget is **added lines plus deleted lines in the entire current custom patch**
+against the candidate's verified pure-generated snapshot. It is not the PR's diff
+against main, and additions and deletions never cancel. Replacing 500 generated
+lines with 500 handwritten lines costs 1,000 lines. Deleting a generated file
+counts all its removed lines. Restoring generated content reduces the budget.
+
+The checker reuses `scripts/castiron/custom_code_report.py` without changing its
+snapshot/hash validation or generated-file ownership. It counts generated-owned
+files, including runtime code, tests, and generated documentation. Wholly
+handwritten-only files are outside this existing report's scope. Changes in
+generation ownership remain visible in the report; do not change exclusions or
+checkpoints to hide customization. Non-text custom patches fail as uncountable.
+
+The ceiling is defined in [`.castiron-ratchet.json`](../../.castiron-ratchet.json).
+The policy file contains only an integer `schema_version` (currently 1) and a
+nonnegative integer `max_custom_patch_lines`. Missing, deleted, renamed, executable, symlinked,
+malformed, or unsupported policy files fail closed. There is no disable flag or
+automatic budget update command.
+
+Budget-file isolation is checked against the complete PR diff, not just its latest
+commit. Increases never apply to their own PR or merge group. Decreases must also
+fit the measured usage. Human approval is contributor and agent policy plus normal
+review, not an automated claim that GitHub can identify who operated an account.
+
+## Trusted CI
+
+The custom-code workflow pair separates candidate execution from trusted checks:
+
+- `castiron-custom-code.yml` runs proposed offline tests and the advisory report
+  on `pull_request` with read-only permissions.
+- `castiron-custom-code-comment.yml` handles `workflow_run` from **main**. Its
+  read-only compute job runs main's reporter against candidate Git objects in a
+  new bare repository, then reuses that verified report to check main's budget.
+  It never checks out, imports, installs, or executes candidate code.
+- An unprivileged `merge_group` job in the first workflow only signals that a candidate
+  needs checking. A `workflow_run` handler whose **workflow definition is on
+  main** then uses the same trusted checkout. It ignores the signal's conclusion
+  and artifacts, verifies the run and queue membership through GitHub and commit
+  ancestry, checks isolation per constituent PR, and measures the complete merged
+  candidate against actual main. A budget PR queued in the same group cannot
+  grant the SDK PR a higher limit.
+
+A separate publisher with no checkout attaches these statuses to the exact PR
+head or merge-group SHA, after rechecking head/base freshness:
+
+- `Castiron / budget-only change`
+- `Castiron / custom-code budget`
+
+The policy is read from the current base commit, not the PR or its merge base.
+Reporter changes in a PR cannot change the checker executing on that PR. Missing
+snapshots, invalid hashes, unavailable queue membership, and policy errors fail
+closed. If main moves during evaluation, rerun the workflow; reruns check out the
+new main. PR-head statuses are feedback at a point in time: a main update alone
+does not rerun them. The checker therefore fails unless main has an effective
+**require merge queue** rule. The queue must recheck combined usage against current
+main before merging; do not replace that protection with PR-head statuses alone.
+
+The queue signal cannot supply a passing result, and removing it leaves required
+statuses missing. No write-capable job executes from the candidate's workflow
+definition. See GitHub's [workflow_run trust model](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_run)
+and [merge-queue behavior](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue).
+
+The trusted run summary reports additions, deletions, total, mixed-file count,
+headroom, largest patches, and exact policy/candidate/generated revisions. The
+existing custom-code comment remains unchanged, including when the budget fails.
+The trusted compute job reuses its own report, never the candidate's artifacts.
+The checker, policy, and workflows are maintained in the SDK and preserved
+through the normal three-way merge during generation.
+
+## Local verification
+
+Run from the SDK repository with Python 3.10+; no SDK dependencies are needed:
+
+```sh
+python3 -m unittest discover -s scripts/castiron -p 'test_custom_code*.py'
+```
+
+Use a **trusted checkout's** script to inspect committed revisions:
+
+```sh
+python3 -I scripts/castiron/custom_code_budget.py check \
+  --repo /path/to/sdk --base FULL_MAIN_SHA --head FULL_CANDIDATE_SHA \
+  --public --fetch --out /tmp/custom-code-budget
+```
+
+The inspected repo's `origin` must match its snapshot source. Omit `--public`
+for the private SDK repository's checkpoints. Local checks are diagnostic; CI
+independently binds main and the candidate to live GitHub metadata.
+
+## Activation order
+
+1. Merge the initial budget policy in its budget-only PR after human review.
+2. Merge the tooling and guidance separately. Do not enable required
+   statuses before the policy and trusted checker exist on main. There is no
+   permanent bootstrap exemption in the checker.
+3. Exercise a passing PR, over-budget PR, mixed budget/code PR, a fork PR, and a
+   merge-queue candidate. Policy increases must still use the old limit.
+4. Have a human administrator retain/enable **require merge queue** and add both
+   exact status names above to the main ruleset, bound to GitHub Actions. Retain
+   normal review and CODEOWNERS settings. Exercise a main-policy decrease after
+   an unchanged PR head passed, and confirm its queued candidate uses the new limit.
+   The tests job is separate from these authoritative statuses.
+
+This is an accidental-change guardrail, not an adversarial approval boundary.
+Workflow definitions and ruleset changes still have the normal repository review
+and administrator controls; GitHub Actions status names alone are not a unique
+workflow identity. Stronger organization-required workflow enforcement can be
+added later.

--- a/scripts/castiron/custom_code_budget.py
+++ b/scripts/castiron/custom_code_budget.py
@@ -1,0 +1,430 @@
+#!/usr/bin/env python3
+"""SDK custom-code budget gate. Run only from a trusted checkout, never PR code.
+
+Reuses Castiron's vendored snapshot verifier and generated-file accounting. This
+file and its workflow are maintained in the SDK repository.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+# Explicitly load the reporter beside this trusted script, including under python -I.
+# The inspected repository is only a Git object store, not a Python import path.
+_spec = importlib.util.spec_from_file_location(
+    "castiron_budget_reporter", Path(__file__).with_name("custom_code_report.py")
+)
+assert _spec is not None and _spec.loader is not None
+report = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = report
+_spec.loader.exec_module(report)
+
+POLICY = ".castiron-ratchet.json"
+ISOLATION_MESSAGE = (
+    "Budget changes require a separate, budget-only PR. "
+    "Put the justification in the PR description."
+)
+
+
+def unique_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    for key, item in pairs:
+        if key in value:
+            raise ValueError(f"duplicate policy key: {key}")
+        value[key] = item
+    return value
+
+
+def read_budget(repo: Path, revision: str) -> int:
+    revision = report.require_sha(revision)
+    entry = report.git(repo, "ls-tree", revision, "--", POLICY).split()
+    if len(entry) != 4 or entry[:2] != [b"100644", b"blob"]:
+        raise ValueError(f"{POLICY} must exist as a regular, non-executable file at {revision}")
+    if int(report.git(repo, "cat-file", "-s", entry[2].decode())) > 4096:
+        raise ValueError("budget file exceeds 4096 bytes")
+    value = json.loads(
+        report.git(repo, "show", f"{revision}:{POLICY}"), object_pairs_hook=unique_keys
+    )
+    if not isinstance(value, dict):
+        raise ValueError("budget file must be an object")
+    value = cast(dict[str, Any], value)
+    if set(value) != {"schema_version", "max_custom_patch_lines"}:
+        raise ValueError("budget file must contain only schema_version and max_custom_patch_lines")
+    if type(value["schema_version"]) is not int or value["schema_version"] != 1:
+        raise ValueError("unsupported budget schema_version")
+    limit = value["max_custom_patch_lines"]
+    if type(limit) is not int or limit < 0:
+        raise ValueError("max_custom_patch_lines must be a nonnegative integer")
+    return limit
+
+
+def changed_paths(repo: Path, base: str, head: str) -> set[bytes]:
+    """Use the entire PR diff, not its last commit or a truncated API file list."""
+    start = (
+        report.git(repo, "merge-base", report.require_sha(base), report.require_sha(head))
+        .decode()
+        .strip()
+    )
+    return set(
+        report.git(
+            repo,
+            "diff",
+            "--name-only",
+            "-z",
+            "--no-renames",
+            "--no-ext-diff",
+            "--no-textconv",
+            start,
+            head,
+            "--",
+        ).split(b"\0")
+    ) - {b""}
+
+
+def check_isolation(repo: Path, base: str, head: str) -> int | None:
+    # Validate even if the policy was removed by an earlier commit in this PR.
+    proposed = read_budget(repo, head)
+    paths = changed_paths(repo, base, head)
+    if POLICY.encode() not in paths:
+        return None
+    if paths != {POLICY.encode()}:
+        raise ValueError(ISOLATION_MESSAGE)
+    return proposed
+
+
+def count_custom_lines(result: dict[str, Any]) -> tuple[int, int]:
+    if result.get("status") != "ok":
+        raise ValueError("custom-code report could not verify the generated baseline")
+    added = removed = 0
+    for file in result["files"]:
+        if not file["custom_after"]:
+            continue
+        counts = [file["added"], file["removed"]]
+        if any(not isinstance(n, str) or not n.isascii() or not n.isdecimal() for n in counts):
+            raise ValueError(f"cannot count non-text customization: {file['path']}")
+        added += int(counts[0])
+        removed += int(counts[1])
+    return added, removed
+
+
+def outcome(state: str, description: str) -> dict[str, str]:
+    return {"state": state, "description": description}
+
+
+def evaluate(
+    repo: Path,
+    base: str,
+    head: str,
+    *,
+    public: bool,
+    fetch: bool = False,
+    pull_heads: list[str] | None = None,
+    measurement: tuple[dict[str, Any], bytes] | None = None,
+) -> tuple[dict[str, Any], bytes]:
+    """In a queue, isolate each PR but budget the complete merged candidate."""
+    base, head = report.require_sha(base), report.require_sha(head)
+    result: dict[str, Any] = {"base_sha": base, "head_sha": head, "checks": {}}
+    checks = result["checks"]
+    proposed_limits: list[int] = []
+    try:
+        read_budget(repo, base)
+        read_budget(repo, head)
+        if pull_heads is not None and not pull_heads:
+            raise ValueError("merge group has no verified constituent PRs")
+        for pr_head in pull_heads if pull_heads is not None else [head]:
+            proposed = check_isolation(repo, base, pr_head)
+            if proposed is not None:
+                proposed_limits.append(proposed)
+        checks["isolation"] = outcome(
+            "success", "Budget changes are isolated; human review is required for increases."
+        )
+    except (report.ReportError, ValueError, UnicodeError) as exc:
+        checks["isolation"] = outcome("failure", str(exc))
+
+    patch = b""
+    try:
+        limit = read_budget(repo, base)
+        result["limit"] = limit
+        measured, patch = (
+            measurement
+            if measurement is not None
+            else report.build_report(
+                repo,
+                base,
+                head,
+                public=public,
+                fetch=fetch,
+                require_head_hash=True,
+            )
+        )
+        added, removed = count_custom_lines(measured)
+        total = added + removed
+        result.update(
+            additions=added,
+            deletions=removed,
+            total=total,
+            mixed_files=measured["counts"]["after"],
+            generated=measured["after"],
+            files=measured["files"],
+        )
+        # Increases never apply to their own PR/group. Decreases must be viable too.
+        checked_limit = min([limit, *proposed_limits])
+        result["checked_limit"] = checked_limit
+        state = "success" if total <= checked_limit else "failure"
+        checks["budget"] = outcome(
+            state, f"+{added} / -{removed} = {total} custom lines; limit {checked_limit}."
+        )
+    except (report.ReportError, ValueError, UnicodeError, KeyError) as exc:
+        checks["budget"] = outcome("failure", str(exc))
+    return result, patch
+
+
+def write_result(out: Path, result: dict[str, Any], patch: bytes = b"") -> None:
+    out.mkdir(parents=True, exist_ok=True)
+    (out / "budget.json").write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
+    (out / "custom-code.patch").write_bytes(patch)
+    lines = ["## Custom-code budget", ""]
+    for name in ("isolation", "budget"):
+        check = result["checks"][name]
+        lines.append(f"- **{name}: {check['state']}** — {html.escape(check['description'])}")
+    if "total" in result:
+        lines += [
+            "",
+            f"Mixed files: **{result['mixed_files']}**. Base-budget headroom: **{result['limit'] - result['total']} lines**.",
+        ]
+        lines += [
+            "",
+            f"Policy: `{result['base_sha']}` · candidate: `{result['head_sha']}`.",
+            f"Verified generated snapshot: `{result['generated']['commit']}`.",
+            "",
+            "| Largest custom patches | Added | Deleted |",
+            "|---|---:|---:|",
+        ]
+        files = [f for f in result["files"] if f["custom_after"]]
+        for file in sorted(files, key=lambda f: int(f["added"]) + int(f["removed"]), reverse=True)[
+            :10
+        ]:
+            path = html.escape(file["path"]).replace("|", "&#124;").replace("\n", "&#10;")
+            lines.append(f"| <code>{path}</code> | {file['added']} | {file['removed']} |")
+        ownership = [f for f in result["files"] if f["category"] == "no_longer_generated"]
+        if ownership:
+            lines += ["", "**No longer generated (outside the current budget):**"]
+            lines += [f"- <code>{html.escape(f['path'])}</code>" for f in ownership]
+    lines += [
+        "",
+        "Budget increases require a separate budget-only PR, explicit justification, and a human approving review. Agents may not approve or bypass an increase.",
+    ]
+    summary = "\n".join(lines) + "\n"
+    (out / "summary.md").write_text(summary)
+    print(summary)
+
+
+def queued_entries(repository: str, branch: str) -> list[tuple[str, str]]:
+    """Query the actual queue; never infer PR membership from commit messages."""
+    owner, name = repository.split("/")
+    query = """query($owner:String!,$name:String!,$branch:String!,$cursor:String) {
+      repository(owner:$owner,name:$name) { mergeQueue(branch:$branch) {
+        entries(first:100,after:$cursor) {
+          nodes { pullRequest { headRefOid } headCommit { oid } }
+          pageInfo { hasNextPage endCursor }
+        }
+      } }
+    }"""
+    cursor = None
+    heads: list[tuple[str, str]] = []
+    while True:
+        response = report.api(
+            "POST",
+            "graphql",
+            {
+                "query": query,
+                "variables": {"owner": owner, "name": name, "branch": branch, "cursor": cursor},
+            },
+        )
+        entries = response["data"]["repository"]["mergeQueue"]["entries"]
+        for node in entries["nodes"]:
+            # Entries still awaiting preparation have no synthetic queue commit.
+            if node["headCommit"] is not None:
+                heads.append(
+                    (
+                        report.require_sha(node["pullRequest"]["headRefOid"]),
+                        report.require_sha(node["headCommit"]["oid"]),
+                    )
+                )
+        page = entries["pageInfo"]
+        if not page["hasNextPage"]:
+            return heads
+        if not page["endCursor"] or page["endCursor"] == cursor:
+            raise ValueError("invalid merge-queue pagination")
+        cursor = page["endCursor"]
+
+
+def github_evaluate(
+    repo: Path,
+    repository: str,
+    event: dict[str, Any],
+    trusted_sha: str,
+    trusted_report_dir: Path | None = None,
+) -> tuple[dict[str, Any], bytes]:
+    """Fetch data into a fresh bare repo; the executable checkout remains trusted."""
+    if not report.REPOSITORY.fullmatch(repository):
+        raise ValueError("invalid repository")
+    root = f"repos/{repository}"
+    metadata = report.api("GET", root)
+    if event["repository"]["full_name"] != repository:
+        raise ValueError("event repository mismatch")
+    branch = metadata["default_branch"]
+    main = report.require_sha(report.api("GET", f"{root}/git/ref/heads/{branch}")["object"]["sha"])
+    if report.require_sha(trusted_sha) != main:
+        raise ValueError("trusted checkout is stale; rerun against current main")
+    signal = event["workflow_run"]
+    run_id = signal["id"]
+    if type(run_id) is not int or run_id <= 0:
+        raise ValueError("invalid source run ID")
+    run = report.api("GET", f"{root}/actions/runs/{run_id}")
+    if (
+        run["head_sha"] != signal["head_sha"]
+        or run["repository"]["full_name"] != repository
+        or run["path"].split("@", 1)[0] != ".github/workflows/castiron-custom-code.yml"
+        or run["status"] != "completed"
+        or run["run_attempt"] != signal["run_attempt"]
+    ):
+        raise ValueError("unexpected or superseded source workflow run")
+    head = report.require_sha(run["head_sha"])
+    if run["event"] == "pull_request":
+        associated = run["pull_requests"] or report.api(
+            "GET", f"{root}/commits/{head}/pulls?per_page=100"
+        )
+        current: list[int] = []
+        for number in sorted({int(pr["number"]) for pr in associated}):
+            if number <= 0:
+                raise ValueError("invalid associated PR number")
+            pull = report.api("GET", f"{root}/pulls/{number}")
+            if (
+                pull["state"] == "open"
+                and pull["head"]["sha"] == head
+                and pull["base"]["repo"]["full_name"] == repository
+                and pull["base"]["ref"] == branch
+                and pull["base"]["sha"] == main
+            ):
+                current.append(number)
+        if len(current) != 1:
+            raise ValueError("source run must identify exactly one current PR targeting main")
+    elif run["event"] == "merge_group":
+        if not run["head_branch"].startswith(f"gh-readonly-queue/{branch}/"):
+            raise ValueError("queue signal does not target main")
+    else:
+        raise ValueError("unsupported budget event")
+    # PR statuses can outlive their base revision. Require the queue's fresh,
+    # combined candidate check before merging rather than relying on those alone.
+    rules = report.api("GET", f"{root}/rules/branches/{branch}")
+    if not any(rule["type"] == "merge_queue" for rule in rules):
+        raise ValueError("main must require a merge queue before activating the budget gate")
+    measurement = None
+    if trusted_report_dir is not None:
+        # Only the preceding main-branch step may supply this directory. Never
+        # download a candidate artifact here. Reuse its verified report and bare
+        # object store, avoiding a second snapshot fetch/hash/diff computation.
+        if run["event"] != "pull_request":
+            raise ValueError("only PR runs can reuse the trusted report")
+        measured = json.loads((trusted_report_dir / "report.json").read_text())
+        if measured["target_base_sha"] != main or measured["head_sha"] != head:
+            raise ValueError("trusted report is stale; rerun against current main")
+        if report.git(repo, "rev-parse", "--is-bare-repository").strip() != b"true":
+            raise ValueError("trusted report must use a bare object store")
+        measurement = (measured, (trusted_report_dir / "custom-code.patch").read_bytes())
+    else:
+        if repo.exists():
+            raise ValueError("Git object directory must be fresh")
+        subprocess.run(["git", "init", "--bare", str(repo)], check=True, capture_output=True)
+        report.git(repo, "remote", "add", "origin", f"https://github.com/{repository}.git")
+        report.git(repo, "fetch", "--quiet", "--no-tags", "origin", main, head)
+    pull_heads: list[str] | None = None
+    if run["event"] == "merge_group":
+        if report.git(repo, "merge-base", main, head).decode().strip() != main:
+            raise ValueError("merge group does not include current main; retry the current group")
+        pull_heads = []
+        entries = queued_entries(repository, branch)
+        if not any(queue_head == head for _, queue_head in entries):
+            raise ValueError("merge-group head is no longer in the current queue")
+        for candidate, queue_head in entries:
+            report.git(repo, "fetch", "--quiet", "--no-tags", "origin", queue_head)
+            ancestor = report.git(repo, "merge-base", queue_head, head).decode().strip()
+            if ancestor == queue_head:
+                report.git(repo, "fetch", "--quiet", "--no-tags", "origin", candidate)
+                pull_heads.append(candidate)
+        if not pull_heads:
+            raise ValueError("cannot verify merge-group PR membership; retry the current group")
+    return evaluate(
+        repo,
+        main,
+        head,
+        public=not metadata["private"],
+        fetch=True,
+        pull_heads=pull_heads,
+        measurement=measurement,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    local = commands.add_parser("check")
+    local.add_argument("--base", required=True)
+    local.add_argument("--head", required=True)
+    local.add_argument("--public", action="store_true")
+    local.add_argument("--fetch", action="store_true")
+    github = commands.add_parser("github")
+    github.add_argument("--repository", required=True)
+    github.add_argument("--event-path", type=Path, required=True)
+    github.add_argument("--trusted-sha", required=True)
+    github.add_argument("--trusted-report-dir", type=Path)
+    for command in (local, github):
+        command.add_argument("--repo", type=Path, required=True)
+        command.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        if args.command == "check":
+            result, patch = evaluate(
+                args.repo, args.base, args.head, public=args.public, fetch=args.fetch
+            )
+        else:
+            result, patch = github_evaluate(
+                args.repo,
+                args.repository,
+                json.loads(args.event_path.read_text()),
+                args.trusted_sha,
+                args.trusted_report_dir,
+            )
+    except (
+        report.ReportError,
+        ValueError,
+        OSError,
+        KeyError,
+        TypeError,
+        subprocess.SubprocessError,
+    ) as exc:
+        result = {
+            "checks": {name: outcome("failure", str(exc)) for name in ("isolation", "budget")}
+        }
+        patch = b""
+    write_result(args.out, result, patch)
+    if args.command == "github" and "GITHUB_OUTPUT" in os.environ:
+        with Path(os.environ["GITHUB_OUTPUT"]).open("a") as output:
+            for name in ("isolation", "budget"):
+                output.write(f"{name}={result['checks'][name]['state']}\n")
+            output.write(f"base_sha={result.get('base_sha', '')}\n")
+            output.write(f"head_sha={result.get('head_sha', '')}\n")
+    return 0 if all(c["state"] == "success" for c in result["checks"].values()) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/castiron/custom_code_report.py
+++ b/scripts/castiron/custom_code_report.py
@@ -767,7 +767,14 @@ def api(method: str, path: str, payload: dict[str, Any] | None = None) -> Any:
 
 
 def publish_comment(
-    report: dict[str, Any], repository: str, number: int, run_id: int, run_attempt: int
+    report: dict[str, Any],
+    repository: str,
+    number: int,
+    run_id: int,
+    run_attempt: int,
+    *,
+    artifact_run_id: int = 0,
+    artifact_run_attempt: int = 0,
 ) -> str:
     if not REPOSITORY.fullmatch(repository) or min(number, run_id, run_attempt) <= 0:
         raise ReportError("invalid GitHub publication target")
@@ -794,12 +801,14 @@ def publish_comment(
         raise ReportError("workflow run does not match report PR/head")
     if run["run_attempt"] != run_attempt:
         return "Skipped stale report"
+    artifact_run_id = artifact_run_id or run_id
+    artifact_run_attempt = artifact_run_attempt or run_attempt
     body = render_report(
         report,
-        f"https://github.com/{repository}/actions/runs/{run_id}",
+        f"https://github.com/{repository}/actions/runs/{artifact_run_id}",
         repository=repository,
-        run_id=run_id,
-        run_attempt=run_attempt,
+        run_id=artifact_run_id,
+        run_attempt=artifact_run_attempt,
     )
     body += f"\n<!-- castiron:run:v1:{run_id}:{run_attempt} -->\n"
     found = None
@@ -834,6 +843,84 @@ def publish_comment(
     return str(result["html_url"])
 
 
+def write_report(
+    repo: Path,
+    base: str,
+    head: str,
+    out: Path,
+    *,
+    fetch: bool,
+    require_head_hash: bool,
+    public: bool,
+) -> dict[str, Any]:
+    out.mkdir(parents=True, exist_ok=True)
+    try:
+        report, patch = build_report(
+            repo, base, head, fetch=fetch, require_head_hash=require_head_hash, public=public
+        )
+    except (ReportError, UnicodeError, KeyError, ValueError) as exc:
+        report = {
+            "schema_version": 1,
+            "status": "error",
+            "target_base_sha": require_sha(base),
+            "head_sha": require_sha(head),
+            "error": str(exc),
+        }
+        patch = b""
+    (out / "report.json").write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    (out / "custom-code.patch").write_bytes(patch)
+    summary = render_report(report)
+    (out / "summary.md").write_text(summary)
+    sys.stdout.write(summary)
+    return report
+
+
+def trusted_report(repo: Path, repository: str, run_id: int, run_attempt: int, out: Path) -> None:
+    """Recompute from GitHub-associated Git objects, never from PR-produced artifacts."""
+    if not REPOSITORY.fullmatch(repository) or min(run_id, run_attempt) <= 0:
+        raise ReportError("invalid GitHub report target")
+    root = f"repos/{repository}"
+    run = api("GET", f"{root}/actions/runs/{run_id}")
+    if (
+        run["event"] != "pull_request"
+        or run.get("path", "").split("@", 1)[0] != ".github/workflows/castiron-custom-code.yml"
+        or run["status"] != "completed"
+    ):
+        raise ReportError("unexpected source workflow run")
+    if run["run_attempt"] != run_attempt:
+        return
+    head = require_sha(run["head_sha"])
+    associated = run["pull_requests"] or api("GET", f"{root}/commits/{head}/pulls?per_page=100")
+    current: list[tuple[int, str]] = []
+    for number in sorted({int(pr["number"]) for pr in associated}):
+        if number <= 0:
+            raise ReportError("invalid associated pull request")
+        pull = api("GET", f"{root}/pulls/{number}")
+        if (
+            pull["state"] == "open"
+            and pull["head"]["sha"] == head
+            and pull["base"]["repo"]["full_name"] == repository
+        ):
+            current.append((number, require_sha(pull["base"]["sha"])))
+    if not current:
+        return
+    if len(current) != 1:
+        raise ReportError("workflow run has multiple current pull requests")
+    number, base = current[0]
+    public = not api("GET", root)["private"]
+    # This must be a new, bare repository: no PR worktree, hooks, configuration,
+    # submodules, or Python imports can affect the trusted reporter.
+    repo.mkdir()
+    git(repo, "init", "--quiet", "--bare")
+    git(repo, "remote", "add", "origin", f"https://github.com/{repository}.git")
+    git(repo, "fetch", "--quiet", "--no-tags", "origin", base, head)
+    write_report(repo, base, head, out, fetch=True, require_head_hash=True, public=public)
+    (out / "context.json").write_text(
+        json.dumps({"pr": number, "repository": repository, "run": run_id, "attempt": run_attempt})
+        + "\n"
+    )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     commands = parser.add_subparsers(dest="command", required=True)
@@ -848,6 +935,12 @@ def main() -> int:
     reporting.add_argument("--fetch", action="store_true")
     reporting.add_argument("--require-head-hash", action="store_true")
     reporting.add_argument("--public", action="store_true")
+    trusted = commands.add_parser("trusted-report")
+    trusted.add_argument("--repo", type=Path, required=True)
+    trusted.add_argument("--repository", required=True)
+    trusted.add_argument("--run-id", type=int, required=True)
+    trusted.add_argument("--run-attempt", type=int, required=True)
+    trusted.add_argument("--out", type=Path, required=True)
     preparing = commands.add_parser("prepare-public")
     preparing.add_argument("--source-repo", type=Path, required=True)
     preparing.add_argument("--source-base", required=True)
@@ -861,6 +954,8 @@ def main() -> int:
     commenting.add_argument("--pr", type=int, required=True)
     commenting.add_argument("--run-id", type=int, required=True)
     commenting.add_argument("--run-attempt", type=int, required=True)
+    commenting.add_argument("--artifact-run-id", type=int, default=0)
+    commenting.add_argument("--artifact-run-attempt", type=int, default=0)
     args = parser.parse_args()
     try:
         if args.command == "hash":
@@ -879,41 +974,34 @@ def main() -> int:
                 )
                 + "\n"
             )
+        elif args.command == "trusted-report":
+            trusted_report(args.repo, args.repository, args.run_id, args.run_attempt, args.out)
         elif args.command == "comment":
             if args.report.stat().st_size > 5_000_000:
                 raise ReportError("report artifact is too large")
             report = json.loads(args.report.read_text())
             sys.stdout.write(
-                publish_comment(report, args.repository, args.pr, args.run_id, args.run_attempt)
+                publish_comment(
+                    report,
+                    args.repository,
+                    args.pr,
+                    args.run_id,
+                    args.run_attempt,
+                    artifact_run_id=args.artifact_run_id,
+                    artifact_run_attempt=args.artifact_run_attempt,
+                )
                 + "\n"
             )
         else:
-            args.out.mkdir(parents=True, exist_ok=True)
-            try:
-                report, patch = build_report(
-                    args.repo,
-                    args.base,
-                    args.head,
-                    fetch=args.fetch,
-                    require_head_hash=args.require_head_hash,
-                    public=args.public,
-                )
-            except (ReportError, UnicodeError, KeyError, ValueError) as exc:
-                report = {
-                    "schema_version": 1,
-                    "status": "error",
-                    "target_base_sha": require_sha(args.base),
-                    "head_sha": require_sha(args.head),
-                    "error": str(exc),
-                }
-                patch = b""
-            (args.out / "report.json").write_text(
-                json.dumps(report, indent=2, sort_keys=True) + "\n"
+            report = write_report(
+                args.repo,
+                args.base,
+                args.head,
+                args.out,
+                fetch=args.fetch,
+                require_head_hash=args.require_head_hash,
+                public=args.public,
             )
-            (args.out / "custom-code.patch").write_bytes(patch)
-            summary = render_report(report)
-            (args.out / "summary.md").write_text(summary)
-            sys.stdout.write(summary)
             return 0 if report["status"] == "ok" else 1
     except (ReportError, OSError, subprocess.TimeoutExpired) as exc:
         sys.stderr.write(f"Castiron custom-code report: {exc}\n")

--- a/scripts/castiron/test_custom_code_budget.py
+++ b/scripts/castiron/test_custom_code_budget.py
@@ -1,0 +1,639 @@
+# Regression tests for the custom-code budget.
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any, cast
+from unittest import mock
+
+import custom_code_budget as budget
+import test_custom_code_report as fixtures
+
+
+def source_run(head: str, event: str = "pull_request") -> dict[str, Any]:
+    return {
+        "id": 123,
+        "event": event,
+        "head_sha": head,
+        "head_branch": "gh-readonly-queue/main/pr-7-example" if event == "merge_group" else "sdk",
+        "repository": {"full_name": "openai/example"},
+        "path": ".github/workflows/castiron-custom-code.yml",
+        "status": "completed",
+        "run_attempt": 1,
+        "pull_requests": [{"number": 3}] if event == "pull_request" else [],
+        "conclusion": "failure",  # The candidate's result is deliberately ignored.
+    }
+
+
+class BudgetTests(unittest.TestCase):
+    def setUp(self) -> None:  # pyright: ignore[reportImplicitOverride]
+        # Reuse the reporter's real Git/checkpoint fixture without inheriting its tests.
+        self.fixture = fixtures.CustomCodeTests()
+        self.fixture.setUp()
+        self.addCleanup(self.fixture.doCleanups)
+        self.repo = self.fixture.repo
+        self.generated, _ = self.fixture.baseline()
+        self.policy(10)
+        self.base = self.fixture.commit("human-owned budget")
+
+    def policy(self, limit: int) -> None:
+        self.fixture.write(
+            budget.POLICY, json.dumps({"schema_version": 1, "max_custom_patch_lines": limit}) + "\n"
+        )
+
+    def evaluate(self, head: str, base: str | None = None, **kwargs: Any) -> dict[str, Any]:
+        return budget.evaluate(self.repo, base or self.base, head, public=False, **kwargs)[0]
+
+    def test_additions_and_deletions_do_not_cancel(self) -> None:
+        self.fixture.write("generated.py", "replacement\n")
+        result = self.evaluate(self.fixture.commit())
+        self.assertEqual((result["additions"], result["deletions"], result["total"]), (1, 1, 2))
+        self.assertEqual(result["checks"]["budget"]["state"], "success")
+
+    def test_below_equal_and_above_limit(self) -> None:
+        for additions in (9, 10, 11):
+            with self.subTest(additions=additions):
+                self.fixture.write("generated.py", "generated\n" + "custom\n" * additions)
+                result = self.evaluate(self.fixture.commit())
+                self.assertEqual(result["total"], additions)
+                self.assertEqual(
+                    result["checks"]["budget"]["state"], "failure" if additions > 10 else "success"
+                )
+
+    def test_whole_generated_file_deletion_is_counted(self) -> None:
+        (self.repo / "generated.py").unlink()
+        result = self.evaluate(self.fixture.commit())
+        self.assertEqual((result["additions"], result["deletions"]), (0, 1))
+        self.assertEqual(result["mixed_files"], 1)
+
+    def test_restoring_generated_content_removes_customization(self) -> None:
+        self.fixture.write("generated.py", "generated\ncustom\n")
+        customized = self.fixture.commit()
+        self.fixture.write("generated.py", "generated\n")
+        result = self.evaluate(self.fixture.commit(), base=customized)
+        self.assertEqual(result["total"], 0)
+        self.assertEqual(result["mixed_files"], 0)
+
+    def test_handwritten_only_files_keep_existing_report_scope(self) -> None:
+        self.fixture.write("handwritten.py", "custom\n" * 100)
+        self.assertEqual(self.evaluate(self.fixture.commit())["total"], 0)
+
+    def test_increase_is_isolated_but_does_not_apply_to_itself(self) -> None:
+        self.policy(20)
+        result = self.evaluate(self.fixture.commit())
+        self.assertEqual(result["checks"]["isolation"]["state"], "success")
+        self.assertEqual(result["limit"], 10)
+        self.assertEqual(result["checked_limit"], 10)
+
+    def test_entire_pr_must_be_budget_only_not_just_latest_commit(self) -> None:
+        self.fixture.write("generated.py", "generated\n" + "custom\n" * 11)
+        self.fixture.commit("SDK change first")
+        self.policy(100)
+        result = self.evaluate(self.fixture.commit("budget-only last commit"))
+        self.assertEqual(result["checks"]["isolation"]["state"], "failure")
+        self.assertIn("separate, budget-only PR", result["checks"]["isolation"]["description"])
+        self.assertEqual(result["checks"]["budget"]["state"], "failure")
+        self.assertEqual(result["limit"], 10)
+
+    def test_new_base_budget_is_used_for_stale_pr_branch(self) -> None:
+        self.fixture.git("checkout", "-q", "-b", "sdk", self.base)
+        self.fixture.write("generated.py", "generated\n" + "custom\n" * 11)
+        head = self.fixture.commit()
+        self.fixture.git("checkout", "-q", "main")
+        self.policy(20)
+        new_base = self.fixture.commit("separate approved increase")
+        result = self.evaluate(head, base=new_base)
+        self.assertEqual(result["limit"], 20)
+        self.assertEqual(result["checks"]["isolation"]["state"], "success")
+        self.assertEqual(result["checks"]["budget"]["state"], "success")
+
+    def test_decrease_must_fit_current_usage(self) -> None:
+        self.fixture.write("generated.py", "generated\ncustom\ncustom\n")
+        base = self.fixture.commit()
+        self.policy(1)
+        result = self.evaluate(self.fixture.commit(), base=base)
+        self.assertEqual(result["checks"]["isolation"]["state"], "success")
+        self.assertEqual(result["checks"]["budget"]["state"], "failure")
+        self.assertEqual(result["checked_limit"], 1)
+
+    def test_missing_base_policy_fails_closed(self) -> None:
+        (self.repo / budget.POLICY).unlink()
+        base = self.fixture.commit()
+        self.policy(100)
+        result = self.evaluate(self.fixture.commit(), base=base)
+        self.assertTrue(all(c["state"] == "failure" for c in result["checks"].values()))
+
+    def test_policy_deletion_rename_symlink_and_mode_change_fail(self) -> None:
+        for change in ("delete", "rename", "symlink", "executable"):
+            with self.subTest(change=change):
+                self.fixture.git("checkout", "--detach", "-q", self.base)
+                path = self.repo / budget.POLICY
+                if change == "delete":
+                    path.unlink()
+                elif change == "rename":
+                    path.rename(self.repo / "renamed.json")
+                elif change == "symlink":
+                    path.unlink()
+                    path.symlink_to("generated.py")
+                else:
+                    path.chmod(0o755)
+                result = self.evaluate(self.fixture.commit())
+                self.assertEqual(result["checks"]["isolation"]["state"], "failure")
+
+    def test_invalid_policy_values_fail(self) -> None:
+        invalid = [
+            "[]",
+            "{}",
+            "not json",
+            '{"schema_version":1,"max_custom_patch_lines":true}',
+            '{"schema_version":true,"max_custom_patch_lines":10}',
+            '{"schema_version":2,"max_custom_patch_lines":10}',
+            '{"schema_version":1,"max_custom_patch_lines":-1}',
+            '{"schema_version":1,"max_custom_patch_lines":10.5}',
+            '{"schema_version":1,"max_custom_patch_lines":null}',
+            '{"schema_version":1,"max_custom_patch_lines":10,"mode":"report-only"}',
+            '{"schema_version":1,"max_custom_patch_lines":10,"max_custom_patch_lines":999}',
+            " " * 4097,
+        ]
+        for contents in invalid:
+            with self.subTest(contents=contents[:100]):
+                self.fixture.write(budget.POLICY, contents)
+                result = self.evaluate(self.fixture.commit())
+                self.assertEqual(result["checks"]["isolation"]["state"], "failure")
+
+    def test_bad_snapshot_and_binary_change_fail_budget(self) -> None:
+        self.fixture.write("generated.py", "binary\0content")
+        result = self.evaluate(self.fixture.commit())
+        self.assertIn("non-text", result["checks"]["budget"]["description"])
+        self.fixture.write("generated.py", "generated\n")
+        path = self.repo / ".castiron.stats.yml"
+        path.write_text(
+            path.read_text().replace(
+                budget.report.hash_codegen_commit(self.repo, self.generated), "f" * 64
+            )
+        )
+        result = self.evaluate(self.fixture.commit())
+        self.assertIn("codegen_hash mismatch", result["checks"]["budget"]["description"])
+
+    def test_budget_uses_existing_reporter_with_strict_verification(self) -> None:
+        with mock.patch.object(
+            budget.report, "build_report", wraps=budget.report.build_report
+        ) as measured:
+            self.evaluate(self.base)
+        self.assertEqual(
+            measured.call_args.kwargs, {"public": False, "fetch": False, "require_head_hash": True}
+        )
+
+    def test_queue_isolates_prs_but_uses_main_budget_for_combined_tree(self) -> None:
+        self.fixture.git("checkout", "-q", "-b", "policy", self.base)
+        self.policy(100)
+        policy_head = self.fixture.commit()
+        self.fixture.git("checkout", "-q", "-b", "sdk", self.base)
+        self.fixture.write("generated.py", "generated\n" + "custom\n" * 11)
+        sdk_head = self.fixture.commit()
+        self.fixture.git("checkout", "-q", "-b", "queue", self.base)
+        self.fixture.git("merge", "--no-ff", "-m", "queue policy", policy_head)
+        self.fixture.git("merge", "--no-ff", "-m", "queue SDK", sdk_head)
+        result = self.evaluate(
+            self.fixture.git("rev-parse", "HEAD"), pull_heads=[policy_head, sdk_head]
+        )
+        self.assertEqual(result["checks"]["isolation"]["state"], "success")
+        self.assertEqual(result["checks"]["budget"]["state"], "failure")
+        self.assertEqual(result["limit"], 10)
+
+    def test_queue_without_verified_members_fails(self) -> None:
+        self.assertEqual(
+            self.evaluate(self.base, pull_heads=[])["checks"]["isolation"]["state"], "failure"
+        )
+
+    def test_queue_membership_uses_synthetic_commit_not_original_pr_ancestry(self) -> None:
+        self.fixture.git("checkout", "-q", "-b", "sdk", self.base)
+        self.fixture.write("generated.py", "generated\ncustom\n")
+        pr_head = self.fixture.commit()
+        self.fixture.git("checkout", "-q", "-b", "queue", self.base)
+        self.fixture.git("merge", "--squash", "sdk")
+        queue_head = self.fixture.commit("synthetic queue commit")
+        self.assertNotEqual(self.fixture.git("merge-base", pr_head, queue_head), pr_head)
+        event = {
+            "repository": {"full_name": "openai/example"},
+            "workflow_run": source_run(queue_head, "merge_group"),
+        }
+        original_git = budget.report.git
+
+        def local_fetch(repo: Path, *args: str) -> bytes:
+            if args[0] == "fetch":
+                args = tuple(str(self.repo) if arg == "origin" else arg for arg in args)
+            return cast(bytes, original_git(repo, *args))
+
+        with (
+            tempfile.TemporaryDirectory() as temp,
+            mock.patch.object(
+                budget.report,
+                "api",
+                side_effect=[
+                    {"default_branch": "main", "private": False},
+                    {"object": {"sha": self.base}},
+                    source_run(queue_head, "merge_group"),
+                    [{"type": "merge_queue"}],
+                ],
+            ),
+            mock.patch.object(budget, "queued_entries", return_value=[(pr_head, queue_head)]),
+            mock.patch.object(
+                budget.report,
+                "git",
+                side_effect=local_fetch,
+            ),
+            mock.patch.object(budget, "evaluate", return_value=({}, b"")) as evaluate,
+        ):
+            repo = Path(temp) / "queue.git"
+            budget.github_evaluate(repo, "openai/example", event, self.base)
+            evaluate.assert_called_once_with(
+                repo,
+                self.base,
+                queue_head,
+                public=True,
+                fetch=True,
+                pull_heads=[pr_head],
+                measurement=None,
+            )
+
+    def test_cli_executes_trusted_reporter_not_inspected_repo(self) -> None:
+        self.fixture.write(
+            "scripts/castiron/custom_code_report.py", 'raise RuntimeError("PR CODE EXECUTED")\n'
+        )
+        self.fixture.write("sitecustomize.py", 'raise RuntimeError("PR IMPORTED")\n')
+        head = self.fixture.commit()
+        out = self.repo / "result"
+        command = [
+            sys.executable,
+            "-I",
+            str(Path(budget.__file__).resolve()),
+            "check",
+            "--repo",
+            str(self.repo),
+            "--base",
+            self.base,
+            "--head",
+            head,
+            "--out",
+            str(out),
+        ]
+        completed = subprocess.run(command, cwd=self.repo, capture_output=True, text=True)
+        self.assertEqual(completed.returncode, 0, completed.stderr + completed.stdout)
+        self.assertEqual(json.loads((out / "budget.json").read_text())["total"], 0)
+
+    def test_summary_has_counts_revisions_and_no_longer_generated(self) -> None:
+        self.fixture.write("generated.py", "replacement\n")
+        result = self.evaluate(self.fixture.commit())
+        out = self.repo / "report-output"
+        budget.write_result(out, result)
+        summary = (out / "summary.md").read_text()
+        self.assertIn("+1 / -1 = 2", summary)
+        self.assertIn(self.generated, summary)
+        self.assertIn(self.base, summary)
+        self.assertIn("human approving review", summary)
+
+
+@unittest.skipUnless(shutil.which("node"), "Node is needed to execute the status-publisher fixture")
+class StatusPublisherTests(unittest.TestCase):
+    def publish(
+        self,
+        *,
+        event_name: str = "pull_request",
+        head_changed: bool = False,
+        base_changed: bool = False,
+        no_result: bool = False,
+        failed_budget: bool = False,
+        run_overrides: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        path = (
+            Path(__file__).resolve().parents[2]
+            / ".github/workflows/castiron-custom-code-comment.yml"
+        )
+        section = path.read_text().split("\n  budget-status:\n", 1)[1].split("\n  comment:\n", 1)[0]
+        publisher = section.split("          script: |\n", 1)[1]
+        script = "\n".join(line[12:] for line in publisher.splitlines())
+        base, head = "a" * 40, "b" * 40
+        payload = {
+            "script": script,
+            "context": {
+                "eventName": "workflow_run",
+                "repo": {"owner": "openai", "repo": "example"},
+                "serverUrl": "https://github.com",
+                "runId": 123,
+                "payload": {
+                    "workflow_run": source_run(head, event_name),
+                },
+            },
+            "run": {**source_run(head, event_name), **(run_overrides or {})},
+            "current": {
+                "state": "open",
+                "head": {"sha": "c" * 40 if head_changed else head},
+                "base": {
+                    "sha": "c" * 40 if base_changed else base,
+                    "ref": "main",
+                    "repo": {"full_name": "openai/example"},
+                },
+            },
+            "env": {
+                "BASE_SHA": "" if no_result else base,
+                "HEAD_SHA": "" if no_result else head,
+                "ISOLATION_RESULT": "success",
+                "BUDGET_RESULT": "failure" if failed_budget else "success",
+            },
+        }
+        harness = """
+          const fs = require('node:fs');
+          const data = JSON.parse(fs.readFileSync(0, 'utf8'));
+          const published = [];
+          const github = {rest: {
+            pulls: {get: async () => ({data: data.current})},
+            actions: {getWorkflowRun: async () => ({data: data.run})},
+            git: {getRef: async () => ({data: {object: {sha: data.current.base.sha}}})},
+            repos: {createCommitStatus: async value => published.push(value)},
+          }};
+          const AsyncFunction = Object.getPrototypeOf(async function(){}).constructor;
+          new AsyncFunction('github','context','process', data.script)(github, data.context, {env:data.env})
+            .then(() => process.stdout.write(JSON.stringify(published)))
+            .catch(error => { console.error(error); process.exitCode = 1; });
+        """
+        output = subprocess.run(
+            ["node", "-e", harness],
+            input=json.dumps(payload),
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        return cast(list[dict[str, Any]], json.loads(output.stdout))
+
+    def test_statuses_attach_to_candidate_not_main(self) -> None:
+        for event in ("pull_request", "merge_group"):
+            with self.subTest(event=event):
+                results = self.publish(event_name=event)
+                self.assertEqual(len(results), 2)
+                self.assertTrue(
+                    all(r["sha"] == "b" * 40 and r["state"] == "success" for r in results)
+                )
+
+    def test_stale_pr_head_is_not_published(self) -> None:
+        self.assertEqual(self.publish(head_changed=True), [])
+
+    def test_stale_base_and_missing_evaluation_cannot_publish_success(self) -> None:
+        for event in ("pull_request", "merge_group"):
+            for base_changed, no_result in ((True, False), (False, True)):
+                results = self.publish(
+                    event_name=event, base_changed=base_changed, no_result=no_result
+                )
+                self.assertEqual(len(results), 2)
+                self.assertTrue(all(r["state"] == "failure" for r in results))
+
+    def test_superseded_or_wrong_source_run_cannot_publish(self) -> None:
+        for overrides in (
+            {"run_attempt": 2},
+            {"head_sha": "c" * 40},
+            {"event": "push"},
+            {"path": "other.yml"},
+        ):
+            with self.subTest(overrides=overrides):
+                self.assertEqual(self.publish(run_overrides=overrides), [])
+
+    def test_independent_check_failures_are_preserved(self) -> None:
+        results = self.publish(failed_budget=True)
+        self.assertEqual([r["state"] for r in results], ["success", "failure"])
+
+
+class GitHubBudgetTests(unittest.TestCase):
+    def test_merge_queue_rule_is_required_before_passing(self) -> None:
+        base, head = "a" * 40, "b" * 40
+        event = {
+            "repository": {"full_name": "openai/example"},
+            "workflow_run": source_run(head, "merge_group"),
+        }
+        with (
+            tempfile.TemporaryDirectory() as temp,
+            mock.patch.object(
+                budget.report,
+                "api",
+                side_effect=[
+                    {"default_branch": "main"},
+                    {"object": {"sha": base}},
+                    source_run(head, "merge_group"),
+                    [{"type": "required_status_checks"}],
+                ],
+            ),
+        ):
+            repo = Path(temp) / "objects.git"
+            with self.assertRaisesRegex(ValueError, "must require a merge queue"):
+                budget.github_evaluate(repo, "openai/example", event, base)
+            self.assertFalse(repo.exists())
+
+    def test_wrong_or_superseded_source_runs_fail_before_fetching(self) -> None:
+        base, head = "a" * 40, "b" * 40
+        event = {"repository": {"full_name": "openai/example"}, "workflow_run": source_run(head)}
+        for overrides in (
+            {"run_attempt": 2},
+            {"status": "in_progress"},
+            {"path": "other.yml"},
+            {"head_sha": "c" * 40},
+            {"repository": {"full_name": "wrong/repo"}},
+        ):
+            with (
+                self.subTest(overrides=overrides),
+                tempfile.TemporaryDirectory() as temp,
+                mock.patch.object(
+                    budget.report,
+                    "api",
+                    side_effect=[
+                        {"default_branch": "main"},
+                        {"object": {"sha": base}},
+                        {**source_run(head), **overrides},
+                    ],
+                ),
+            ):
+                repo = Path(temp) / "objects.git"
+                with self.assertRaisesRegex(ValueError, "source workflow run"):
+                    budget.github_evaluate(repo, "openai/example", event, base)
+                self.assertFalse(repo.exists())
+
+    def test_reuses_only_matching_main_job_report(self) -> None:
+        base, head = "a" * 40, "b" * 40
+        event = {"repository": {"full_name": "openai/example"}, "workflow_run": source_run(head)}
+        pull = {
+            "state": "open",
+            "head": {"sha": head},
+            "base": {
+                "sha": base,
+                "ref": "main",
+                "repo": {"full_name": "openai/example"},
+            },
+        }
+        for stale in (False, True):
+            with self.subTest(stale=stale), tempfile.TemporaryDirectory() as temp:
+                trusted = Path(temp)
+                measured = {"target_base_sha": "c" * 40 if stale else base, "head_sha": head}
+                (trusted / "report.json").write_text(json.dumps(measured))
+                (trusted / "custom-code.patch").write_bytes(b"verified patch")
+                repo = trusted / "objects.git"
+                repo.mkdir()
+                with (
+                    mock.patch.object(
+                        budget.report,
+                        "api",
+                        side_effect=[
+                            {"default_branch": "main", "private": False},
+                            {"object": {"sha": base}},
+                            source_run(head),
+                            pull,
+                            [{"type": "merge_queue"}],
+                        ],
+                    ),
+                    mock.patch.object(budget.report, "git", return_value=b"true\n") as git,
+                    mock.patch.object(budget, "evaluate", return_value=({}, b"")) as evaluate,
+                ):
+                    if stale:
+                        with self.assertRaisesRegex(ValueError, "trusted report is stale"):
+                            budget.github_evaluate(repo, "openai/example", event, base, trusted)
+                        evaluate.assert_not_called()
+                    else:
+                        budget.github_evaluate(repo, "openai/example", event, base, trusted)
+                        evaluate.assert_called_once_with(
+                            repo,
+                            base,
+                            head,
+                            public=True,
+                            fetch=True,
+                            pull_heads=None,
+                            measurement=(measured, b"verified patch"),
+                        )
+                        git.assert_called_once_with(repo, "rev-parse", "--is-bare-repository")
+
+    def test_queue_pagination(self) -> None:
+        pages = [
+            {
+                "nodes": [
+                    {"pullRequest": {"headRefOid": "a" * 40}, "headCommit": {"oid": "c" * 40}}
+                ],
+                "pageInfo": {"hasNextPage": True, "endCursor": "cursor"},
+            },
+            {
+                "nodes": [
+                    {"pullRequest": {"headRefOid": "b" * 40}, "headCommit": {"oid": "d" * 40}}
+                ],
+                "pageInfo": {"hasNextPage": False, "endCursor": None},
+            },
+        ]
+        with mock.patch.object(
+            budget.report,
+            "api",
+            side_effect=[{"data": {"repository": {"mergeQueue": {"entries": p}}}} for p in pages],
+        ) as api:
+            self.assertEqual(
+                budget.queued_entries("openai/example", "main"),
+                [("a" * 40, "c" * 40), ("b" * 40, "d" * 40)],
+            )
+        self.assertEqual(api.call_args_list[1].args[2]["variables"]["cursor"], "cursor")
+
+    def test_pull_context_refuses_stale_checkout_before_fetching(self) -> None:
+        with (
+            tempfile.TemporaryDirectory() as temp,
+            mock.patch.object(
+                budget.report,
+                "api",
+                side_effect=[{"default_branch": "main"}, {"object": {"sha": "a" * 40}}],
+            ),
+        ):
+            repo = Path(temp) / "objects.git"
+            with self.assertRaisesRegex(ValueError, "trusted checkout is stale"):
+                budget.github_evaluate(
+                    repo,
+                    "openai/example",
+                    {"repository": {"full_name": "openai/example"}},
+                    "b" * 40,
+                )
+            self.assertFalse(repo.exists())
+
+    def test_github_uses_fresh_bare_data_repo_and_checks_current_head(self) -> None:
+        base, head = "a" * 40, "b" * 40
+        event = {
+            "repository": {"full_name": "openai/example"},
+            "workflow_run": source_run(head),
+        }
+        pull = {
+            "state": "open",
+            "head": {"sha": head},
+            "base": {"sha": base, "ref": "main", "repo": {"full_name": "openai/example"}},
+        }
+        responses = [
+            {"default_branch": "main", "private": False},
+            {"object": {"sha": base}},
+            source_run(head),
+            pull,
+            [{"type": "merge_queue"}],
+        ]
+        with (
+            tempfile.TemporaryDirectory() as temp,
+            mock.patch.object(budget.report, "api", side_effect=responses),
+            mock.patch.object(budget.report, "git") as git,
+            mock.patch.object(budget, "evaluate", return_value=({}, b"")) as evaluate,
+        ):
+            repo = Path(temp) / "objects.git"
+            budget.github_evaluate(repo, "openai/example", event, base)
+            self.assertTrue((repo / "HEAD").exists())
+            self.assertFalse((repo / "src").exists())
+            self.assertIn(
+                mock.call(repo, "fetch", "--quiet", "--no-tags", "origin", base, head),
+                git.call_args_list,
+            )
+            evaluate.assert_called_once_with(
+                repo, base, head, public=True, fetch=True, pull_heads=None, measurement=None
+            )
+
+    def test_stale_pull_and_wrong_target_fail_before_objects_created(self) -> None:
+        for kind in ("head", "base", "repository", "branch", "closed"):
+            with self.subTest(kind=kind), tempfile.TemporaryDirectory() as temp:
+                base, head = "a" * 40, "b" * 40
+                event = {
+                    "repository": {"full_name": "openai/example"},
+                    "workflow_run": source_run(head),
+                }
+                pull: dict[str, Any] = {
+                    "state": "open",
+                    "head": {"sha": head},
+                    "base": {"sha": base, "ref": "main", "repo": {"full_name": "openai/example"}},
+                }
+                if kind == "head":
+                    pull["head"]["sha"] = "c" * 40
+                elif kind == "base":
+                    pull["base"]["sha"] = "c" * 40
+                elif kind == "repository":
+                    pull["base"]["repo"]["full_name"] = "wrong/repo"
+                elif kind == "branch":
+                    pull["base"]["ref"] = "other"
+                else:
+                    pull["state"] = "closed"
+                with mock.patch.object(
+                    budget.report,
+                    "api",
+                    side_effect=[
+                        {"default_branch": "main"},
+                        {"object": {"sha": base}},
+                        source_run(head),
+                        pull,
+                    ],
+                ):
+                    with self.assertRaisesRegex(ValueError, "exactly one current PR"):
+                        budget.github_evaluate(
+                            Path(temp) / "objects.git",
+                            "openai/example",
+                            event,
+                            base,
+                        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/castiron/test_custom_code_report.py
+++ b/scripts/castiron/test_custom_code_report.py
@@ -12,6 +12,7 @@ import tempfile
 import textwrap
 import unittest
 from pathlib import Path
+from typing import Any
 from unittest import mock
 
 import custom_code_report as report
@@ -328,6 +329,256 @@ async function check(stale, exists, priorRun, expected) {
         self.assertNotIn("ref: ${{ github.event.pull_request.head.sha }}", publisher)
         self.assertIn("persist-credentials: false", publisher)
         self.assertIn("--report", publisher)
+        compute, comment = publisher.split("\n  comment:\n", 1)
+        self.assertNotIn("pull-requests: write", compute)
+        self.assertIn("pull-requests: read", compute)
+        self.assertIn(" trusted-report ", compute)
+        self.assertNotIn("download-artifact@", compute)
+        self.assertNotIn("unittest", compute)
+        self.assertIn("needs: compute", comment)
+        self.assertIn("artifact-ids: ${{ needs.compute.outputs.artifact-id }}", comment)
+        self.assertNotIn("run-id: ${{ github.event.workflow_run.id }}", comment)
+        self.assertNotIn("git fetch", comment)
+        self.assertIn("--artifact-run-id", comment)
+        digest = hashlib.sha256(
+            (workflows.parents[1] / "scripts/castiron/custom_code_report.py").read_bytes()
+        ).hexdigest()
+        self.assertIn(f"REPORTER_SHA256: {digest}", producer)
+
+    def test_comment_only_rerun_links_to_the_compute_artifact_attempt(self) -> None:
+        workflow = (
+            Path(__file__).resolve().parents[2]
+            / ".github/workflows/castiron-custom-code-comment.yml"
+        ).read_text()
+        compute, comment = workflow.split("\n  comment:\n", 1)
+
+        def field(section: str, prefix: str) -> str:
+            return next(
+                line.removeprefix(prefix)
+                for line in section.splitlines()
+                if line.startswith(prefix)
+            )
+
+        def resolve(value: str, context: dict[str, str]) -> str:
+            for key, replacement in context.items():
+                value = value.replace("${{ " + key + " }}", replacement)
+            self.assertNotIn("${{", value)
+            return value
+
+        # A successful compute job's outputs survive a comment-only rerun.
+        compute_context = {"github.run_id": "9", "github.run_attempt": "3"}
+        uploaded_name = resolve(field(compute, "          name: "), compute_context)
+        saved_attempt = resolve(field(compute, "      artifact-run-attempt: "), compute_context)
+        comment_context = {
+            "github.run_id": "9",
+            "github.run_attempt": "4",
+            "needs.compute.outputs.artifact-run-attempt": saved_attempt,
+        }
+        artifact_attempt = resolve(
+            field(comment, "          ARTIFACT_RUN_ATTEMPT: "), comment_context
+        )
+        self.assertEqual(uploaded_name, "castiron-custom-code-9-3")
+        self.assertEqual(artifact_attempt, "3")
+
+        _, base = self.baseline()
+        result, _ = report.build_report(self.repo, base, base)
+        pull = {"state": "open", "head": {"sha": base}, "base": {"sha": base}}
+        run = {
+            "event": "pull_request",
+            "path": ".github/workflows/castiron-custom-code.yml",
+            "head_sha": base,
+            "run_attempt": 1,
+            "pull_requests": [{"number": 1}],
+        }
+        with mock.patch.object(
+            report, "api", side_effect=[pull, run, [], pull, {"html_url": "published"}]
+        ) as api:
+            self.assertEqual(
+                report.publish_comment(
+                    result,
+                    "openai/example",
+                    1,
+                    2,
+                    1,
+                    artifact_run_id=9,
+                    artifact_run_attempt=int(artifact_attempt),
+                ),
+                "published",
+            )
+        body = api.call_args.args[2]["body"]
+        self.assertIn(f"--name {uploaded_name}", body)
+        self.assertNotIn("--name castiron-custom-code-9-4", body)
+        self.assertIn("castiron:run:v1:2:1", body)
+
+    def test_trusted_report_recomputes_pr_output_in_a_bare_repository(self) -> None:
+        generated, _ = self.baseline()
+        content_hash = report.hash_codegen_commit(self.repo, generated)
+        snapshot = report.create_public_snapshot(
+            self.repo,
+            self.git("rev-parse", f"{generated}^{{tree}}"),
+            GENERATION,
+            content_hash,
+            "codegen/public-test",
+            None,
+        )
+        self.git("branch", "codegen/public-test", snapshot)
+        stats = (self.repo / ".castiron.stats.yml").read_text()
+        self.write(".castiron.stats.yml", stats + f"public_codegen_sha: {snapshot}\n")
+        base = self.commit()
+        legitimate, _ = report.build_report(self.repo, base, base, require_head_hash=True)
+        self.write("generated.py", "generated\n# custom\n")
+        # Neither a replacement reporter nor its claimed result may be executed
+        # or read by the trusted job.
+        self.write("scripts/castiron/custom_code_report.py", "raise RuntimeError('PR code ran')\n")
+        self.write("report.json", json.dumps(legitimate))
+        head = self.commit()
+        broken_stats = (
+            (self.repo / ".castiron.stats.yml").read_text().replace(content_hash, "0" * 64)
+        )
+        self.write(".castiron.stats.yml", broken_stats)
+        broken = self.commit()
+        remote = self.repo / "public.git"
+        self.git("clone", "--bare", str(self.repo), str(remote))
+        real_git = report.git
+
+        def local_git(repo: Path, *args: str, input_bytes: bytes | None = None) -> bytes:
+            if args[:3] == ("remote", "add", "origin"):
+                self.assertEqual(args[3], "https://github.com/openai/example.git")
+                args = (*args[:3], str(remote))
+            self.assertNotIn("checkout", args)
+            return real_git(repo, *args, input_bytes=input_bytes)
+
+        for label, revision in (("genuine", base), ("custom", head), ("broken", broken)):
+            with self.subTest(label=label):
+                calls: list[tuple[str, str]] = []
+                bodies: list[str] = []
+                pull = {
+                    "state": "open",
+                    "head": {"sha": revision},
+                    "base": {"sha": base, "repo": {"full_name": "openai/example"}},
+                }
+                run: dict[str, Any] = {
+                    "event": "pull_request",
+                    "status": "completed",
+                    "path": ".github/workflows/castiron-custom-code.yml",
+                    "head_sha": revision,
+                    "run_attempt": 1,
+                    "pull_requests": [],
+                }
+                forged: dict[str, Any] = {**legitimate, "head_sha": revision, "files": []}
+                self.assertIn("Generated baselines verified", report.render_report(forged))
+                producer = self.repo / f"producer-{label}"
+                producer.mkdir()
+                (producer / "report.json").write_text(json.dumps(forged))
+
+                def fake_api(method: str, path: str, payload: dict[str, Any] | None = None) -> Any:
+                    calls.append((method, path))
+                    if method == "GET":
+                        responses: dict[str, Any] = {
+                            "repos/openai/example": {"private": False},
+                            "repos/openai/example/actions/runs/2": run,
+                            f"repos/openai/example/commits/{revision}/pulls?per_page=100": [
+                                {"number": 1}
+                            ],
+                            "repos/openai/example/pulls/1": pull,
+                            "repos/openai/example/issues/1/comments?per_page=100&page=1": [],
+                        }
+                        if path in responses:
+                            return responses[path]
+                    if (
+                        method == "POST"
+                        and path == "repos/openai/example/issues/1/comments"
+                        and payload
+                    ):
+                        bodies.append(payload["body"])
+                        return {
+                            "html_url": "https://github.com/openai/example/pull/1#issuecomment-1"
+                        }
+                    raise AssertionError(f"unexpected API call: {method} {path}")
+
+                objects = self.repo / f"objects-{label}.git"
+                out = self.repo / f"trusted-{label}"
+                with (
+                    mock.patch.object(report, "api", side_effect=fake_api),
+                    mock.patch.object(report, "git", side_effect=local_git),
+                ):
+                    report.trusted_report(objects, "openai/example", 2, 1, out)
+                    self.assertTrue(all(method == "GET" for method, _ in calls))
+                    self.assertEqual(
+                        real_git(objects, "rev-parse", "--is-bare-repository"), b"true\n"
+                    )
+                    self.assertFalse((objects / "scripts").exists())
+                    actual = json.loads((out / "report.json").read_text())
+                    report.publish_comment(
+                        actual,
+                        "openai/example",
+                        1,
+                        2,
+                        1,
+                        artifact_run_id=9,
+                        artifact_run_attempt=3,
+                    )
+                self.assertEqual(len(bodies), 1)
+                body = bodies[0]
+                self.assertIn("castiron:run:v1:2:1", body)
+                self.assertIn("/actions/runs/9", body)
+                if label == "broken":
+                    self.assertIn("Report unavailable", body)
+                    self.assertNotIn("Generated baselines verified", body)
+                elif label == "custom":
+                    self.assertIn("1 newly customized", body)
+                    self.assertIn("generated.py", body)
+                    self.assertIn(b"+# custom", (out / "custom-code.patch").read_bytes())
+                    self.assertNotIn("No new custom-code files detected", body)
+                else:
+                    self.assertIn("No new custom-code files detected", body)
+                    self.assertIn("Generated baselines verified", body)
+                    self.assertIn("--name castiron-custom-code-9-3", body)
+
+    def test_trusted_report_rejects_invalid_or_stale_association_before_fetch(self) -> None:
+        run = {
+            "event": "pull_request",
+            "status": "completed",
+            "path": ".github/workflows/castiron-custom-code.yml",
+            "head_sha": "a" * 40,
+            "run_attempt": 1,
+            "pull_requests": [{"number": 1}],
+        }
+        pull = {
+            "state": "open",
+            "head": {"sha": "a" * 40},
+            "base": {"sha": "b" * 40, "repo": {"full_name": "openai/example"}},
+        }
+        cases: list[tuple[list[Any], bool]] = [
+            ([{**run, "path": "other.yml"}], True),
+            ([{**run, "status": "in_progress"}], True),
+            ([{**run, "run_attempt": 2}], False),
+            ([run, {**pull, "state": "closed"}], False),
+            ([run, {**pull, "head": {"sha": "c" * 40}}], False),
+            (
+                [run, {**pull, "base": {"sha": "b" * 40, "repo": {"full_name": "other/repo"}}}],
+                False,
+            ),
+            ([{**run, "pull_requests": []}, []], False),
+            ([{**run, "pull_requests": [{"number": 1}, {"number": 2}]}, pull, pull], True),
+        ]
+        for responses, raises in cases:
+            with (
+                self.subTest(responses=responses),
+                mock.patch.object(report, "api", side_effect=responses),
+                mock.patch.object(report, "git") as git,
+            ):
+                if raises:
+                    with self.assertRaises(report.ReportError):
+                        report.trusted_report(
+                            self.repo / "objects", "openai/example", 2, 1, self.repo / "out"
+                        )
+                else:
+                    report.trusted_report(
+                        self.repo / "objects", "openai/example", 2, 1, self.repo / "out"
+                    )
+                git.assert_not_called()
+                self.assertFalse((self.repo / "out").exists())
 
     def test_removals_include_changed_baselines_but_not_handwritten_only_files(self) -> None:
         _, base = self.baseline()


### PR DESCRIPTION
## Summary

Catch accidental growth in the SDK's remaining generated-file customization before it becomes a large patch to maintain. This ports the same layout and tooling approved in [Python #3714](https://github.com/openai/openai-python/pull/3714) and [Python #3715](https://github.com/openai/openai-python/pull/3715), including Python's trusted report computation.

The existing workflow pair measures additions **plus** deletions against verified generated output, using the checker and budget from main. A PR cannot increase its own allowance; budget changes must be isolated and explicitly justified, and increases require a human approving review. Agents cannot approve or bypass increases.

Technical details live in `scripts/castiron/CUSTOM_CODE.md`, with references from AGENTS and CONTRIBUTING. No extra workflow files, SDK API changes, checkpoint edits, exclusion changes, or CODEOWNERS changes. **Ruleset enforcement is intentionally deferred.**

The integrated tooling measures **+776 / −144 = 920 custom lines**, below the **2,000-line** ceiling. This includes the reporter changes themselves.

## Stack

The [budget-only foundation](https://github.com/openai/openai-go/pull/840) has merged. This tooling commit is now restacked onto `main` at `31ce1430b984`; the tooling patch is unchanged and the PR contains no budget-file change. CI is rerunning against main. The trusted statuses become active after the tooling lands, but will not be required until a separately authorized ruleset rollout.
