### PR TITLE
test: protect large HTTP payload compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,3 +183,22 @@ govulncheck ./...
 Also test with `GOTOOLCHAIN=local` on every Go release line listed in the CI
 matrix. Use `scripts/detect-breaking-changes` when a dependency update could
 affect exported APIs.
+
+## Large-payload compatibility
+
+Treat large payloads as a normal API contract, not evidence of malformed or
+hostile input. Responses, Chat Completions, and other APIs can legitimately
+return large `application/json` bodies, streaming events, and, where supported,
+WebSocket messages. Do not introduce arbitrary fixed limits on bodies, frames,
+events, or lines as a security or efficiency fix. Prefer incremental processing,
+amortized-linear buffering, timely cleanup, and caller cancellation. Any new
+rejection limit needs an explicit, owner-approved API contract and a review of
+existing supported payloads and transports.
+
+Protect this behavior with focused, deterministic public-entrypoint tests using
+large synthetic payloads generated in memory, not committed captures or live
+image generation. Their high memory use is intentional: do not shrink the
+payloads or raise client limits to make the tests pass. Keep coverage to the main
+JSON, streaming, and supported WebSocket categories, and run large cases
+sequentially to keep peak memory reasonable. The fixture size is a regression
+probe, not a new API maximum.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,17 +186,21 @@ affect exported APIs.
 
 ## Large-payload compatibility
 
-Treat large payloads as a normal API contract, not evidence of malformed or
-hostile input. Responses, Chat Completions, and other APIs can legitimately
-return large `application/json` bodies and streaming events. Do not introduce
-arbitrary fixed limits on bodies, events, or lines as a security or efficiency fix. Prefer incremental processing,
-amortized-linear buffering, timely cleanup, and caller cancellation. Any new
-rejection limit needs an explicit, owner-approved API contract and a review of
-existing supported payloads and transports.
+Large HTTP JSON bodies and SSE events are normal Responses, Chat Completions,
+and other API output, not evidence of malformed or hostile input. Preserve
+historically supported payloads when changing parsers, streaming, or final-result
+helpers. Do not introduce arbitrary new body, event, line, or accumulation limits
+as a security or efficiency fix. Any new restriction or tightening of an existing
+limit needs an explicit, owner-approved API contract and review of supported
+payloads. Preserve established limits unless changing them is explicitly in scope;
+compatibility regression work is not authorization to remove longstanding limits.
+Prefer incremental processing, amortized-linear buffering, timely cleanup, and
+caller cancellation when improving large-payload handling.
 
-Protect this behavior with focused, deterministic public-entrypoint tests using
-large synthetic payloads generated in memory, not committed captures or live
-image generation. Their high memory use is intentional: do not shrink the
-payloads or raise client limits to make the tests pass. Keep coverage to the main
-HTTP JSON and SSE categories, and run large cases sequentially to keep peak memory reasonable. The fixture size is a regression
-probe, not a new API maximum.
+Protect existing behavior with focused, deterministic public-entrypoint tests
+using large synthetic payloads generated in memory, not committed captures or
+live image generation. Their high memory use is intentional: do not shrink the
+payloads or raise client limits to make a new restriction pass. Cover HTTP JSON,
+SSE, and independent final-result helpers, and run large cases sequentially to
+keep peak memory reasonable. Fixture sizes are regression probes chosen within
+the historically supported behavior, not new API maxima.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,9 +188,8 @@ affect exported APIs.
 
 Treat large payloads as a normal API contract, not evidence of malformed or
 hostile input. Responses, Chat Completions, and other APIs can legitimately
-return large `application/json` bodies, streaming events, and, where supported,
-WebSocket messages. Do not introduce arbitrary fixed limits on bodies, frames,
-events, or lines as a security or efficiency fix. Prefer incremental processing,
+return large `application/json` bodies and streaming events. Do not introduce
+arbitrary fixed limits on bodies, events, or lines as a security or efficiency fix. Prefer incremental processing,
 amortized-linear buffering, timely cleanup, and caller cancellation. Any new
 rejection limit needs an explicit, owner-approved API contract and a review of
 existing supported payloads and transports.
@@ -199,6 +198,5 @@ Protect this behavior with focused, deterministic public-entrypoint tests using
 large synthetic payloads generated in memory, not committed captures or live
 image generation. Their high memory use is intentional: do not shrink the
 payloads or raise client limits to make the tests pass. Keep coverage to the main
-JSON, streaming, and supported WebSocket categories, and run large cases
-sequentially to keep peak memory reasonable. The fixture size is a regression
+HTTP JSON and SSE categories, and run large cases sequentially to keep peak memory reasonable. The fixture size is a regression
 probe, not a new API maximum.

--- a/internal/testutil/large_payload_contract_test.go
+++ b/internal/testutil/large_payload_contract_test.go
@@ -1,0 +1,151 @@
+package testutil_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+	"github.com/openai/openai-go/v3/responses"
+)
+
+// High memory use is intentional: valid API payloads must not be rejected by
+// arbitrary body, event, or line caps. Keep this above 32 MiB; do not shrink it
+// to make a cap pass. This is a regression probe, not an API maximum. Generate
+// data in memory and do not parallelize these cases.
+const largePayloadSize = 32*1024*1024 + 1
+
+func TestLargeResponsesPayloadContract(t *testing.T) {
+	for _, streaming := range []bool{false, true} {
+		name := "blocking JSON"
+		if streaming {
+			name = "streaming event"
+		}
+		t.Run(name, func(t *testing.T) {
+			text := strings.Repeat("x", largePayloadSize)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost || r.URL.Path != "/responses" {
+					t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+					http.NotFound(w, r)
+					return
+				}
+				if streaming {
+					w.Header().Set("Content-Type", "text/event-stream")
+					writeLargePayload(t, w, "event: response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\"text\":\"")
+					writeLargePayload(t, w, text)
+					writeLargePayload(t, w, "\",\"item_id\":\"msg_test\",\"output_index\":0,\"content_index\":0,\"sequence_number\":1,\"logprobs\":[]}\n\ndata: [DONE]\n\n")
+				} else {
+					w.Header().Set("Content-Type", "application/json")
+					writeLargePayload(t, w, `{"id":"resp_test","object":"response","status":"completed","output":[{"type":"message","id":"msg_test","role":"assistant","status":"completed","content":[{"type":"output_text","text":"`)
+					writeLargePayload(t, w, text)
+					writeLargePayload(t, w, `","annotations":[]}]}]}`)
+				}
+			}))
+			defer server.Close()
+			client := openai.NewClient(option.WithAPIKey("test-key"), option.WithBaseURL(server.URL), option.WithMaxRetries(0))
+			params := responses.ResponseNewParams{Model: "gpt-4o-mini", Input: responses.ResponseNewParamsInputUnion{OfString: openai.String("Hello")}}
+			if streaming {
+				stream := client.Responses.NewStreaming(context.Background(), params)
+				defer func() { _ = stream.Close() }()
+				if !stream.Next() {
+					t.Fatalf("large event was not delivered: %v", stream.Err())
+				}
+				event := stream.Current()
+				if event.Type != "response.output_text.done" || event.AsResponseOutputTextDone().Text != text {
+					t.Fatal("large streaming event was truncated or changed")
+				}
+				if stream.Next() || stream.Err() != nil {
+					t.Fatalf("unexpected end of stream: %v", stream.Err())
+				}
+			} else {
+				response, err := client.Responses.New(context.Background(), params)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if response.OutputText() != text {
+					t.Fatal("large blocking JSON message was truncated or changed")
+				}
+			}
+		})
+	}
+}
+
+func TestLargeChatCompletionPayloadContract(t *testing.T) {
+	for _, streaming := range []bool{false, true} {
+		name := "blocking JSON"
+		if streaming {
+			name = "streaming accumulation"
+		}
+		t.Run(name, func(t *testing.T) {
+			text := strings.Repeat("x", largePayloadSize)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost || r.URL.Path != "/chat/completions" {
+					t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+					http.NotFound(w, r)
+					return
+				}
+				if streaming {
+					w.Header().Set("Content-Type", "text/event-stream")
+					// Accumulation is a separate contract from single-event decoding:
+					// each chunk fits below 32 MiB, but the final content does not.
+					for _, part := range []string{text[:len(text)/2], text[len(text)/2:]} {
+						writeLargePayload(t, w, `data: {"id":"chatcmpl_test","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"`)
+						writeLargePayload(t, w, part)
+						writeLargePayload(t, w, "\"}}]}\n\n")
+					}
+					writeLargePayload(t, w, "data: {\"id\":\"chatcmpl_test\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n")
+				} else {
+					w.Header().Set("Content-Type", "application/json")
+					writeLargePayload(t, w, `{"id":"chatcmpl_test","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"`)
+					writeLargePayload(t, w, text)
+					writeLargePayload(t, w, `"},"finish_reason":"stop"}]}`)
+				}
+			}))
+			defer server.Close()
+			client := openai.NewClient(option.WithAPIKey("test-key"), option.WithBaseURL(server.URL), option.WithMaxRetries(0))
+			params := openai.ChatCompletionNewParams{Model: "gpt-4o-mini", Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("Hello")}}
+			if streaming {
+				stream := client.Chat.Completions.NewStreaming(context.Background(), params)
+				defer func() { _ = stream.Close() }()
+				acc := openai.ChatCompletionAccumulator{}
+				finished := false
+				for stream.Next() {
+					if !acc.AddChunk(stream.Current()) {
+						t.Fatal("large content was rejected by the accumulator")
+					}
+					if content, ok := acc.JustFinishedContent(); ok {
+						finished = true
+						if content != text {
+							t.Fatal("large finished content was truncated or changed")
+						}
+					}
+				}
+				if err := stream.Err(); err != nil {
+					t.Fatal(err)
+				}
+				if !finished || len(acc.Choices) != 1 || acc.Choices[0].Message.Content != text {
+					t.Fatal("large accumulated message was not completed intact")
+				}
+			} else {
+				completion, err := client.Chat.Completions.New(context.Background(), params)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(completion.Choices) != 1 || completion.Choices[0].Message.Content != text {
+					t.Fatal("large blocking JSON message was truncated or changed")
+				}
+			}
+		})
+	}
+}
+
+func writeLargePayload(t *testing.T, w io.Writer, part string) {
+	t.Helper()
+	if _, err := io.WriteString(w, part); err != nil {
+		t.Errorf("write synthetic response: %v", err)
+	}
+}

--- a/internal/testutil/large_payload_contract_test.go
+++ b/internal/testutil/large_payload_contract_test.go
@@ -13,11 +13,16 @@ import (
 	"github.com/openai/openai-go/v3/responses"
 )
 
-// High memory use is intentional: valid API payloads must not be rejected by
-// arbitrary body, event, or line caps. Keep this above 32 MiB; do not shrink it
-// to make a cap pass. This is a regression probe, not an API maximum. Generate
-// data in memory and do not parallelize these cases.
+// High memory use is intentional: these historically supported payloads must
+// not regress under new body, event, or accumulation limits. Do not shrink the
+// payloads or raise client limits to make a new cap pass. These are regression
+// probes, not API maxima. Generate data in memory and run cases sequentially.
 const largePayloadSize = 32*1024*1024 + 1
+
+// The SSE decoder has long had a 32 MiB line limit. Preserve it, reserving 1 KiB
+// for the data prefix and JSON envelope instead of treating its removal as a
+// regression fix. JSON bodies and accumulated multi-event text are independent.
+const largeStreamingPayloadSize = 32*1024*1024 - 1024
 
 func TestLargeResponsesPayloadContract(t *testing.T) {
 	for _, streaming := range []bool{false, true} {
@@ -26,7 +31,11 @@ func TestLargeResponsesPayloadContract(t *testing.T) {
 			name = "streaming event"
 		}
 		t.Run(name, func(t *testing.T) {
-			text := strings.Repeat("x", largePayloadSize)
+			payloadSize := largePayloadSize
+			if streaming {
+				payloadSize = largeStreamingPayloadSize
+			}
+			text := strings.Repeat("x", payloadSize)
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.Method != http.MethodPost || r.URL.Path != "/responses" {
 					t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)

--- a/packages/ssestream/ssestream.go
+++ b/packages/ssestream/ssestream.go
@@ -41,9 +41,8 @@ func NewDecoder(res *http.Response) Decoder {
 		}
 	}
 
-	scn := bufio.NewScanner(res.Body)
-	scn.Buffer(nil, bufio.MaxScanTokenSize<<9)
-	return &eventStreamDecoder{rc: res.Body, scn: scn}
+	// Buffered reads grow with the line instead of imposing an arbitrary event-size cap.
+	return &eventStreamDecoder{rc: res.Body, rdr: bufio.NewReader(res.Body)}
 }
 
 var decoderTypes = map[string](func(io.ReadCloser) Decoder){}
@@ -83,7 +82,7 @@ func (e *StreamError) Error() string {
 type eventStreamDecoder struct {
 	evt Event
 	rc  io.ReadCloser
-	scn *bufio.Scanner
+	rdr *bufio.Reader
 	err error
 }
 
@@ -95,13 +94,24 @@ func (s *eventStreamDecoder) Next() bool {
 	event := ""
 	var data []byte
 
-	for s.scn.Scan() {
-		txt := s.scn.Bytes()
+	for {
+		txt, err := s.rdr.ReadBytes('\n')
+		if err != nil && err != io.EOF {
+			s.err = err
+		}
+		if len(txt) == 0 {
+			return false
+		}
+		txt = bytes.TrimSuffix(txt, []byte{'\n'})
+		txt = bytes.TrimSuffix(txt, []byte{'\r'})
 
 		// Dispatch event on an empty line
 		if len(txt) == 0 {
 			if len(data) == 0 {
 				event = ""
+				if err != nil {
+					return false
+				}
 				continue
 			}
 			s.evt = Event{
@@ -122,20 +132,16 @@ func (s *eventStreamDecoder) Next() bool {
 		switch string(name) {
 		case "":
 			// An empty line in the for ": something" is a comment and should be ignored.
-			continue
 		case "event":
 			event = string(value)
 		case "data":
 			data = append(data, value...)
 			data = append(data, '\n')
 		}
+		if err != nil {
+			return false
+		}
 	}
-
-	if s.scn.Err() != nil {
-		s.err = s.scn.Err()
-	}
-
-	return false
 }
 
 func (s *eventStreamDecoder) Event() Event {

--- a/packages/ssestream/ssestream.go
+++ b/packages/ssestream/ssestream.go
@@ -41,8 +41,9 @@ func NewDecoder(res *http.Response) Decoder {
 		}
 	}
 
-	// Buffered reads grow with the line instead of imposing an arbitrary event-size cap.
-	return &eventStreamDecoder{rc: res.Body, rdr: bufio.NewReader(res.Body)}
+	scn := bufio.NewScanner(res.Body)
+	scn.Buffer(nil, bufio.MaxScanTokenSize<<9)
+	return &eventStreamDecoder{rc: res.Body, scn: scn}
 }
 
 var decoderTypes = map[string](func(io.ReadCloser) Decoder){}
@@ -82,7 +83,7 @@ func (e *StreamError) Error() string {
 type eventStreamDecoder struct {
 	evt Event
 	rc  io.ReadCloser
-	rdr *bufio.Reader
+	scn *bufio.Scanner
 	err error
 }
 
@@ -94,24 +95,13 @@ func (s *eventStreamDecoder) Next() bool {
 	event := ""
 	var data []byte
 
-	for {
-		txt, err := s.rdr.ReadBytes('\n')
-		if err != nil && err != io.EOF {
-			s.err = err
-		}
-		if len(txt) == 0 {
-			return false
-		}
-		txt = bytes.TrimSuffix(txt, []byte{'\n'})
-		txt = bytes.TrimSuffix(txt, []byte{'\r'})
+	for s.scn.Scan() {
+		txt := s.scn.Bytes()
 
 		// Dispatch event on an empty line
 		if len(txt) == 0 {
 			if len(data) == 0 {
 				event = ""
-				if err != nil {
-					return false
-				}
 				continue
 			}
 			s.evt = Event{
@@ -132,16 +122,20 @@ func (s *eventStreamDecoder) Next() bool {
 		switch string(name) {
 		case "":
 			// An empty line in the for ": something" is a comment and should be ignored.
+			continue
 		case "event":
 			event = string(value)
 		case "data":
 			data = append(data, value...)
 			data = append(data, '\n')
 		}
-		if err != nil {
-			return false
-		}
 	}
+
+	if s.scn.Err() != nil {
+		s.err = s.scn.Err()
+	}
+
+	return false
 }
 
 func (s *eventStreamDecoder) Event() Event {


### PR DESCRIPTION
## Summary

Protect historically supported large Responses and Chat Completions payloads against new restrictions in parsers, streaming, or final-result helpers. This adapts the compatibility guidance from https://github.com/openai/openai-node/pull/2433 to HTTP JSON/SSE without changing existing runtime limits.

- Add deterministic, sequential synthetic tests for Responses JSON `OutputText()`, a Responses output-text SSE event, Chat Completions JSON, and multi-chunk chat accumulation including `JustFinishedContent()`.
- Keep JSON bodies and accumulated chat text at 32 MiB + 1 byte. The single Responses SSE payload is 32 MiB minus 1 KiB, leaving room for its JSON envelope below the longstanding 32 MiB line limit shipped in https://github.com/openai/openai-[go/pull/442](https://www.golinks.io/pull/442?trackSource=github). Each chat chunk also fits below that existing line limit while the accumulated result exceeds it.
- Document that new restrictions or tighter limits require an explicit, owner-approved API contract, while preserving established limits outside explicitly authorized changes. High memory use is intentional; fixture sizes protect existing behavior and do not define new API maxima.

No production code, dependencies, generation metadata, ownership exclusions, or custom-code budget changes. All payloads are generated locally in memory, with no live API calls or large captures.
