### PR TITLE
fix(examples): support recursive structured output schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,12 +281,13 @@ type Origin struct {
 	Organization string `json:"organization" jsonschema_description:"The organization that was in charge of its development"`
 }
 
-// Structured Outputs uses a subset of JSON schema
-// These flags are necessary to comply with the subset
 func GenerateSchema[T any]() (map[string]any, error) {
+	// Structured Outputs requires object schemas to disallow additional
+	// properties. Keep definitions referenced so recursive Go types terminate,
+	// while expanding the root struct preserves the example's object-shaped root.
 	reflector := jsonschema.Reflector{
 		AllowAdditionalProperties: false,
-		DoNotReference:            true,
+		ExpandedStruct:             true,
 	}
 	var v T
 	schema := reflector.Reflect(v)

--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ for _, item := range response.Output {
 ```go
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/invopop/jsonschema"
 	// ...
 )
@@ -283,15 +284,28 @@ type Origin struct {
 
 func GenerateSchema[T any]() (map[string]any, error) {
 	// Structured Outputs requires object schemas to disallow additional
-	// properties. Keep definitions referenced so recursive Go types terminate,
-	// while expanding the root struct preserves the example's object-shaped root.
+	// properties. Keep definitions referenced so recursive Go types terminate.
 	reflector := jsonschema.Reflector{
 		AllowAdditionalProperties: false,
-		ExpandedStruct:             true,
 	}
 	var v T
 	schema := reflector.Reflect(v)
-
+	if schema.Ref != "" {
+		const definitionsPrefix = "#/$defs/"
+		if len(schema.Ref) <= len(definitionsPrefix) || schema.Ref[:len(definitionsPrefix)] != definitionsPrefix {
+			return nil, fmt.Errorf("expand root JSON schema reference %q: unsupported reference", schema.Ref)
+		}
+		definition, ok := schema.Definitions[schema.Ref[len(definitionsPrefix):]]
+		if !ok {
+			return nil, fmt.Errorf("expand root JSON schema reference %q: definition not found", schema.Ref)
+		}
+		expanded := *definition
+		expanded.Version = schema.Version
+		expanded.ID = schema.ID
+		expanded.Anchor = schema.Anchor
+		expanded.Definitions = schema.Definitions
+		schema = &expanded
+	}
 	data, err := json.Marshal(schema)
 	if err != nil {
 		return nil, err

--- a/examples/structured-outputs/main.go
+++ b/examples/structured-outputs/main.go
@@ -29,11 +29,11 @@ type Origin struct {
 }
 
 func GenerateSchema[T any]() (map[string]any, error) {
-	// Structured Outputs uses a subset of JSON schema
-	// These flags are necessary to comply with the subset
+	// Structured Outputs requires object schemas to disallow additional
+	// properties. Keep references enabled so recursive Go types can use
+	// $defs/$ref instead of being inlined indefinitely.
 	reflector := jsonschema.Reflector{
 		AllowAdditionalProperties: false,
-		DoNotReference:            true,
 	}
 	var v T
 	schema := reflector.Reflect(v)

--- a/examples/structured-outputs/main.go
+++ b/examples/structured-outputs/main.go
@@ -30,14 +30,28 @@ type Origin struct {
 
 func GenerateSchema[T any]() (map[string]any, error) {
 	// Structured Outputs requires object schemas to disallow additional
-	// properties. Keep definitions referenced so recursive Go types terminate,
-	// while expanding the root struct preserves the example's object-shaped root.
+	// properties. Keep definitions referenced so recursive Go types terminate.
 	reflector := jsonschema.Reflector{
 		AllowAdditionalProperties: false,
-		ExpandedStruct:             true,
 	}
 	var v T
 	schema := reflector.Reflect(v)
+	if schema.Ref != "" {
+		const definitionsPrefix = "#/$defs/"
+		if len(schema.Ref) <= len(definitionsPrefix) || schema.Ref[:len(definitionsPrefix)] != definitionsPrefix {
+			return nil, fmt.Errorf("expand root JSON schema reference %q: unsupported reference", schema.Ref)
+		}
+		definition, ok := schema.Definitions[schema.Ref[len(definitionsPrefix):]]
+		if !ok {
+			return nil, fmt.Errorf("expand root JSON schema reference %q: definition not found", schema.Ref)
+		}
+		expanded := *definition
+		expanded.Version = schema.Version
+		expanded.ID = schema.ID
+		expanded.Anchor = schema.Anchor
+		expanded.Definitions = schema.Definitions
+		schema = &expanded
+	}
 	data, err := json.Marshal(schema)
 	if err != nil {
 		return nil, fmt.Errorf("marshal JSON schema: %w", err)

--- a/examples/structured-outputs/main.go
+++ b/examples/structured-outputs/main.go
@@ -30,10 +30,11 @@ type Origin struct {
 
 func GenerateSchema[T any]() (map[string]any, error) {
 	// Structured Outputs requires object schemas to disallow additional
-	// properties. Keep references enabled so recursive Go types can use
-	// $defs/$ref instead of being inlined indefinitely.
+	// properties. Keep definitions referenced so recursive Go types terminate,
+	// while expanding the root struct preserves the example's object-shaped root.
 	reflector := jsonschema.Reflector{
 		AllowAdditionalProperties: false,
+		ExpandedStruct:             true,
 	}
 	var v T
 	schema := reflector.Reflect(v)

--- a/examples/structured-outputs/main_test.go
+++ b/examples/structured-outputs/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -100,4 +101,58 @@ func TestGenerateSchemaPreserves64BitIntegerEnums(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestGenerateSchemaPreservesRecursiveReferences(t *testing.T) {
+	type recursiveSchemaNode struct {
+		Children []recursiveSchemaNode `json:"children"`
+	}
+
+	schema, err := GenerateSchema[recursiveSchemaNode]()
+	if err != nil {
+		t.Fatalf("GenerateSchema() error = %v", err)
+	}
+
+	data, err := json.Marshal(schema)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	var decoded struct {
+		Type string `json:"type"`
+		Defs map[string]struct {
+			Properties map[string]struct {
+				Items struct {
+					Ref string `json:"$ref"`
+				} `json:"items"`
+			} `json:"properties"`
+		} `json:"$defs"`
+	}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	if decoded.Type != "object" {
+		t.Fatalf("root type = %q, want %q", decoded.Type, "object")
+	}
+	if len(decoded.Defs) == 0 {
+		t.Fatal("recursive schema has no $defs")
+	}
+
+	const refPrefix = "#/$defs/"
+	for definitionName, definition := range decoded.Defs {
+		children, ok := definition.Properties["children"]
+		if !ok {
+			continue
+		}
+		if !strings.HasPrefix(children.Items.Ref, refPrefix) {
+			t.Fatalf("%s children items $ref = %q, want prefix %q", definitionName, children.Items.Ref, refPrefix)
+		}
+		if strings.TrimPrefix(children.Items.Ref, refPrefix) != definitionName {
+			t.Fatalf("%s children items $ref = %q, want self-reference", definitionName, children.Items.Ref)
+		}
+		return
+	}
+
+	t.Fatalf("recursive $defs has no definition with children property: %s", data)
 }


### PR DESCRIPTION
## Summary

Make the Structured Outputs schema helper support recursive Go types without changing the example's object-shaped root schema.

Fixes #492.

## Problem

The example configures `invopop/jsonschema` with `DoNotReference: true`. That forces referenced types to be inlined. A self-referential type therefore has no cycle breaker and schema reflection recurses until the Go runtime exhausts the goroutine stack.

Simply re-enabling references avoids the recursion, but `jsonschema` normally represents the root as a `$ref` into `$defs`, while the Structured Outputs example needs an object-shaped root.

## Fix

Keep references enabled and expand only the reflector's local root `$ref`:

- `AllowAdditionalProperties: false` remains unchanged;
- the referenced root definition is copied into the root schema;
- `$defs` is retained, so nested and recursive definitions can continue to use `$ref`;
- schema metadata (`$schema`, `$id`, `$anchor`) is preserved;
- the existing `json.RawMessage` conversion remains in place so large integer constraints keep their exact JSON representation.

This deliberately does **not** use `ExpandedStruct: true`: revalidation against `invopop/jsonschema` v0.14.0 showed that for the recursive fixture it expands the root while omitting `$defs`, leaving the emitted nested `$ref` dangling.

The duplicated Structured Outputs snippet in `README.md` uses the same logic.

## Regression coverage

The recursive fixture verifies that:

- the root remains `type: "object"`;
- `$defs` is present;
- the recursive `children` item is a self-reference into `$defs`.

The existing object-shape and exact 64-bit integer enum tests remain intact.

## Validation

Current head: `32823ea5723614ad1053f3caaa4cc1bc6686dfe3`.

Local / isolated validation:

- focused recursive regression test: pass;
- complete `examples` test module: pass;
- root and examples `go vet ./...`: pass;
- root and examples builds: pass;
- external consumer test: pass;
- `git diff --check`: pass;
- synthetic merge with current `upstream/main` at `37c0f0ab07fbe5f5b2775c12ca3500acd0caad8c`: clean; examples tests and root build pass on the merged tree.

Fork CI on the exact head is green for the executable gates:

- lint + `check-go-mod`: pass;
- Go 1.25.x: root module, examples module, and external consumer tests pass;
- Go 1.26.x: root module, examples module, and external consumer tests pass.

The upstream workflows for this external-contributor head remain `action_required`; that is an approval gate, not a technical test failure.