### PR TITLE
chore(api): update generation metadata

### DIFF
--- a/.castiron.stats.yml
+++ b/.castiron.stats.yml
@@ -1,8 +1,8 @@
 schema_version: 1
-generation_id: 66587b9e-f863-444f-ada4-e8487b1daf79
+generation_id: ab0aed33-06cb-466d-b61d-fec2fd543af2
 openapi_spec_hash: 92700e1a33a4f6174a01b46648c8186a
 openapi_transformed_spec_hash: e37bbe0f04caa6093f1cb5d65d23ad03
-config_hash: d13c582815d0db08c374985806be7352
-codegen_sha: d33e287269e11f98cb5f476ba185435b8fc68d3a
+config_hash: beab4f058e80bab30085bb6c8467b65f
+codegen_sha: e867c06e75cfec8d4d6f071675e997b0935d0646
 codegen_hash: 7d99b7f425498f9e870867b7b3ac87104849f579e6ae7edae4f309d0cce027fc
-public_codegen_sha: 5e69e2b63c681a68ec92a45ac41cf38311347cd0
+public_codegen_sha: 2bee6780f2222edb8183c23fc9766281bfa97f4e


### PR DESCRIPTION
## Summary

Regenerate or update non-functional generation metadata only. There are no changes to the public API, SDK behavior, or required inputs; no release is necessary for customers.

## Changes

- No changes to public API surface, exported types, method signatures, or runtime behavior
- Only non-customer-facing generation/metadata was modified; no customer-visible effects and no release impact
