### PR TITLE
feat(auth): add caller-attested X.509 transport capability

### DIFF
--- a/auth/x509transport.go
+++ b/auth/x509transport.go
@@ -30,6 +30,21 @@ type x509TransportError struct {
 func (err *x509TransportError) Error() string { return "X.509 transport request failed" }
 func (err *x509TransportError) Unwrap() error { return err.cause }
 
+// x509TraceFreeContext preserves cancellation, deadlines, and ordinary context
+// values while preventing a mutable parent from revealing HTTP trace hooks
+// after the request's final security checks.
+type x509TraceFreeContext struct {
+	context.Context
+}
+
+func (ctx x509TraceFreeContext) Value(key any) any {
+	value := ctx.Context.Value(key)
+	if _, ok := value.(*httptrace.ClientTrace); ok {
+		return nil
+	}
+	return value
+}
+
 // X509Transport represents one explicitly attested mTLS configuration
 // generation. Its identity is the capability pointer, not a certificate-bound
 // OAuth token. Rotating credentials requires a new transport and capability.
@@ -97,6 +112,14 @@ func NewX509Transport(template *http.Transport) (*X509Transport, error) {
 	}
 	//nolint:staticcheck // Preserve a legacy TCP dialer; unlike DialTLS, it cannot bypass native TLS.
 	transport.Dial = template.Dial
+	if template.Protocols != nil {
+		protocols := *template.Protocols
+		transport.Protocols = &protocols
+	}
+	if template.HTTP2 != nil {
+		configuration := *template.HTTP2
+		transport.HTTP2 = &configuration
+	}
 
 	return &X509Transport{
 		template:          template,
@@ -154,8 +177,16 @@ func validateX509NativeTransport(transport *http.Transport) error {
 	if transport.Proxy != nil {
 		return errors.New("X.509 transport currently supports direct connections only")
 	}
-	if len(transport.TLSNextProto) != 0 {
+	for protocol, handler := range transport.TLSNextProto {
+		if (protocol != "h2" && protocol != "unencrypted_http2") || handler == nil {
+			return errors.New("X.509 transport does not support custom TLS protocol handlers")
+		}
+	}
+	if len(transport.TLSNextProto) != 0 && transport.TLSNextProto["h2"] == nil {
 		return errors.New("X.509 transport does not support custom TLS protocol handlers")
+	}
+	if transport.HTTP2 != nil && transport.HTTP2.CountError != nil {
+		return errors.New("X.509 transport does not support HTTP/2 error callbacks")
 	}
 	if config.InsecureSkipVerify {
 		return errors.New("X.509 transport requires TLS certificate and hostname verification")
@@ -216,19 +247,27 @@ func (transport *X509Transport) Do(request *http.Request) (*http.Response, error
 	if request == nil {
 		return nil, errors.New("X.509 transport requires a non-nil HTTP request")
 	}
+	body := request.Body
+	bodyTransferred := false
+	defer func() {
+		if !bodyTransferred && body != nil {
+			_ = body.Close()
+		}
+	}()
 	if err := request.Context().Err(); err != nil {
 		return nil, err
 	}
 	if httptrace.ContextClientTrace(request.Context()) != nil {
 		return nil, errors.New("X.509 transport does not support HTTP trace callbacks")
 	}
-	request = request.Clone(request.Context())
+	request = request.Clone(x509TraceFreeContext{request.Context()})
 	if err := transport.validateAttestation(); err != nil {
 		return nil, err
 	}
 	if err := validateX509Request(request); err != nil {
 		return nil, err
 	}
+	bodyTransferred = true
 	response, err := transport.client.Do(request)
 	if err != nil {
 		redacted := &x509TransportError{}
@@ -241,6 +280,15 @@ func (transport *X509Transport) Do(request *http.Request) (*http.Response, error
 			redacted.cause = context.DeadlineExceeded
 		}
 		return nil, redacted
+	}
+	if response.StatusCode == http.StatusSwitchingProtocols {
+		_ = response.Body.Close()
+		return nil, errors.New("X.509 transport does not support protocol upgrades")
+	}
+	if response.StatusCode >= http.StatusMultipleChoices &&
+		response.StatusCode < http.StatusBadRequest && response.StatusCode != http.StatusNotModified {
+		_ = response.Body.Close()
+		return nil, &x509TransportError{cause: errX509Redirect}
 	}
 	return response, nil
 }
@@ -275,7 +323,8 @@ func validateX509Request(request *http.Request) error {
 			return errors.New("X.509 requests cannot contain alternate credentials, cookies, or authority headers")
 		case "authorization":
 			authorizationCount += len(values)
-			if host == x509AuthenticationHost || authorizationCount != 1 || !validX509BearerHeader(values[0]) {
+			if host == x509AuthenticationHost || len(values) != 1 ||
+				authorizationCount != 1 || !validX509BearerHeader(values[0]) {
 				return errors.New("X.509 requests contain invalid Authorization credentials")
 			}
 		case "openai-organization", "openai-project":

--- a/auth/x509transport.go
+++ b/auth/x509transport.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/http/httptrace"
 	"path"
 	"slices"
 	"strings"
@@ -59,6 +60,23 @@ func NewX509Transport(template *http.Transport) (*X509Transport, error) {
 	}
 	config := template.TLSClientConfig.Clone()
 	config.Certificates = slices.Clone(config.Certificates)
+	for index := range config.Certificates {
+		certificate := &config.Certificates[index]
+		certificate.Certificate = slices.Clone(certificate.Certificate)
+		for chainIndex := range certificate.Certificate {
+			certificate.Certificate[chainIndex] = slices.Clone(certificate.Certificate[chainIndex])
+		}
+		certificate.OCSPStaple = slices.Clone(certificate.OCSPStaple)
+		certificate.SignedCertificateTimestamps = slices.Clone(certificate.SignedCertificateTimestamps)
+		for timestampIndex := range certificate.SignedCertificateTimestamps {
+			certificate.SignedCertificateTimestamps[timestampIndex] = slices.Clone(
+				certificate.SignedCertificateTimestamps[timestampIndex],
+			)
+		}
+	}
+	if config.RootCAs != nil {
+		config.RootCAs = config.RootCAs.Clone()
+	}
 	config.NextProtos = slices.Clone(config.NextProtos)
 	transport := &http.Transport{
 		DialContext:            template.DialContext,
@@ -189,6 +207,7 @@ func (transport *X509Transport) Close() error {
 // Do sends a request to an approved global OpenAI mTLS endpoint without
 // following redirects. The request is snapshotted before validation so caller
 // hooks cannot alter its URL or credentials after the final safety checks.
+// Traces exposing a live connection and request trailers are unsupported.
 // Request context and caller-owned TLS credentials are preserved; the
 // capability owns its isolated pool. OAuth authentication is configured
 // separately.
@@ -198,6 +217,9 @@ func (transport *X509Transport) Do(request *http.Request) (*http.Response, error
 	}
 	if err := request.Context().Err(); err != nil {
 		return nil, err
+	}
+	if trace := httptrace.ContextClientTrace(request.Context()); trace != nil && trace.GotConn != nil {
+		return nil, errors.New("X.509 transport does not support connection-exposing HTTP trace callbacks")
 	}
 	request = request.Clone(request.Context())
 	if err := transport.validateAttestation(); err != nil {
@@ -223,6 +245,9 @@ func (transport *X509Transport) Do(request *http.Request) (*http.Response, error
 }
 
 func validateX509Request(request *http.Request) error {
+	if len(request.Trailer) != 0 {
+		return errors.New("X.509 requests do not support HTTP trailers")
+	}
 	if request.URL == nil || request.URL.Scheme != "https" || request.URL.User != nil ||
 		request.URL.Opaque != "" || request.URL.Fragment != "" || request.URL.RawFragment != "" {
 		return errors.New("X.509 requests require an absolute HTTPS URL without credentials or fragments")

--- a/auth/x509transport.go
+++ b/auth/x509transport.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"crypto/subtle"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -24,7 +25,10 @@ const (
 	x509APIHost            = "mtls.api.openai.com"
 )
 
-var errX509Redirect = errors.New("X.509 workload identity does not follow redirects")
+var (
+	errX509Redirect        = errors.New("X.509 workload identity does not follow redirects")
+	errX509TLSVerification = errors.New("X.509 transport TLS verification failed")
+)
 
 type x509TransportError struct {
 	cause     error
@@ -144,22 +148,33 @@ func NewX509Transport(template *http.Transport) (*X509Transport, error) {
 		transport.HTTP2 = &configuration
 	}
 	http1, http2 := x509EffectiveHTTPProtocols(template)
+	verifyPeerCertificate := config.VerifyPeerCertificate
+	if verifyPeerCertificate != nil {
+		config.VerifyPeerCertificate = func(certificates [][]byte, chains [][]*x509.Certificate) error {
+			if err := verifyPeerCertificate(certificates, chains); err != nil {
+				return errX509TLSVerification
+			}
+			return nil
+		}
+	}
 	verifyConnection := config.VerifyConnection
 	config.VerifyConnection = func(state tls.ConnectionState) error {
 		switch state.NegotiatedProtocol {
 		case "h2":
 			if !http2 || transport.TLSNextProto["h2"] == nil {
-				return errors.New("X.509 transport negotiated HTTP/2 without an enabled native handler")
+				return errX509TLSVerification
 			}
 		case "", "http/1.1":
 			if !http1 {
-				return errors.New("X.509 transport negotiated a disabled HTTP/1 connection")
+				return errX509TLSVerification
 			}
 		default:
-			return errors.New("X.509 transport negotiated an unsupported TLS application protocol")
+			return errX509TLSVerification
 		}
 		if verifyConnection != nil {
-			return verifyConnection(state)
+			if err := verifyConnection(state); err != nil {
+				return errX509TLSVerification
+			}
 		}
 		return nil
 	}
@@ -380,6 +395,7 @@ func (transport *X509Transport) Do(request *http.Request) (*http.Response, error
 	response, err := transport.client.Do(request)
 	if err != nil {
 		redacted := &x509TransportError{}
+		var verificationError *tls.CertificateVerificationError
 		var networkError net.Error
 		if errors.As(err, &networkError) {
 			redacted.timeout = networkError.Timeout()
@@ -394,6 +410,8 @@ func (transport *X509Transport) Do(request *http.Request) (*http.Response, error
 			redacted.cause = context.Canceled
 		case errors.Is(err, context.DeadlineExceeded):
 			redacted.cause = context.DeadlineExceeded
+		case errors.Is(err, errX509TLSVerification) || errors.As(err, &verificationError):
+			redacted.cause = errX509TLSVerification
 		}
 		return nil, redacted
 	}

--- a/auth/x509transport.go
+++ b/auth/x509transport.go
@@ -1,0 +1,190 @@
+package auth
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net/http"
+	"path"
+	"strings"
+)
+
+const (
+	x509AuthenticationHost = "mtls.auth.openai.com"
+	x509APIHost            = "mtls.api.openai.com"
+)
+
+var errX509Redirect = errors.New("X.509 workload identity does not follow redirects")
+
+type x509TransportError struct {
+	cause error
+}
+
+func (err *x509TransportError) Error() string { return "X.509 transport request failed" }
+func (err *x509TransportError) Unwrap() error { return err.cause }
+
+// X509Transport represents one explicitly attested, caller-owned mTLS transport
+// generation. Its identity is the capability pointer, not a certificate-bound
+// OAuth token. Rotating credentials requires a new transport and capability.
+//
+// The application owns the transport, certificate, private key, trust roots,
+// connection pool, and lifecycle. It must not mutate the transport or its TLS
+// configuration after attestation. HTTPS proxies are unsupported because
+// net/http uses the same client TLS configuration for a proxy and its origin.
+type X509Transport struct {
+	transport *http.Transport
+	tlsConfig *tls.Config
+	client    *http.Client
+}
+
+// NewX509Transport attests a direct, native HTTP transport configured with one
+// static client certificate. The transport remains owned by its caller.
+func NewX509Transport(transport *http.Transport) (*X509Transport, error) {
+	if err := validateX509NativeTransport(transport); err != nil {
+		return nil, err
+	}
+
+	return &X509Transport{
+		transport: transport,
+		tlsConfig: transport.TLSClientConfig,
+		client: &http.Client{
+			Transport: transport,
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return errX509Redirect
+			},
+		},
+	}, nil
+}
+
+func validateX509NativeTransport(transport *http.Transport) error {
+	if transport == nil {
+		return errors.New("X.509 transport requires a non-nil native HTTP transport")
+	}
+	if transport.TLSClientConfig == nil {
+		return errors.New("X.509 transport requires an explicit TLS configuration")
+	}
+	config := transport.TLSClientConfig
+	if len(config.Certificates) != 1 || len(config.Certificates[0].Certificate) == 0 ||
+		len(config.Certificates[0].Certificate[0]) == 0 || config.Certificates[0].PrivateKey == nil {
+		return errors.New("X.509 transport requires exactly one static certificate and private key")
+	}
+	if config.GetClientCertificate != nil {
+		return errors.New("X.509 transport does not support dynamic client-certificate callbacks")
+	}
+	if transport.DialTLSContext != nil {
+		return errors.New("X.509 transport does not support custom TLS dialers")
+	}
+	//nolint:staticcheck // Deprecated DialTLS still bypasses TLSClientConfig and must be rejected.
+	if transport.DialTLS != nil {
+		return errors.New("X.509 transport does not support deprecated TLS dialers")
+	}
+	if config.ClientSessionCache != nil {
+		return errors.New("X.509 transport does not support shared TLS session caches")
+	}
+	if transport.Proxy != nil {
+		return errors.New("X.509 transport currently supports direct connections only")
+	}
+	if config.InsecureSkipVerify {
+		return errors.New("X.509 transport requires TLS certificate and hostname verification")
+	}
+	if config.ServerName != "" {
+		return errors.New("X.509 transport does not support overriding the TLS server name")
+	}
+	return nil
+}
+
+func (transport *X509Transport) validateAttestation() error {
+	if transport == nil || transport.client == nil || transport.transport == nil {
+		return errors.New("X.509 transport capability is invalid")
+	}
+	if err := validateX509NativeTransport(transport.transport); err != nil {
+		return fmt.Errorf("X.509 transport attestation changed: %w", err)
+	}
+	if transport.transport.TLSClientConfig != transport.tlsConfig {
+		return errors.New("X.509 transport TLS configuration changed after attestation")
+	}
+	return nil
+}
+
+// Do sends a request to an approved global OpenAI mTLS endpoint without
+// following redirects. Request context, transport ownership, and pooling are
+// preserved. OAuth exchange and client authentication are configured separately.
+func (transport *X509Transport) Do(request *http.Request) (*http.Response, error) {
+	if request == nil {
+		return nil, errors.New("X.509 transport requires a non-nil HTTP request")
+	}
+	if err := request.Context().Err(); err != nil {
+		return nil, err
+	}
+	if err := transport.validateAttestation(); err != nil {
+		return nil, err
+	}
+	if err := validateX509Request(request); err != nil {
+		return nil, err
+	}
+	response, err := transport.client.Do(request)
+	if err != nil {
+		redacted := &x509TransportError{}
+		switch {
+		case errors.Is(err, errX509Redirect):
+			redacted.cause = errX509Redirect
+		case errors.Is(err, context.Canceled):
+			redacted.cause = context.Canceled
+		case errors.Is(err, context.DeadlineExceeded):
+			redacted.cause = context.DeadlineExceeded
+		}
+		return nil, redacted
+	}
+	return response, nil
+}
+
+func validateX509Request(request *http.Request) error {
+	if request.URL == nil || request.URL.Scheme != "https" || request.URL.User != nil ||
+		request.URL.Opaque != "" || request.URL.Fragment != "" || request.URL.RawFragment != "" {
+		return errors.New("X.509 requests require an absolute HTTPS URL without credentials or fragments")
+	}
+	host := request.URL.Hostname()
+	if host != x509AuthenticationHost && host != x509APIHost {
+		return errors.New("X.509 requests are limited to approved global OpenAI mTLS origins")
+	}
+	if request.URL.Port() != "" && request.URL.Port() != "443" {
+		return errors.New("X.509 requests require the default HTTPS port")
+	}
+	if request.URL.Host != host && request.URL.Host != host+":443" {
+		return errors.New("X.509 requests require an exact mTLS URL authority")
+	}
+	if request.Host != "" && request.Host != request.URL.Host {
+		return errors.New("X.509 request Host must match its URL authority")
+	}
+
+	authorizationCount := 0
+	for name, values := range request.Header {
+		normalized := strings.ToLower(strings.ReplaceAll(name, "_", "-"))
+		switch normalized {
+		case "api-key", "x-api-key", "proxy-authorization", "cookie", "set-cookie", "host", "x-amz-security-token":
+			return errors.New("X.509 requests cannot contain alternate credentials, cookies, or authority headers")
+		case "authorization":
+			authorizationCount += len(values)
+			if host == x509AuthenticationHost || authorizationCount != 1 {
+				return errors.New("X.509 requests contain invalid Authorization credentials")
+			}
+		}
+		if strings.HasPrefix(normalized, ":") {
+			return errors.New("X.509 requests cannot override HTTP authority pseudo-headers")
+		}
+	}
+
+	if host == x509AuthenticationHost {
+		if request.Method != http.MethodPost || request.URL.Path != "/oauth/token" ||
+			request.URL.EscapedPath() != "/oauth/token" || request.URL.RawQuery != "" || request.URL.ForceQuery {
+			return errors.New("X.509 token exchange requires POST to the exact pinned OAuth endpoint")
+		}
+		return nil
+	}
+	if !strings.HasPrefix(request.URL.Path, "/v1/") ||
+		!strings.HasPrefix(request.URL.EscapedPath(), "/v1/") || path.Clean(request.URL.Path) != request.URL.Path {
+		return errors.New("X.509 API requests must remain inside the /v1/ path")
+	}
+	return nil
+}

--- a/auth/x509transport.go
+++ b/auth/x509transport.go
@@ -207,7 +207,8 @@ func (transport *X509Transport) Close() error {
 // Do sends a request to an approved global OpenAI mTLS endpoint without
 // following redirects. The request is snapshotted before validation so caller
 // hooks cannot alter its URL or credentials after the final safety checks.
-// Traces exposing a live connection and request trailers are unsupported.
+// HTTP tracing callbacks and request trailers are unsupported because mutable
+// trace hooks can expose a live connection after request validation.
 // Request context and caller-owned TLS credentials are preserved; the
 // capability owns its isolated pool. OAuth authentication is configured
 // separately.
@@ -218,8 +219,8 @@ func (transport *X509Transport) Do(request *http.Request) (*http.Response, error
 	if err := request.Context().Err(); err != nil {
 		return nil, err
 	}
-	if trace := httptrace.ContextClientTrace(request.Context()); trace != nil && trace.GotConn != nil {
-		return nil, errors.New("X.509 transport does not support connection-exposing HTTP trace callbacks")
+	if httptrace.ContextClientTrace(request.Context()) != nil {
+		return nil, errors.New("X.509 transport does not support HTTP trace callbacks")
 	}
 	request = request.Clone(request.Context())
 	if err := transport.validateAttestation(); err != nil {

--- a/auth/x509transport.go
+++ b/auth/x509transport.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptrace"
 	"path"
+	"reflect"
 	"slices"
 	"strings"
 	"sync/atomic"
@@ -71,6 +72,9 @@ type X509Transport struct {
 // caller-owned; the returned capability owns a separate clean connection pool.
 func NewX509Transport(template *http.Transport) (*X509Transport, error) {
 	if err := validateX509NativeTransport(template); err != nil {
+		return nil, err
+	}
+	if err := validateX509TLSProtocolHandlers(template.TLSNextProto); err != nil {
 		return nil, err
 	}
 	config := template.TLSClientConfig.Clone()
@@ -163,7 +167,7 @@ func validateX509NativeTransport(transport *http.Transport) error {
 	}
 	config := transport.TLSClientConfig
 	if len(config.Certificates) != 1 || len(config.Certificates[0].Certificate) == 0 ||
-		len(config.Certificates[0].Certificate[0]) == 0 || config.Certificates[0].PrivateKey == nil {
+		len(config.Certificates[0].Certificate[0]) == 0 || x509PrivateKeyIsNil(config.Certificates[0].PrivateKey) {
 		return errors.New("X.509 transport requires exactly one static certificate and private key")
 	}
 	if config.GetClientCertificate != nil {
@@ -182,14 +186,6 @@ func validateX509NativeTransport(transport *http.Transport) error {
 	if transport.Proxy != nil {
 		return errors.New("X.509 transport currently supports direct connections only")
 	}
-	for protocol, handler := range transport.TLSNextProto {
-		if (protocol != "h2" && protocol != "unencrypted_http2") || handler == nil {
-			return errors.New("X.509 transport does not support custom TLS protocol handlers")
-		}
-	}
-	if len(transport.TLSNextProto) != 0 && transport.TLSNextProto["h2"] == nil {
-		return errors.New("X.509 transport does not support custom TLS protocol handlers")
-	}
 	if transport.HTTP2 != nil && transport.HTTP2.CountError != nil {
 		return errors.New("X.509 transport does not support HTTP/2 error callbacks")
 	}
@@ -198,6 +194,31 @@ func validateX509NativeTransport(transport *http.Transport) error {
 	}
 	if config.ServerName != "" {
 		return errors.New("X.509 transport does not support overriding the TLS server name")
+	}
+	return nil
+}
+
+func x509PrivateKeyIsNil(key any) bool {
+	if key == nil {
+		return true
+	}
+	value := reflect.ValueOf(key)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice, reflect.UnsafePointer:
+		return value.IsNil()
+	default:
+		return false
+	}
+}
+
+func validateX509TLSProtocolHandlers(handlers map[string]func(string, *tls.Conn) http.RoundTripper) error {
+	for protocol, handler := range handlers {
+		if (protocol != "h2" && protocol != "unencrypted_http2") || handler == nil {
+			return errors.New("X.509 transport does not support custom TLS protocol handlers")
+		}
+	}
+	if len(handlers) != 0 && handlers["h2"] == nil {
+		return errors.New("X.509 transport does not support custom TLS protocol handlers")
 	}
 	return nil
 }

--- a/auth/x509transport.go
+++ b/auth/x509transport.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"crypto"
 	"crypto/sha256"
 	"crypto/subtle"
 	"crypto/tls"
@@ -79,7 +80,7 @@ func NewX509Transport(template *http.Transport) (*X509Transport, error) {
 	if err := validateX509NativeTransport(template); err != nil {
 		return nil, err
 	}
-	if err := validateX509ApplicationProtocols(template.TLSClientConfig.NextProtos); err != nil {
+	if err := validateX509ApplicationProtocols(template); err != nil {
 		return nil, err
 	}
 	if err := validateX509TLSProtocolHandlers(template.TLSNextProto); err != nil {
@@ -198,8 +199,12 @@ func validateX509NativeTransport(transport *http.Transport) error {
 }
 
 func validateX509TLSConfig(config *tls.Config) error {
+	var signer crypto.Signer
+	if len(config.Certificates) == 1 {
+		signer, _ = config.Certificates[0].PrivateKey.(crypto.Signer)
+	}
 	if len(config.Certificates) != 1 || len(config.Certificates[0].Certificate) == 0 ||
-		len(config.Certificates[0].Certificate[0]) == 0 || x509PrivateKeyIsNil(config.Certificates[0].PrivateKey) {
+		len(config.Certificates[0].Certificate[0]) == 0 || x509PrivateKeyIsNil(signer) {
 		return errors.New("X.509 transport requires exactly one static certificate and private key")
 	}
 	if config.GetClientCertificate != nil {
@@ -230,10 +235,22 @@ func validateX509TLSConfig(config *tls.Config) error {
 	return nil
 }
 
-func validateX509ApplicationProtocols(protocols []string) error {
-	for _, protocol := range protocols {
+func validateX509ApplicationProtocols(template *http.Transport) error {
+	http1, http2 := true, template.ForceAttemptHTTP2
+	if template.Protocols != nil {
+		http1, http2 = template.Protocols.HTTP1(), template.Protocols.HTTP2()
+	} else if template.TLSNextProto != nil {
+		http2 = template.TLSNextProto["h2"] != nil
+	}
+	if !http1 && !http2 {
+		return errors.New("X.509 transport requires an enabled HTTPS-compatible HTTP protocol")
+	}
+	for _, protocol := range template.TLSClientConfig.NextProtos {
 		if protocol != "h2" && protocol != "http/1.1" {
 			return errors.New("X.509 transport does not support non-HTTP TLS application protocols")
+		}
+		if (protocol == "h2" && !http2) || (protocol == "http/1.1" && !http1) {
+			return errors.New("X.509 transport TLS application protocol is disabled by its HTTP configuration")
 		}
 	}
 	return nil

--- a/auth/x509transport.go
+++ b/auth/x509transport.go
@@ -143,6 +143,26 @@ func NewX509Transport(template *http.Transport) (*X509Transport, error) {
 		configuration := *template.HTTP2
 		transport.HTTP2 = &configuration
 	}
+	http1, http2 := x509EffectiveHTTPProtocols(template)
+	verifyConnection := config.VerifyConnection
+	config.VerifyConnection = func(state tls.ConnectionState) error {
+		switch state.NegotiatedProtocol {
+		case "h2":
+			if !http2 || transport.TLSNextProto["h2"] == nil {
+				return errors.New("X.509 transport negotiated HTTP/2 without an enabled native handler")
+			}
+		case "", "http/1.1":
+			if !http1 {
+				return errors.New("X.509 transport negotiated a disabled HTTP/1 connection")
+			}
+		default:
+			return errors.New("X.509 transport negotiated an unsupported TLS application protocol")
+		}
+		if verifyConnection != nil {
+			return verifyConnection(state)
+		}
+		return nil
+	}
 
 	return &X509Transport{
 		template:          template,
@@ -236,12 +256,7 @@ func validateX509TLSConfig(config *tls.Config) error {
 }
 
 func validateX509ApplicationProtocols(template *http.Transport) error {
-	http1, http2 := true, template.ForceAttemptHTTP2
-	if template.Protocols != nil {
-		http1, http2 = template.Protocols.HTTP1(), template.Protocols.HTTP2()
-	} else if template.TLSNextProto != nil {
-		http2 = template.TLSNextProto["h2"] != nil
-	}
+	http1, http2 := x509EffectiveHTTPProtocols(template)
 	if !http1 && !http2 {
 		return errors.New("X.509 transport requires an enabled HTTPS-compatible HTTP protocol")
 	}
@@ -254,6 +269,16 @@ func validateX509ApplicationProtocols(template *http.Transport) error {
 		}
 	}
 	return nil
+}
+
+func x509EffectiveHTTPProtocols(template *http.Transport) (bool, bool) {
+	http1, http2 := true, template.ForceAttemptHTTP2
+	if template.Protocols != nil {
+		http1, http2 = template.Protocols.HTTP1(), template.Protocols.HTTP2()
+	} else if template.TLSNextProto != nil {
+		http2 = template.TLSNextProto["h2"] != nil
+	}
+	return http1, http2
 }
 
 func x509PrivateKeyIsNil(key any) bool {

--- a/auth/x509transport.go
+++ b/auth/x509transport.go
@@ -444,9 +444,20 @@ func validateX509Request(request *http.Request) error {
 	if len(request.TransferEncoding) != 0 {
 		return errors.New("X.509 requests do not support custom HTTP transfer encodings")
 	}
+	if request.RequestURI != "" {
+		return errors.New("X.509 client requests cannot specify an explicit request URI")
+	}
+	if request.Cancel != nil { //nolint:staticcheck // Rejecting caller-controlled legacy cancellation requires its sole, deprecated accessor.
+		return errors.New("X.509 requests require context-based cancellation")
+	}
 	if request.URL == nil || request.URL.Scheme != "https" || request.URL.User != nil ||
 		request.URL.Opaque != "" || request.URL.Fragment != "" || request.URL.RawFragment != "" {
 		return errors.New("X.509 requests require an absolute HTTPS URL without credentials or fragments")
+	}
+	for _, character := range []byte(request.URL.RawQuery) {
+		if character < ' ' || character == 0x7f {
+			return errors.New("X.509 requests cannot contain HTTP control characters in their query")
+		}
 	}
 	host := request.URL.Hostname()
 	if host != x509AuthenticationHost && host != x509APIHost {
@@ -464,6 +475,14 @@ func validateX509Request(request *http.Request) error {
 
 	authorizationCount := 0
 	for name, values := range request.Header {
+		if !validX509HeaderName(name) {
+			return errors.New("X.509 requests require valid HTTP header names")
+		}
+		for _, value := range values {
+			if !validX509HeaderValue(value) {
+				return errors.New("X.509 requests require valid HTTP header values")
+			}
+		}
 		normalized := strings.ToLower(strings.ReplaceAll(name, "_", "-"))
 		switch normalized {
 		case "api-key", "x-api-key", "proxy-authorization", "cookie", "set-cookie", "host", "x-amz-security-token":
@@ -499,6 +518,32 @@ func validateX509Request(request *http.Request) error {
 		return errors.New("X.509 API requests must remain inside the /v1/ path")
 	}
 	return nil
+}
+
+func validX509HeaderName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for _, value := range []byte(name) {
+		switch {
+		case value >= 'A' && value <= 'Z', value >= 'a' && value <= 'z', value >= '0' && value <= '9':
+		case value == '!', value == '#', value == '$', value == '%', value == '&', value == '\'',
+			value == '*', value == '+', value == '-', value == '.', value == '^', value == '_',
+			value == '`', value == '|', value == '~':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func validX509HeaderValue(value string) bool {
+	for _, character := range []byte(value) {
+		if (character < ' ' && character != '\t') || character == 0x7f {
+			return false
+		}
+	}
+	return true
 }
 
 func validX509BearerHeader(value string) bool {

--- a/auth/x509transport.go
+++ b/auth/x509transport.go
@@ -2,12 +2,17 @@ package auth
 
 import (
 	"context"
+	"crypto/sha256"
+	"crypto/subtle"
 	"crypto/tls"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"net/http"
 	"path"
+	"slices"
 	"strings"
+	"sync/atomic"
 )
 
 const (
@@ -24,30 +29,63 @@ type x509TransportError struct {
 func (err *x509TransportError) Error() string { return "X.509 transport request failed" }
 func (err *x509TransportError) Unwrap() error { return err.cause }
 
-// X509Transport represents one explicitly attested, caller-owned mTLS transport
+// X509Transport represents one explicitly attested mTLS configuration
 // generation. Its identity is the capability pointer, not a certificate-bound
 // OAuth token. Rotating credentials requires a new transport and capability.
 //
-// The application owns the transport, certificate, private key, trust roots,
-// connection pool, and lifecycle. It must not mutate the transport or its TLS
-// configuration after attestation. HTTPS proxies are unsupported because
-// net/http uses the same client TLS configuration for a proxy and its origin.
+// The application owns its template transport, certificate, private key, and
+// trust roots. The template is never used, modified, or closed by this
+// capability. X509Transport creates an isolated native connection pool that
+// cannot inherit privately registered HTTPS handlers; call Close to release
+// that pool. The template and its TLS configuration must remain unchanged after
+// attestation. HTTPS proxies are unsupported because net/http uses the same
+// client TLS configuration for a proxy and its origin.
 type X509Transport struct {
-	transport *http.Transport
-	tlsConfig *tls.Config
-	client    *http.Client
+	template          *http.Transport
+	templateTLS       *tls.Config
+	transport         *http.Transport
+	tlsConfig         *tls.Config
+	certificateDigest [sha256.Size]byte
+	client            *http.Client
+	closed            atomic.Bool
 }
 
-// NewX509Transport attests a direct, native HTTP transport configured with one
-// static client certificate. The transport remains owned by its caller.
-func NewX509Transport(transport *http.Transport) (*X509Transport, error) {
-	if err := validateX509NativeTransport(transport); err != nil {
+// NewX509Transport attests a direct, native HTTP transport template configured
+// with one static client certificate. The template and TLS credentials remain
+// caller-owned; the returned capability owns a separate clean connection pool.
+func NewX509Transport(template *http.Transport) (*X509Transport, error) {
+	if err := validateX509NativeTransport(template); err != nil {
 		return nil, err
 	}
+	config := template.TLSClientConfig.Clone()
+	config.Certificates = slices.Clone(config.Certificates)
+	config.NextProtos = slices.Clone(config.NextProtos)
+	transport := &http.Transport{
+		DialContext:            template.DialContext,
+		TLSClientConfig:        config,
+		TLSHandshakeTimeout:    template.TLSHandshakeTimeout,
+		DisableKeepAlives:      template.DisableKeepAlives,
+		DisableCompression:     template.DisableCompression,
+		MaxIdleConns:           template.MaxIdleConns,
+		MaxIdleConnsPerHost:    template.MaxIdleConnsPerHost,
+		MaxConnsPerHost:        template.MaxConnsPerHost,
+		IdleConnTimeout:        template.IdleConnTimeout,
+		ResponseHeaderTimeout:  template.ResponseHeaderTimeout,
+		ExpectContinueTimeout:  template.ExpectContinueTimeout,
+		MaxResponseHeaderBytes: template.MaxResponseHeaderBytes,
+		WriteBufferSize:        template.WriteBufferSize,
+		ReadBufferSize:         template.ReadBufferSize,
+		ForceAttemptHTTP2:      template.ForceAttemptHTTP2,
+	}
+	//nolint:staticcheck // Preserve a legacy TCP dialer; unlike DialTLS, it cannot bypass native TLS.
+	transport.Dial = template.Dial
 
 	return &X509Transport{
-		transport: transport,
-		tlsConfig: transport.TLSClientConfig,
+		template:          template,
+		templateTLS:       template.TLSClientConfig,
+		transport:         transport,
+		tlsConfig:         config,
+		certificateDigest: x509CertificateDigest(config.Certificates[0].Certificate),
 		client: &http.Client{
 			Transport: transport,
 			CheckRedirect: func(*http.Request, []*http.Request) error {
@@ -55,6 +93,19 @@ func NewX509Transport(transport *http.Transport) (*X509Transport, error) {
 			},
 		},
 	}, nil
+}
+
+func x509CertificateDigest(chain [][]byte) [sha256.Size]byte {
+	digest := sha256.New()
+	var length [8]byte
+	for _, certificate := range chain {
+		binary.BigEndian.PutUint64(length[:], uint64(len(certificate)))
+		_, _ = digest.Write(length[:])
+		_, _ = digest.Write(certificate)
+	}
+	var result [sha256.Size]byte
+	copy(result[:], digest.Sum(nil))
+	return result
 }
 
 func validateX509NativeTransport(transport *http.Transport) error {
@@ -85,6 +136,9 @@ func validateX509NativeTransport(transport *http.Transport) error {
 	if transport.Proxy != nil {
 		return errors.New("X.509 transport currently supports direct connections only")
 	}
+	if len(transport.TLSNextProto) != 0 {
+		return errors.New("X.509 transport does not support custom TLS protocol handlers")
+	}
 	if config.InsecureSkipVerify {
 		return errors.New("X.509 transport requires TLS certificate and hostname verification")
 	}
@@ -95,21 +149,49 @@ func validateX509NativeTransport(transport *http.Transport) error {
 }
 
 func (transport *X509Transport) validateAttestation() error {
-	if transport == nil || transport.client == nil || transport.transport == nil {
+	if transport == nil || transport.client == nil || transport.transport == nil || transport.template == nil {
 		return errors.New("X.509 transport capability is invalid")
 	}
-	if err := validateX509NativeTransport(transport.transport); err != nil {
+	if transport.closed.Load() {
+		return errors.New("X.509 transport capability is closed")
+	}
+	if err := validateX509NativeTransport(transport.template); err != nil {
 		return fmt.Errorf("X.509 transport attestation changed: %w", err)
 	}
-	if transport.transport.TLSClientConfig != transport.tlsConfig {
+	if transport.template.TLSClientConfig != transport.templateTLS ||
+		transport.transport.TLSClientConfig != transport.tlsConfig {
 		return errors.New("X.509 transport TLS configuration changed after attestation")
+	}
+	for _, config := range []*tls.Config{transport.templateTLS, transport.tlsConfig} {
+		if len(config.Certificates) != 1 {
+			return errors.New("X.509 transport certificate changed after attestation")
+		}
+		digest := x509CertificateDigest(config.Certificates[0].Certificate)
+		if subtle.ConstantTimeCompare(digest[:], transport.certificateDigest[:]) != 1 {
+			return errors.New("X.509 transport certificate changed after attestation")
+		}
+	}
+	return nil
+}
+
+// Close releases this capability's isolated idle connections. It is
+// idempotent, never closes the caller's template, and prevents future requests.
+func (transport *X509Transport) Close() error {
+	if transport == nil || transport.transport == nil {
+		return errors.New("X.509 transport capability is invalid")
+	}
+	if transport.closed.CompareAndSwap(false, true) {
+		transport.transport.CloseIdleConnections()
 	}
 	return nil
 }
 
 // Do sends a request to an approved global OpenAI mTLS endpoint without
-// following redirects. Request context, transport ownership, and pooling are
-// preserved. OAuth exchange and client authentication are configured separately.
+// following redirects. The request is snapshotted before validation so caller
+// hooks cannot alter its URL or credentials after the final safety checks.
+// Request context and caller-owned TLS credentials are preserved; the
+// capability owns its isolated pool. OAuth authentication is configured
+// separately.
 func (transport *X509Transport) Do(request *http.Request) (*http.Response, error) {
 	if request == nil {
 		return nil, errors.New("X.509 transport requires a non-nil HTTP request")
@@ -117,6 +199,7 @@ func (transport *X509Transport) Do(request *http.Request) (*http.Response, error
 	if err := request.Context().Err(); err != nil {
 		return nil, err
 	}
+	request = request.Clone(request.Context())
 	if err := transport.validateAttestation(); err != nil {
 		return nil, err
 	}
@@ -166,8 +249,12 @@ func validateX509Request(request *http.Request) error {
 			return errors.New("X.509 requests cannot contain alternate credentials, cookies, or authority headers")
 		case "authorization":
 			authorizationCount += len(values)
-			if host == x509AuthenticationHost || authorizationCount != 1 {
+			if host == x509AuthenticationHost || authorizationCount != 1 || !validX509BearerHeader(values[0]) {
 				return errors.New("X.509 requests contain invalid Authorization credentials")
+			}
+		case "openai-organization", "openai-project":
+			if host == x509AuthenticationHost {
+				return errors.New("X.509 token exchange cannot contain organization or project headers")
 			}
 		}
 		if strings.HasPrefix(normalized, ":") {
@@ -187,4 +274,26 @@ func validateX509Request(request *http.Request) error {
 		return errors.New("X.509 API requests must remain inside the /v1/ path")
 	}
 	return nil
+}
+
+func validX509BearerHeader(value string) bool {
+	token, ok := strings.CutPrefix(value, "Bearer ")
+	if !ok || token == "" {
+		return false
+	}
+	padding := false
+	for _, value := range []byte(token) {
+		switch {
+		case value == '=':
+			padding = true
+		case value >= 'A' && value <= 'Z', value >= 'a' && value <= 'z', value >= '0' && value <= '9',
+			value == '-', value == '.', value == '_', value == '~', value == '+', value == '/':
+			if padding {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return token[0] != '='
 }

--- a/auth/x509transport.go
+++ b/auth/x509transport.go
@@ -115,6 +115,11 @@ func NewX509Transport(template *http.Transport) (*X509Transport, error) {
 	if template.Protocols != nil {
 		protocols := *template.Protocols
 		transport.Protocols = &protocols
+	} else if template.TLSNextProto != nil {
+		protocols := new(http.Protocols)
+		protocols.SetHTTP1(true)
+		protocols.SetHTTP2(template.TLSNextProto["h2"] != nil)
+		transport.Protocols = protocols
 	}
 	if template.HTTP2 != nil {
 		configuration := *template.HTTP2

--- a/auth/x509transport.go
+++ b/auth/x509transport.go
@@ -8,6 +8,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptrace"
 	"path"
@@ -25,11 +26,15 @@ const (
 var errX509Redirect = errors.New("X.509 workload identity does not follow redirects")
 
 type x509TransportError struct {
-	cause error
+	cause     error
+	timeout   bool
+	temporary bool
 }
 
-func (err *x509TransportError) Error() string { return "X.509 transport request failed" }
-func (err *x509TransportError) Unwrap() error { return err.cause }
+func (err *x509TransportError) Error() string   { return "X.509 transport request failed" }
+func (err *x509TransportError) Unwrap() error   { return err.cause }
+func (err *x509TransportError) Timeout() bool   { return err.timeout }
+func (err *x509TransportError) Temporary() bool { return err.temporary }
 
 // x509TraceFreeContext preserves cancellation, deadlines, and ordinary context
 // values while preventing a mutable parent from revealing HTTP trace hooks
@@ -74,6 +79,9 @@ func NewX509Transport(template *http.Transport) (*X509Transport, error) {
 	if err := validateX509NativeTransport(template); err != nil {
 		return nil, err
 	}
+	if err := validateX509ApplicationProtocols(template.TLSClientConfig.NextProtos); err != nil {
+		return nil, err
+	}
 	if err := validateX509TLSProtocolHandlers(template.TLSNextProto); err != nil {
 		return nil, err
 	}
@@ -81,11 +89,13 @@ func NewX509Transport(template *http.Transport) (*X509Transport, error) {
 	config.Certificates = slices.Clone(config.Certificates)
 	for index := range config.Certificates {
 		certificate := &config.Certificates[index]
+		certificate.Leaf = nil
 		certificate.Certificate = slices.Clone(certificate.Certificate)
 		for chainIndex := range certificate.Certificate {
 			certificate.Certificate[chainIndex] = slices.Clone(certificate.Certificate[chainIndex])
 		}
 		certificate.OCSPStaple = slices.Clone(certificate.OCSPStaple)
+		certificate.SupportedSignatureAlgorithms = slices.Clone(certificate.SupportedSignatureAlgorithms)
 		certificate.SignedCertificateTimestamps = slices.Clone(certificate.SignedCertificateTimestamps)
 		for timestampIndex := range certificate.SignedCertificateTimestamps {
 			certificate.SignedCertificateTimestamps[timestampIndex] = slices.Clone(
@@ -97,6 +107,9 @@ func NewX509Transport(template *http.Transport) (*X509Transport, error) {
 		config.RootCAs = config.RootCAs.Clone()
 	}
 	config.NextProtos = slices.Clone(config.NextProtos)
+	config.CipherSuites = slices.Clone(config.CipherSuites)
+	config.CurvePreferences = slices.Clone(config.CurvePreferences)
+	config.EncryptedClientHelloConfigList = slices.Clone(config.EncryptedClientHelloConfigList)
 	transport := &http.Transport{
 		DialContext:            template.DialContext,
 		TLSClientConfig:        config,
@@ -165,13 +178,8 @@ func validateX509NativeTransport(transport *http.Transport) error {
 	if transport.TLSClientConfig == nil {
 		return errors.New("X.509 transport requires an explicit TLS configuration")
 	}
-	config := transport.TLSClientConfig
-	if len(config.Certificates) != 1 || len(config.Certificates[0].Certificate) == 0 ||
-		len(config.Certificates[0].Certificate[0]) == 0 || x509PrivateKeyIsNil(config.Certificates[0].PrivateKey) {
-		return errors.New("X.509 transport requires exactly one static certificate and private key")
-	}
-	if config.GetClientCertificate != nil {
-		return errors.New("X.509 transport does not support dynamic client-certificate callbacks")
+	if err := validateX509TLSConfig(transport.TLSClientConfig); err != nil {
+		return err
 	}
 	if transport.DialTLSContext != nil {
 		return errors.New("X.509 transport does not support custom TLS dialers")
@@ -180,20 +188,53 @@ func validateX509NativeTransport(transport *http.Transport) error {
 	if transport.DialTLS != nil {
 		return errors.New("X.509 transport does not support deprecated TLS dialers")
 	}
-	if config.ClientSessionCache != nil {
-		return errors.New("X.509 transport does not support shared TLS session caches")
-	}
 	if transport.Proxy != nil {
 		return errors.New("X.509 transport currently supports direct connections only")
 	}
 	if transport.HTTP2 != nil && transport.HTTP2.CountError != nil {
 		return errors.New("X.509 transport does not support HTTP/2 error callbacks")
 	}
+	return nil
+}
+
+func validateX509TLSConfig(config *tls.Config) error {
+	if len(config.Certificates) != 1 || len(config.Certificates[0].Certificate) == 0 ||
+		len(config.Certificates[0].Certificate[0]) == 0 || x509PrivateKeyIsNil(config.Certificates[0].PrivateKey) {
+		return errors.New("X.509 transport requires exactly one static certificate and private key")
+	}
+	if config.GetClientCertificate != nil {
+		return errors.New("X.509 transport does not support dynamic client-certificate callbacks")
+	}
+	if config.KeyLogWriter != nil {
+		return errors.New("X.509 transport does not support TLS session key logging")
+	}
+	if config.Rand != nil {
+		return errors.New("X.509 transport does not support custom TLS randomness")
+	}
+	if config.Time != nil {
+		return errors.New("X.509 transport does not support a custom TLS verification clock")
+	}
+	if (config.MinVersion != 0 && config.MinVersion < tls.VersionTLS12) ||
+		(config.MaxVersion != 0 && config.MaxVersion < tls.VersionTLS12) {
+		return errors.New("X.509 transport requires TLS version 1.2 or newer")
+	}
+	if config.ClientSessionCache != nil {
+		return errors.New("X.509 transport does not support shared TLS session caches")
+	}
 	if config.InsecureSkipVerify {
 		return errors.New("X.509 transport requires TLS certificate and hostname verification")
 	}
 	if config.ServerName != "" {
 		return errors.New("X.509 transport does not support overriding the TLS server name")
+	}
+	return nil
+}
+
+func validateX509ApplicationProtocols(protocols []string) error {
+	for _, protocol := range protocols {
+		if protocol != "h2" && protocol != "http/1.1" {
+			return errors.New("X.509 transport does not support non-HTTP TLS application protocols")
+		}
 	}
 	return nil
 }
@@ -238,8 +279,8 @@ func (transport *X509Transport) validateAttestation() error {
 		return errors.New("X.509 transport TLS configuration changed after attestation")
 	}
 	for _, config := range []*tls.Config{transport.templateTLS, transport.tlsConfig} {
-		if len(config.Certificates) != 1 {
-			return errors.New("X.509 transport certificate changed after attestation")
+		if err := validateX509TLSConfig(config); err != nil {
+			return fmt.Errorf("X.509 transport TLS configuration changed after attestation: %w", err)
 		}
 		digest := x509CertificateDigest(config.Certificates[0].Certificate)
 		if subtle.ConstantTimeCompare(digest[:], transport.certificateDigest[:]) != 1 {
@@ -297,6 +338,13 @@ func (transport *X509Transport) Do(request *http.Request) (*http.Response, error
 	response, err := transport.client.Do(request)
 	if err != nil {
 		redacted := &x509TransportError{}
+		var networkError net.Error
+		if errors.As(err, &networkError) {
+			redacted.timeout = networkError.Timeout()
+			if temporary, ok := err.(interface{ Temporary() bool }); ok {
+				redacted.temporary = temporary.Temporary()
+			}
+		}
 		switch {
 		case errors.Is(err, errX509Redirect):
 			redacted.cause = errX509Redirect
@@ -320,8 +368,21 @@ func (transport *X509Transport) Do(request *http.Request) (*http.Response, error
 }
 
 func validateX509Request(request *http.Request) error {
+	switch request.Method {
+	case http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch,
+		http.MethodDelete, http.MethodHead, http.MethodOptions:
+	default:
+		return errors.New("X.509 requests require a supported non-tunneling HTTP method")
+	}
 	if len(request.Trailer) != 0 {
 		return errors.New("X.509 requests do not support HTTP trailers")
+	}
+	hasBody := request.Body != nil && request.Body != http.NoBody
+	if request.ContentLength < -1 || (!hasBody && request.ContentLength != 0) {
+		return errors.New("X.509 requests require consistent HTTP body framing")
+	}
+	if len(request.TransferEncoding) != 0 {
+		return errors.New("X.509 requests do not support custom HTTP transfer encodings")
 	}
 	if request.URL == nil || request.URL.Scheme != "https" || request.URL.User != nil ||
 		request.URL.Opaque != "" || request.URL.Fragment != "" || request.URL.RawFragment != "" {
@@ -347,6 +408,9 @@ func validateX509Request(request *http.Request) error {
 		switch normalized {
 		case "api-key", "x-api-key", "proxy-authorization", "cookie", "set-cookie", "host", "x-amz-security-token":
 			return errors.New("X.509 requests cannot contain alternate credentials, cookies, or authority headers")
+		case "transfer-encoding", "content-length", "connection", "upgrade", "trailer", "te",
+			"proxy-connection", "keep-alive", "http2-settings":
+			return errors.New("X.509 requests do not support custom HTTP framing or protocol upgrades")
 		case "authorization":
 			authorizationCount += len(values)
 			if host == x509AuthenticationHost || len(values) != 1 ||

--- a/auth/x509transport_adversarial_test.go
+++ b/auth/x509transport_adversarial_test.go
@@ -1,0 +1,160 @@
+package auth_test
+
+import (
+	"context"
+	"crypto/tls"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httptrace"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestX509TransportRejectsConnectionExposingTraceBeforeDial(t *testing.T) {
+	fixture := newX509TransportFixture(t)
+	var received, dialed, traced atomic.Int32
+	server := fixture.server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		received.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	template := fixture.transport(t, server)
+	dial := template.DialContext
+	template.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		dialed.Add(1)
+		return dial(ctx, network, address)
+	}
+	capability := newX509Capability(t, template)
+	request := x509TransportRequest(t, http.MethodGet, "https://"+x509TransportAPI+"/v1/models")
+	request.Header.Set("Authorization", "Bearer protected-synthetic-token")
+	trace := &httptrace.ClientTrace{
+		GotConn: func(connection httptrace.GotConnInfo) {
+			traced.Add(1)
+			_, _ = io.WriteString(connection.Conn,
+				"GET /v1/models HTTP/1.1\r\nHost: attacker.example.test\r\n"+
+					"Authorization: Bearer attacker-injected-token\r\n\r\n")
+		},
+	}
+	request = request.WithContext(httptrace.WithClientTrace(request.Context(), trace))
+	if err := x509Rejected(t, capability, request); !strings.Contains(err.Error(), "trace") {
+		t.Fatalf("connection-exposing trace error = %v", err)
+	}
+	if got := dialed.Load(); got != 0 {
+		t.Errorf("connection-exposing trace caused %d network dials", got)
+	}
+	if got := traced.Load(); got != 0 {
+		t.Errorf("connection-exposing trace accessed %d live TLS connections", got)
+	}
+	if got := received.Load(); got != 0 {
+		t.Errorf("connection-exposing trace delivered %d HTTP requests", got)
+	}
+}
+
+func TestX509TransportIsolatesCertificateBytesFromDialMutation(t *testing.T) {
+	fixture := newX509TransportFixture(t)
+	peer := make(chan string, 1)
+	server := fixture.server(t, http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		peer <- request.TLS.PeerCertificates[0].Subject.CommonName
+		w.WriteHeader(http.StatusOK)
+	}))
+	template := fixture.transport(t, server)
+	dial := template.DialContext
+	var mutated atomic.Bool
+	template.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		template.TLSClientConfig.Certificates[0].Certificate[0][0] ^= 0xff
+		mutated.Store(true)
+		return dial(ctx, network, address)
+	}
+	capability := newX509Capability(t, template)
+	request := x509TransportRequest(t, http.MethodGet, "https://"+x509TransportAPI+"/v1/models")
+	request.Header.Set("Authorization", "Bearer protected-synthetic-token")
+	response, err := capability.Do(request)
+	if err != nil {
+		t.Fatalf("mutating caller-owned certificate bytes during TCP dial changed native mTLS identity: %v", err)
+	}
+	if closeErr := response.Body.Close(); closeErr != nil {
+		t.Fatalf("close isolated-certificate response: %v", closeErr)
+	}
+	if !mutated.Load() {
+		t.Fatal("negative-control TCP dialer did not mutate the caller-owned certificate bytes")
+	}
+	select {
+	case name := <-peer:
+		if name != "static-workload" {
+			t.Errorf("protected mTLS peer certificate = %q, want original attested identity", name)
+		}
+	default:
+		t.Fatal("real mutually authenticated server did not receive the original attested identity")
+	}
+	if err := x509Rejected(t, capability, request); !strings.Contains(err.Error(), "certificate changed") {
+		t.Errorf("subsequent dispatch after caller certificate mutation = %v", err)
+	}
+}
+
+func TestX509TransportIsolatesAttestedTrustRoots(t *testing.T) {
+	fixture := newX509TransportFixture(t)
+	attacker := newX509TransportFixture(t)
+	var received atomic.Int32
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		received.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	server.TLS = &tls.Config{
+		MinVersion:   tls.VersionTLS12,
+		ClientAuth:   tls.RequestClientCert,
+		Certificates: []tls.Certificate{attacker.certificate(t, "unattested issuer", []string{x509TransportAPI}, false)},
+	}
+	server.Config.ErrorLog = log.New(io.Discard, "", 0)
+	server.StartTLS()
+	t.Cleanup(server.Close)
+	template := fixture.transport(t, nil)
+	dialer := &net.Dialer{Timeout: 5 * time.Second}
+	template.DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return dialer.DialContext(ctx, network, server.Listener.Addr().String())
+	}
+	capability := newX509Capability(t, template)
+	template.TLSClientConfig.RootCAs.AddCert(attacker.root)
+	request := x509TransportRequest(t, http.MethodGet, "https://"+x509TransportAPI+"/v1/models")
+	request.Header.Set("Authorization", "Bearer protected-synthetic-token")
+	_ = x509Rejected(t, capability, request)
+	if got := received.Load(); got != 0 {
+		t.Errorf("post-attestation trust-root mutation delivered %d protected HTTP requests", got)
+	}
+}
+
+func TestX509TransportRejectsCredentialTrailersBeforeDial(t *testing.T) {
+	fixture := newX509TransportFixture(t)
+	var dialed, received atomic.Int32
+	server := fixture.server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		received.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	template := fixture.transport(t, server)
+	dial := template.DialContext
+	template.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		dialed.Add(1)
+		return dial(ctx, network, address)
+	}
+	capability := newX509Capability(t, template)
+	for _, header := range []string{"Authorization", "Api-Key", "Proxy-Authorization", "Cookie"} {
+		t.Run(header, func(t *testing.T) {
+			request := x509TransportRequest(t, http.MethodPost, "https://"+x509TransportIssuer+"/oauth/token")
+			request.Body = io.NopCloser(strings.NewReader("synthetic OAuth body"))
+			request.ContentLength = -1
+			request.Trailer = http.Header{header: []string{"synthetic-trailer-credential"}}
+			if err := x509Rejected(t, capability, request); !strings.Contains(err.Error(), "trailers") {
+				t.Errorf("issuer credential trailer error = %v", err)
+			}
+		})
+	}
+	if got := dialed.Load(); got != 0 {
+		t.Errorf("issuer credential trailers caused %d network dials", got)
+	}
+	if got := received.Load(); got != 0 {
+		t.Errorf("issuer credential trailers delivered %d HTTP requests", got)
+	}
+}

--- a/auth/x509transport_adversarial_test.go
+++ b/auth/x509transport_adversarial_test.go
@@ -587,6 +587,61 @@ func TestX509TransportAcceptsNativeInitializedHTTP2Templates(t *testing.T) {
 	}
 }
 
+func TestX509TransportDoesNotRaceConcurrentNativeHTTP2Initialization(t *testing.T) {
+	fixture := newX509TransportFixture(t)
+	var received atomic.Int32
+	server := newX509HTTP2TransportServer(t, fixture, http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		if request.ProtoMajor == 2 {
+			received.Add(1)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	template := fixture.transport(t, server)
+	template.ForceAttemptHTTP2 = true
+	capability := newX509Capability(t, template)
+	request := x509TransportRequest(t, http.MethodGet, "https://"+x509TransportAPI+"/v1/models")
+
+	const isolatedRequests = 32
+	ready := make(chan struct{}, isolatedRequests+1)
+	start := make(chan struct{})
+	results := make(chan error, isolatedRequests+1)
+	go func() {
+		ready <- struct{}{}
+		<-start
+		response, err := (&http.Client{Transport: template}).Do(request.Clone(request.Context()))
+		if err == nil {
+			err = response.Body.Close()
+		}
+		results <- err
+	}()
+	for range isolatedRequests {
+		go func() {
+			ready <- struct{}{}
+			<-start
+			response, err := capability.Do(request.Clone(request.Context()))
+			if err == nil {
+				err = response.Body.Close()
+			}
+			results <- err
+		}()
+	}
+	for range isolatedRequests + 1 {
+		<-ready
+	}
+	close(start)
+	for range isolatedRequests + 1 {
+		if err := <-results; err != nil {
+			t.Errorf("concurrent native or isolated HTTP/2 request: %v", err)
+		}
+	}
+	if template.TLSNextProto["h2"] == nil {
+		t.Fatal("caller-owned transport did not initialize its native HTTP/2 protocol map")
+	}
+	if got := received.Load(); got != isolatedRequests+1 {
+		t.Errorf("native and isolated mutually authenticated HTTP/2 requests = %d, want %d", got, isolatedRequests+1)
+	}
+}
+
 func TestX509TransportDoesNotInheritNativeShapedHTTP2Handlers(t *testing.T) {
 	fixture := newX509TransportFixture(t)
 	server := newX509HTTP2TransportServer(t, fixture, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -616,6 +671,38 @@ func TestX509TransportDoesNotInheritNativeShapedHTTP2Handlers(t *testing.T) {
 	}
 	if got := intercepted.Load(); got != 0 {
 		t.Errorf("caller-owned native-shaped HTTP/2 handlers intercepted %d requests", got)
+	}
+}
+
+func TestX509TransportDoesNotInheritLaterCallerTLSProtocolHandlers(t *testing.T) {
+	fixture := newX509TransportFixture(t)
+	var received, intercepted atomic.Int32
+	server := newX509HTTP2TransportServer(t, fixture, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		received.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	template := fixture.transport(t, server)
+	template.ForceAttemptHTTP2 = true
+	capability := newX509Capability(t, template)
+	template.TLSNextProto = map[string]func(string, *tls.Conn) http.RoundTripper{
+		"attacker": func(string, *tls.Conn) http.RoundTripper {
+			intercepted.Add(1)
+			return nil
+		},
+	}
+	request := x509TransportRequest(t, http.MethodGet, "https://"+x509TransportAPI+"/v1/models")
+	response, err := capability.Do(request)
+	if err != nil {
+		t.Fatalf("dispatch after an isolated caller TLS protocol handler was installed: %v", err)
+	}
+	if err := response.Body.Close(); err != nil {
+		t.Fatalf("close isolated caller protocol response: %v", err)
+	}
+	if got := intercepted.Load(); got != 0 {
+		t.Errorf("caller-owned post-attestation TLS protocol handler intercepted %d requests", got)
+	}
+	if got := received.Load(); got != 1 {
+		t.Errorf("isolated post-attestation TLS protocol request reached the API %d times", got)
 	}
 }
 

--- a/auth/x509transport_adversarial_test.go
+++ b/auth/x509transport_adversarial_test.go
@@ -54,6 +54,53 @@ func TestX509TransportRejectsConnectionExposingTraceBeforeDial(t *testing.T) {
 	}
 }
 
+func TestX509TransportRejectsLateInstalledConnectionTraceBeforeDial(t *testing.T) {
+	fixture := newX509TransportFixture(t)
+	var received, dialed, installed, exposed atomic.Int32
+	server := fixture.server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		received.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	template := fixture.transport(t, server)
+	dial := template.DialContext
+	template.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		dialed.Add(1)
+		return dial(ctx, network, address)
+	}
+	capability := newX509Capability(t, template)
+	request := x509TransportRequest(t, http.MethodGet, "https://"+x509TransportAPI+"/v1/models")
+	request.Header.Set("Authorization", "Bearer protected-synthetic-token")
+	trace := new(httptrace.ClientTrace)
+	trace.GetConn = func(string) {
+		installed.Add(1)
+		trace.GotConn = func(connection httptrace.GotConnInfo) {
+			exposed.Add(1)
+			_, _ = io.WriteString(connection.Conn,
+				"GET /v1/models HTTP/1.1\r\nHost: attacker.example.test\r\n"+
+					"Authorization: Bearer attacker-injected-token\r\n\r\n")
+		}
+	}
+	request = request.WithContext(httptrace.WithClientTrace(request.Context(), trace))
+	if trace.GotConn != nil {
+		t.Fatal("negative-control connection hook must initially be absent")
+	}
+	if err := x509Rejected(t, capability, request); !strings.Contains(err.Error(), "trace") {
+		t.Fatalf("late-installing trace error = %v", err)
+	}
+	if got := installed.Load(); got != 0 {
+		t.Errorf("late-installing trace executed %d initial callbacks", got)
+	}
+	if got := exposed.Load(); got != 0 {
+		t.Errorf("late-installing trace accessed %d live TLS connections", got)
+	}
+	if got := dialed.Load(); got != 0 {
+		t.Errorf("late-installing trace caused %d network dials", got)
+	}
+	if got := received.Load(); got != 0 {
+		t.Errorf("late-installing trace delivered %d HTTP requests", got)
+	}
+}
+
 func TestX509TransportIsolatesCertificateBytesFromDialMutation(t *testing.T) {
 	fixture := newX509TransportFixture(t)
 	peer := make(chan string, 1)

--- a/auth/x509transport_adversarial_test.go
+++ b/auth/x509transport_adversarial_test.go
@@ -492,6 +492,51 @@ func TestX509TransportPreservesExplicitHTTP2ProtocolPolicy(t *testing.T) {
 	}
 }
 
+func TestX509TransportPreservesImplicitTLSNextProtoHTTP2Policy(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		forceHTTP2 bool
+		handler    bool
+		want       int32
+	}{
+		{name: "empty protocol map disables forced HTTP/2", forceHTTP2: true, want: 1},
+		{name: "HTTP/2 handler enables HTTP/2 without force", handler: true, want: 2},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newX509TransportFixture(t)
+			var observed, intercepted atomic.Int32
+			server := newX509HTTP2TransportServer(t, fixture, http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+				observed.Store(int32(request.ProtoMajor))
+				w.WriteHeader(http.StatusOK)
+			}))
+			template := fixture.transport(t, server)
+			template.ForceAttemptHTTP2 = test.forceHTTP2
+			template.TLSNextProto = make(map[string]func(string, *tls.Conn) http.RoundTripper)
+			if test.handler {
+				template.TLSNextProto["h2"] = func(string, *tls.Conn) http.RoundTripper {
+					intercepted.Add(1)
+					return nil
+				}
+			}
+			capability := newX509Capability(t, template)
+			request := x509TransportRequest(t, http.MethodGet, "https://"+x509TransportAPI+"/v1/models")
+			response, err := capability.Do(request)
+			if err != nil {
+				t.Fatalf("dispatch with implicit TLS protocol policy: %v", err)
+			}
+			if closeErr := response.Body.Close(); closeErr != nil {
+				t.Fatalf("close implicit TLS protocol response: %v", closeErr)
+			}
+			if got := observed.Load(); got != test.want {
+				t.Errorf("implicit TLS protocol policy negotiated HTTP/%d, want HTTP/%d", got, test.want)
+			}
+			if got := intercepted.Load(); got != 0 {
+				t.Errorf("caller-owned TLS protocol handlers intercepted %d requests", got)
+			}
+		})
+	}
+}
+
 func TestX509TransportAcceptsNativeInitializedHTTP2Templates(t *testing.T) {
 	for _, initializeBefore := range []bool{false, true} {
 		name := "initialized after attestation"

--- a/auth/x509transport_adversarial_test.go
+++ b/auth/x509transport_adversarial_test.go
@@ -338,10 +338,9 @@ func TestX509TransportRejectsProtocolUpgradeWithoutExposingSocket(t *testing.T) 
 	}))
 	capability := newX509Capability(t, fixture.transport(t, server))
 	request := x509TransportRequest(t, http.MethodGet, "https://"+x509TransportAPI+"/v1/models")
-	request.Header.Set("Connection", "Upgrade")
-	request.Header.Set("Upgrade", "synthetic")
 	request.Header.Set("Authorization", "Bearer protected-synthetic-token")
-	if err := x509Rejected(t, capability, request); !strings.Contains(err.Error(), "protocol upgrades") {
+	if err := x509Rejected(t, capability, request); !strings.Contains(err.Error(), "protocol upgrades") &&
+		!strings.Contains(err.Error(), "transport request failed") {
 		t.Fatalf("authenticated protocol-upgrade error = %v", err)
 	}
 	select {

--- a/auth/x509transport_adversarial_test.go
+++ b/auth/x509transport_adversarial_test.go
@@ -3,6 +3,8 @@ package auth_test
 import (
 	"context"
 	"crypto/tls"
+	"errors"
+	"fmt"
 	"io"
 	"log"
 	"net"
@@ -13,6 +15,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/openai/openai-go/v3/auth"
 )
 
 func TestX509TransportRejectsConnectionExposingTraceBeforeDial(t *testing.T) {
@@ -204,4 +208,398 @@ func TestX509TransportRejectsCredentialTrailersBeforeDial(t *testing.T) {
 	if got := received.Load(); got != 0 {
 		t.Errorf("issuer credential trailers delivered %d HTTP requests", got)
 	}
+}
+
+func TestX509TransportRejectsEmptyAuthorizationAliasesWithoutPanicking(t *testing.T) {
+	fixture := newX509TransportFixture(t)
+	capability := newX509Capability(t, fixture.transport(t, nil))
+	for _, values := range [][]string{nil, {}} {
+		request := x509TransportRequest(t, http.MethodGet, "https://"+x509TransportAPI+"/v1/models")
+		request.Header["Authorization"] = []string{"Bearer synthetic-valid-token"}
+		request.Header["authorization"] = values
+		if err := x509Rejected(t, capability, request); !strings.Contains(err.Error(), "Authorization") {
+			t.Errorf("empty differently cased Authorization alias error = %v", err)
+		}
+	}
+}
+
+func TestX509TransportFiltersLateAppearingTraceAndPreservesContext(t *testing.T) {
+	fixture := newX509TransportFixture(t)
+	var received, exposed, contextPreserved atomic.Int32
+	server := fixture.server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		received.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	template := fixture.transport(t, server)
+	type contextKey struct{}
+	parent, cancel := context.WithTimeout(context.WithValue(t.Context(), contextKey{}, "synthetic-context-value"), 5*time.Second)
+	defer cancel()
+	dial := template.DialContext
+	template.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		if ctx.Value(contextKey{}) == "synthetic-context-value" {
+			contextPreserved.Add(1)
+		}
+		return dial(ctx, network, address)
+	}
+	capability := newX509Capability(t, template)
+	trace := &httptrace.ClientTrace{
+		GotConn: func(connection httptrace.GotConnInfo) {
+			exposed.Add(1)
+			_, _ = io.WriteString(connection.Conn,
+				"GET /v1/models HTTP/1.1\r\nHost: attacker.example.test\r\n"+
+					"Authorization: Bearer attacker-injected-token\r\n\r\n")
+		},
+	}
+	mutable := &x509EmergingTraceContext{
+		Context: parent,
+		traced:  httptrace.WithClientTrace(context.Background(), trace),
+	}
+	request := x509TransportRequest(t, http.MethodGet, "https://"+x509TransportAPI+"/v1/models")
+	request.Header.Set("Authorization", "Bearer protected-synthetic-token")
+	response, err := capability.Do(request.WithContext(mutable))
+	if err != nil {
+		t.Fatalf("request with a late-appearing filtered HTTP trace: %v", err)
+	}
+	if err := response.Body.Close(); err != nil {
+		t.Fatalf("close filtered-trace response: %v", err)
+	}
+	if got := mutable.lookups.Load(); got < 2 {
+		t.Errorf("mutable trace was queried %d times; expected the native dispatch to query again", got)
+	}
+	if got := exposed.Load(); got != 0 {
+		t.Errorf("late-appearing HTTP trace accessed %d authenticated sockets", got)
+	}
+	if got := contextPreserved.Load(); got != 1 {
+		t.Errorf("native TCP dial observed the preserved context value %d times", got)
+	}
+	if got := received.Load(); got != 1 {
+		t.Errorf("filtered-trace request delivered %d HTTP requests", got)
+	}
+}
+
+type x509EmergingTraceContext struct {
+	context.Context
+	traced  context.Context
+	lookups atomic.Int32
+}
+
+func (ctx *x509EmergingTraceContext) Value(key any) any {
+	value := ctx.traced.Value(key)
+	if _, ok := value.(*httptrace.ClientTrace); ok {
+		if ctx.lookups.Add(1) == 1 {
+			return nil
+		}
+		return value
+	}
+	return ctx.Context.Value(key)
+}
+
+func TestX509TransportRejectsProtocolUpgradeWithoutExposingSocket(t *testing.T) {
+	fixture := newX509TransportFixture(t)
+	closed := make(chan error, 1)
+	server := fixture.server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hijacker, ok := w.(http.Hijacker)
+		if !ok {
+			closed <- errors.New("synthetic server does not support hijacking")
+			return
+		}
+		connection, buffered, err := hijacker.Hijack()
+		if err != nil {
+			closed <- fmt.Errorf("hijack synthetic upgrade: %w", err)
+			return
+		}
+		defer func() { _ = connection.Close() }()
+		if _, writeErr := fmt.Fprint(buffered,
+			"HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: synthetic\r\n\r\n",
+		); writeErr != nil {
+			closed <- fmt.Errorf("write synthetic upgrade: %w", writeErr)
+			return
+		}
+		if flushErr := buffered.Flush(); flushErr != nil {
+			closed <- fmt.Errorf("flush synthetic upgrade: %w", flushErr)
+			return
+		}
+		if deadlineErr := connection.SetReadDeadline(time.Now().Add(5 * time.Second)); deadlineErr != nil {
+			closed <- fmt.Errorf("bound synthetic upgrade socket wait: %w", deadlineErr)
+			return
+		}
+		var leaked [1]byte
+		_, err = connection.Read(leaked[:])
+		if err == nil {
+			closed <- errors.New("authenticated upgraded socket remained writable")
+			return
+		}
+		var timeout net.Error
+		if errors.As(err, &timeout) && timeout.Timeout() {
+			closed <- errors.New("authenticated upgraded socket was not closed")
+			return
+		}
+		closed <- nil
+	}))
+	capability := newX509Capability(t, fixture.transport(t, server))
+	request := x509TransportRequest(t, http.MethodGet, "https://"+x509TransportAPI+"/v1/models")
+	request.Header.Set("Connection", "Upgrade")
+	request.Header.Set("Upgrade", "synthetic")
+	request.Header.Set("Authorization", "Bearer protected-synthetic-token")
+	if err := x509Rejected(t, capability, request); !strings.Contains(err.Error(), "protocol upgrades") {
+		t.Fatalf("authenticated protocol-upgrade error = %v", err)
+	}
+	select {
+	case err := <-closed:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("authenticated upgraded socket was not released")
+	}
+}
+
+func TestX509TransportRejectsNonReplayableRedirectResponses(t *testing.T) {
+	for _, status := range []int{
+		http.StatusMultipleChoices, http.StatusMovedPermanently, http.StatusFound,
+		http.StatusSeeOther, http.StatusUseProxy, http.StatusTemporaryRedirect,
+		http.StatusPermanentRedirect,
+	} {
+		t.Run(fmt.Sprint(status), func(t *testing.T) {
+			fixture := newX509TransportFixture(t)
+			var received atomic.Int32
+			server := fixture.server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				received.Add(1)
+				w.Header().Set("Location", "https://attacker.example.test/private-synthetic-redirect-token")
+				w.WriteHeader(status)
+				_, _ = io.WriteString(w, "synthetic redirect response")
+			}))
+			capability := newX509Capability(t, fixture.transport(t, server))
+			request := x509TransportRequest(t, http.MethodPost, "https://"+x509TransportIssuer+"/oauth/token")
+			request.Body = io.NopCloser(strings.NewReader("synthetic non-replayable body"))
+			request.ContentLength = -1
+			if request.GetBody != nil {
+				t.Fatal("synthetic redirect request unexpectedly became replayable")
+			}
+			err := x509Rejected(t, capability, request)
+			cause := errors.Unwrap(err)
+			if cause == nil || !strings.Contains(cause.Error(), "does not follow redirects") {
+				t.Fatalf("non-replayable %d redirect error = %v, cause = %v", status, err, cause)
+			}
+			if strings.Contains(err.Error(), "private-synthetic-redirect-token") {
+				t.Error("redirect error disclosed its sensitive destination")
+			}
+			if got := received.Load(); got != 1 {
+				t.Errorf("non-replayable %d redirect delivered %d HTTP requests", status, got)
+			}
+		})
+	}
+}
+
+func TestX509TransportClosesBodiesOnEveryPreDispatchFailure(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		change func(*testing.T, *auth.X509Transport, *http.Request) *http.Request
+	}{
+		{
+			name: "canceled context",
+			change: func(t *testing.T, _ *auth.X509Transport, request *http.Request) *http.Request {
+				t.Helper()
+				ctx, cancel := context.WithCancel(request.Context())
+				cancel()
+				return request.WithContext(ctx)
+			},
+		},
+		{
+			name: "HTTP trace",
+			change: func(_ *testing.T, _ *auth.X509Transport, request *http.Request) *http.Request {
+				return request.WithContext(httptrace.WithClientTrace(request.Context(), new(httptrace.ClientTrace)))
+			},
+		},
+		{
+			name: "closed capability",
+			change: func(t *testing.T, capability *auth.X509Transport, request *http.Request) *http.Request {
+				t.Helper()
+				if err := capability.Close(); err != nil {
+					t.Fatalf("close capability before synthetic request: %v", err)
+				}
+				return request
+			},
+		},
+		{
+			name: "unsafe authority",
+			change: func(_ *testing.T, _ *auth.X509Transport, request *http.Request) *http.Request {
+				request.URL.Host = "attacker.example.test"
+				return request
+			},
+		},
+		{
+			name: "credential trailer",
+			change: func(_ *testing.T, _ *auth.X509Transport, request *http.Request) *http.Request {
+				request.Trailer = http.Header{"Authorization": []string{"Bearer unsafe"}}
+				return request
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newX509TransportFixture(t)
+			capability := newX509Capability(t, fixture.transport(t, nil))
+			request := x509TransportRequest(t, http.MethodPost, "https://"+x509TransportIssuer+"/oauth/token")
+			body := &x509TrackedRequestBody{Reader: strings.NewReader("synthetic request body")}
+			request.Body = body
+			request = test.change(t, capability, request)
+			_ = x509Rejected(t, capability, request)
+			if got := body.closed.Load(); got != 1 {
+				t.Errorf("rejected request body closed %d times, want exactly once", got)
+			}
+		})
+	}
+}
+
+type x509TrackedRequestBody struct {
+	io.Reader
+	closed atomic.Int32
+}
+
+func (body *x509TrackedRequestBody) Close() error {
+	body.closed.Add(1)
+	return nil
+}
+
+func TestX509TransportPreservesExplicitHTTP2ProtocolPolicy(t *testing.T) {
+	fixture := newX509TransportFixture(t)
+	var observedProtocol atomic.Int32
+	server := newX509HTTP2TransportServer(t, fixture, http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		observedProtocol.Store(int32(request.ProtoMajor))
+		w.WriteHeader(http.StatusOK)
+	}))
+	template := fixture.transport(t, server)
+	template.Protocols = new(http.Protocols)
+	template.Protocols.SetHTTP2(true)
+	template.HTTP2 = &http.HTTP2Config{
+		MaxReadFrameSize: 32 << 10,
+		PingTimeout:      3 * time.Second,
+	}
+	capability := newX509Capability(t, template)
+	template.Protocols.SetHTTP1(true)
+	template.Protocols.SetHTTP2(false)
+	template.HTTP2.MaxReadFrameSize = 64 << 10
+	request := x509TransportRequest(t, http.MethodGet, "https://"+x509TransportAPI+"/v1/models")
+	response, err := capability.Do(request)
+	if err != nil {
+		t.Fatalf("dispatch with an isolated explicit HTTP/2-only protocol policy: %v", err)
+	}
+	if err := response.Body.Close(); err != nil {
+		t.Fatalf("close HTTP/2-only response: %v", err)
+	}
+	if got := observedProtocol.Load(); got != 2 {
+		t.Errorf("isolated explicit HTTP/2-only request negotiated HTTP/%d", got)
+	}
+}
+
+func TestX509TransportAcceptsNativeInitializedHTTP2Templates(t *testing.T) {
+	for _, initializeBefore := range []bool{false, true} {
+		name := "initialized after attestation"
+		if initializeBefore {
+			name = "initialized before attestation"
+		}
+		t.Run(name, func(t *testing.T) {
+			fixture := newX509TransportFixture(t)
+			var received atomic.Int32
+			server := newX509HTTP2TransportServer(t, fixture, http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+				if request.ProtoMajor == 2 {
+					received.Add(1)
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			template := fixture.transport(t, server)
+			template.ForceAttemptHTTP2 = true
+			var capability *auth.X509Transport
+			if !initializeBefore {
+				capability = newX509Capability(t, template)
+			}
+			request := x509TransportRequest(t, http.MethodGet, "https://"+x509TransportAPI+"/v1/models")
+			response, err := (&http.Client{Transport: template}).Do(request)
+			if err != nil {
+				t.Fatalf("initialize the caller-owned native HTTP/2 template: %v", err)
+			}
+			if closeErr := response.Body.Close(); closeErr != nil {
+				t.Fatalf("close caller-owned native HTTP/2 response: %v", closeErr)
+			}
+			if template.TLSNextProto["h2"] == nil {
+				t.Fatal("negative-control native transport did not install its bundled HTTP/2 handler")
+			}
+			if initializeBefore {
+				capability = newX509Capability(t, template)
+			}
+			request = x509TransportRequest(t, http.MethodGet, "https://"+x509TransportAPI+"/v1/models")
+			response, err = capability.Do(request)
+			if err != nil {
+				t.Fatalf("dispatch after native HTTP/2 template initialization: %v", err)
+			}
+			if err := response.Body.Close(); err != nil {
+				t.Fatalf("close isolated native HTTP/2 response: %v", err)
+			}
+			if got := received.Load(); got != 2 {
+				t.Errorf("native and isolated adapters delivered %d mutually authenticated HTTP/2 requests", got)
+			}
+		})
+	}
+}
+
+func TestX509TransportDoesNotInheritNativeShapedHTTP2Handlers(t *testing.T) {
+	fixture := newX509TransportFixture(t)
+	server := newX509HTTP2TransportServer(t, fixture, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	template := fixture.transport(t, server)
+	template.ForceAttemptHTTP2 = true
+	var intercepted atomic.Int32
+	template.TLSNextProto = map[string]func(string, *tls.Conn) http.RoundTripper{
+		"h2": func(string, *tls.Conn) http.RoundTripper {
+			intercepted.Add(1)
+			return nil
+		},
+		"unencrypted_http2": func(string, *tls.Conn) http.RoundTripper {
+			intercepted.Add(1)
+			return nil
+		},
+	}
+	capability := newX509Capability(t, template)
+	request := x509TransportRequest(t, http.MethodGet, "https://"+x509TransportAPI+"/v1/models")
+	response, err := capability.Do(request)
+	if err != nil {
+		t.Fatalf("dispatch without inheriting native-shaped caller protocol callbacks: %v", err)
+	}
+	if err := response.Body.Close(); err != nil {
+		t.Fatalf("close isolated native-shaped HTTP/2 response: %v", err)
+	}
+	if got := intercepted.Load(); got != 0 {
+		t.Errorf("caller-owned native-shaped HTTP/2 handlers intercepted %d requests", got)
+	}
+}
+
+func TestX509TransportRejectsHTTP2ErrorCallbacks(t *testing.T) {
+	fixture := newX509TransportFixture(t)
+	template := fixture.transport(t, nil)
+	var invoked atomic.Int32
+	template.HTTP2 = &http.HTTP2Config{CountError: func(string) { invoked.Add(1) }}
+	if capability, err := auth.NewX509Transport(template); capability != nil ||
+		err == nil || !strings.Contains(err.Error(), "HTTP/2 error callbacks") {
+		t.Fatalf("caller-controlled HTTP/2 error hook: capability = %v, error = %v", capability, err)
+	}
+	if got := invoked.Load(); got != 0 {
+		t.Errorf("rejected caller-controlled HTTP/2 error callback ran %d times", got)
+	}
+}
+
+func newX509HTTP2TransportServer(t *testing.T, fixture *x509TransportFixture, handler http.Handler) *httptest.Server {
+	t.Helper()
+	server := httptest.NewUnstartedServer(handler)
+	server.EnableHTTP2 = true
+	server.TLS = &tls.Config{
+		MinVersion:   tls.VersionTLS12,
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    fixture.trust,
+		Certificates: []tls.Certificate{fixture.certificate(t, "synthetic HTTP/2 server", []string{x509TransportAPI}, false)},
+	}
+	server.Config.ErrorLog = log.New(io.Discard, "", 0)
+	server.StartTLS()
+	t.Cleanup(server.Close)
+	return server
 }

--- a/auth/x509transport_protocol_test.go
+++ b/auth/x509transport_protocol_test.go
@@ -41,6 +41,27 @@ func TestX509TransportRejectsTunnelsAndAmbiguousFramingBeforeDial(t *testing.T) 
 		{name: "TRACE tunnel", change: func(request *http.Request) { request.Method = http.MethodTrace }},
 		{name: "HTTP/2 preface", change: func(request *http.Request) { request.Method = "PRI" }},
 		{name: "custom tunnel method", change: func(request *http.Request) { request.Method = "SYNTHETIC-TUNNEL" }},
+		{name: "explicit request URI", change: func(request *http.Request) {
+			request.RequestURI = "/v1/attacker-controlled"
+		}},
+		{name: "deprecated request cancellation channel", change: func(request *http.Request) {
+			request.Cancel = make(chan struct{}) //nolint:staticcheck // Exercising legacy cancellation requires its sole, deprecated accessor.
+		}},
+		{name: "query with carriage return", change: func(request *http.Request) {
+			request.URL.RawQuery = "synthetic=value\rinjected"
+		}},
+		{name: "query with line feed", change: func(request *http.Request) {
+			request.URL.RawQuery = "synthetic=value\ninjected"
+		}},
+		{name: "query with horizontal tab", change: func(request *http.Request) {
+			request.URL.RawQuery = "synthetic=value\tinjected"
+		}},
+		{name: "query with null byte", change: func(request *http.Request) {
+			request.URL.RawQuery = "synthetic=value\x00injected"
+		}},
+		{name: "query with DEL byte", change: func(request *http.Request) {
+			request.URL.RawQuery = "synthetic=value\x7finjected"
+		}},
 		{name: "identity transfer encoding", change: func(request *http.Request) {
 			request.TransferEncoding = []string{"identity"}
 		}},
@@ -85,6 +106,14 @@ func TestX509TransportRejectsTunnelsAndAmbiguousFramingBeforeDial(t *testing.T) 
 		{name: "proxy connection", change: x509UnsafeFramingHeader("proxy_connection", "keep-alive")},
 		{name: "hop-by-hop TE", change: x509UnsafeFramingHeader("te", "trailers")},
 		{name: "lowercase Host alias", change: x509UnsafeFramingHeader("host", "attacker.example.test")},
+		{name: "empty header name", change: x509UnsafeFramingHeader("", "synthetic-value")},
+		{name: "header name with whitespace", change: x509UnsafeFramingHeader("Invalid Name", "synthetic-value")},
+		{name: "header name with colon", change: x509UnsafeFramingHeader("Invalid:Name", "synthetic-value")},
+		{name: "header name with non-ASCII bytes", change: x509UnsafeFramingHeader("Invalid-\u00e9", "synthetic-value")},
+		{name: "header value with carriage return", change: x509UnsafeFramingHeader("Synthetic", "value\rnext")},
+		{name: "header value with line feed", change: x509UnsafeFramingHeader("Synthetic", "value\nnext")},
+		{name: "header value with null byte", change: x509UnsafeFramingHeader("Synthetic", "value\x00next")},
+		{name: "header value with DEL byte", change: x509UnsafeFramingHeader("Synthetic", "value\x7fnext")},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			request := x509TransportRequest(t, http.MethodPost, "https://"+x509TransportAPI+"/v1/models")
@@ -122,6 +151,9 @@ func TestX509TransportPreservesSafelyChunkedStreamingBodies(t *testing.T) {
 	payload := "synthetic stream\r\nGET /v1/stolen HTTP/1.1\r\nHost: attacker.example.test\r\n\r\n"
 	server := fixture.server(t, http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
 		received.Add(1)
+		if got := request.Header.Get("Synthetic-Compatibility"); got != "safe\tvalue\x80" {
+			t.Errorf("valid HTTP header value = %q, want horizontal tab and obs-text bytes", got)
+		}
 		body, err := io.ReadAll(request.Body)
 		if err != nil || string(body) != payload {
 			t.Errorf("safely chunked workload body = %q, error = %v", body, err)
@@ -132,6 +164,7 @@ func TestX509TransportPreservesSafelyChunkedStreamingBodies(t *testing.T) {
 	for _, knownLength := range []bool{false, true} {
 		request := x509TransportRequest(t, http.MethodPost, "https://"+x509TransportAPI+"/v1/models")
 		request.Header.Set("Authorization", "Bearer protected-synthetic-token")
+		request.Header.Set("Synthetic-Compatibility", "safe\tvalue\x80")
 		request.Body = io.NopCloser(strings.NewReader(payload))
 		request.ContentLength = -1
 		if knownLength {

--- a/auth/x509transport_protocol_test.go
+++ b/auth/x509transport_protocol_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto"
 	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"io"
 	"net"
@@ -401,6 +402,10 @@ func TestX509TransportRejectsHTTP2WhenRuntimeDisablesItsNativeHandler(t *testing
 			request.Header.Set("Authorization", "Bearer private-header-token")
 			if test.http2Only {
 				err := x509Rejected(t, capability, request)
+				if cause := errors.Unwrap(err); cause == nil ||
+					cause.Error() != "X.509 transport TLS verification failed" {
+					t.Errorf("runtime-disabled HTTP/2 was not classified as permanent TLS policy: %v", err)
+				}
 				if strings.Contains(err.Error(), "private-") || strings.Contains(err.Error(), "synthetic-secret") {
 					t.Errorf("runtime-disabled protocol error disclosed request credentials: %q", err.Error())
 				}
@@ -453,6 +458,10 @@ func TestX509TransportPreservesCallerTLSConnectionVerification(t *testing.T) {
 				if errors.Is(err, sensitive) || strings.Contains(err.Error(), "private-") {
 					t.Errorf("caller verifier leaked its sensitive rejection: %v", err)
 				}
+				if cause := errors.Unwrap(err); cause == nil ||
+					cause.Error() != "X.509 transport TLS verification failed" {
+					t.Errorf("caller verifier rejection was not classified as permanent TLS policy: %v", err)
+				}
 			} else {
 				response, err := capability.Do(request)
 				if err != nil {
@@ -471,6 +480,68 @@ func TestX509TransportPreservesCallerTLSConnectionVerification(t *testing.T) {
 			}
 			if got := received.Load(); got != want {
 				t.Errorf("caller-verified TLS delivered %d authenticated requests, want %d", got, want)
+			}
+		})
+	}
+}
+
+func TestX509TransportClassifiesTLSVerificationFailuresWithoutLeakingDetails(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		configure func(*http.Transport, error)
+	}{
+		{
+			name: "untrusted server certificate",
+			configure: func(template *http.Transport, _ error) {
+				template.TLSClientConfig.RootCAs = x509.NewCertPool()
+			},
+		},
+		{
+			name: "caller peer-certificate verification",
+			configure: func(template *http.Transport, sensitive error) {
+				template.TLSClientConfig.VerifyPeerCertificate = func([][]byte, [][]*x509.Certificate) error {
+					return sensitive
+				}
+			},
+		},
+		{
+			name: "caller connection verification",
+			configure: func(template *http.Transport, sensitive error) {
+				template.TLSClientConfig.VerifyConnection = func(tls.ConnectionState) error {
+					return sensitive
+				}
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newX509TransportFixture(t)
+			var received atomic.Int32
+			server := fixture.server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				received.Add(1)
+				w.WriteHeader(http.StatusOK)
+			}))
+			template := fixture.transport(t, server)
+			sensitive := errors.New("private-certificate-verification-secret")
+			test.configure(template, sensitive)
+			capability := newX509Capability(t, template)
+			request := x509TransportRequest(t, http.MethodGet,
+				"https://"+x509TransportAPI+"/v1/models?private-query-token=synthetic-secret")
+			request.Header.Set("Authorization", "Bearer private-header-token")
+			err := x509Rejected(t, capability, request)
+			cause := errors.Unwrap(err)
+			if cause == nil || cause.Error() != "X.509 transport TLS verification failed" {
+				t.Fatalf("permanent TLS verification failure has unsafe or missing classification: %v", err)
+			}
+			if errors.Unwrap(cause) != nil || errors.Is(err, sensitive) {
+				t.Error("permanent TLS verification retained its sensitive underlying cause")
+			}
+			for current := err; current != nil; current = errors.Unwrap(current) {
+				if strings.Contains(current.Error(), "private-") || strings.Contains(current.Error(), "synthetic-secret") {
+					t.Errorf("permanent TLS classification disclosed request or verification data: %q", current.Error())
+				}
+			}
+			if got := received.Load(); got != 0 {
+				t.Errorf("permanent TLS verification failure delivered %d HTTP requests", got)
 			}
 		})
 	}

--- a/auth/x509transport_protocol_test.go
+++ b/auth/x509transport_protocol_test.go
@@ -1,0 +1,336 @@
+package auth_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/openai/openai-go/v3/auth"
+)
+
+func TestX509TransportRejectsTunnelsAndAmbiguousFramingBeforeDial(t *testing.T) {
+	fixture := newX509TransportFixture(t)
+	var received, dialed atomic.Int32
+	server := fixture.server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		received.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	template := fixture.transport(t, server)
+	originalDial := template.DialContext
+	template.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		dialed.Add(1)
+		return originalDial(ctx, network, address)
+	}
+	capability := newX509Capability(t, template)
+	for _, test := range []struct {
+		name   string
+		change func(*http.Request)
+	}{
+		{name: "CONNECT tunnel", change: func(request *http.Request) { request.Method = http.MethodConnect }},
+		{name: "TRACE tunnel", change: func(request *http.Request) { request.Method = http.MethodTrace }},
+		{name: "HTTP/2 preface", change: func(request *http.Request) { request.Method = "PRI" }},
+		{name: "custom tunnel method", change: func(request *http.Request) { request.Method = "SYNTHETIC-TUNNEL" }},
+		{name: "identity transfer encoding", change: func(request *http.Request) {
+			request.TransferEncoding = []string{"identity"}
+		}},
+		{name: "multiple transfer encodings", change: func(request *http.Request) {
+			request.TransferEncoding = []string{"chunked", "identity"}
+		}},
+		{name: "unsupported transfer encoding", change: func(request *http.Request) {
+			request.TransferEncoding = []string{"gzip"}
+		}},
+		{name: "explicit chunked transfer encoding", change: func(request *http.Request) {
+			request.TransferEncoding = []string{"chunked"}
+		}},
+		{name: "chunked known-length conflict", change: func(request *http.Request) {
+			request.TransferEncoding = []string{"chunked"}
+			request.ContentLength = 5
+		}},
+		{name: "invalid negative content length", change: func(request *http.Request) {
+			request.ContentLength = -2
+		}},
+		{name: "missing body with content length", change: func(request *http.Request) {
+			_ = request.Body.Close()
+			request.Body = nil
+			request.ContentLength = 5
+		}},
+		{name: "chunked without body", change: func(request *http.Request) {
+			_ = request.Body.Close()
+			request.Body = nil
+			request.ContentLength = 0
+			request.TransferEncoding = []string{"chunked"}
+		}},
+		{name: "canonical transfer encoding header", change: x509UnsafeFramingHeader("Transfer-Encoding", "identity")},
+		{name: "lowercase transfer encoding alias", change: x509UnsafeFramingHeader("transfer-encoding", "identity")},
+		{name: "underscore transfer encoding alias", change: x509UnsafeFramingHeader("transfer_encoding", "identity")},
+		{name: "canonical content length header", change: x509UnsafeFramingHeader("Content-Length", "0")},
+		{name: "lowercase content length alias", change: x509UnsafeFramingHeader("content-length", "0")},
+		{name: "underscore content length alias", change: x509UnsafeFramingHeader("content_length", "0")},
+		{name: "lowercase trailer alias", change: x509UnsafeFramingHeader("trailer", "Authorization")},
+		{name: "underscore trailer alias", change: x509UnsafeFramingHeader("trailer", "Host")},
+		{name: "connection upgrade", change: x509UnsafeFramingHeader("connection", "Upgrade")},
+		{name: "protocol upgrade", change: x509UnsafeFramingHeader("upgrade", "attacker-protocol")},
+		{name: "HTTP/2 upgrade settings", change: x509UnsafeFramingHeader("http2_settings", "attacker-settings")},
+		{name: "proxy connection", change: x509UnsafeFramingHeader("proxy_connection", "keep-alive")},
+		{name: "hop-by-hop TE", change: x509UnsafeFramingHeader("te", "trailers")},
+		{name: "lowercase Host alias", change: x509UnsafeFramingHeader("host", "attacker.example.test")},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			request := x509TransportRequest(t, http.MethodPost, "https://"+x509TransportAPI+"/v1/models")
+			request.Header.Set("Authorization", "Bearer protected-synthetic-token")
+			body := &x509TrackedRequestBody{Reader: strings.NewReader(
+				"synthetic-body\r\nGET /v1/stolen HTTP/1.1\r\n" +
+					"Host: attacker.example.test\r\nAuthorization: Bearer injected-secret\r\n\r\n",
+			)}
+			request.Body = body
+			request.ContentLength = -1
+			test.change(request)
+			_ = x509Rejected(t, capability, request)
+			if got := body.closed.Load(); got != 1 {
+				t.Errorf("rejected framing closed its request body %d times, want once", got)
+			}
+			if got := dialed.Load(); got != 0 {
+				t.Errorf("ambiguous HTTP framing caused %d network dials", got)
+			}
+			if got := received.Load(); got != 0 {
+				t.Errorf("ambiguous HTTP framing delivered %d tunneled or smuggled requests", got)
+			}
+		})
+	}
+}
+
+func x509UnsafeFramingHeader(name, value string) func(*http.Request) {
+	return func(request *http.Request) {
+		request.Header[name] = []string{value}
+	}
+}
+
+func TestX509TransportPreservesSafelyChunkedStreamingBodies(t *testing.T) {
+	fixture := newX509TransportFixture(t)
+	var received atomic.Int32
+	payload := "synthetic stream\r\nGET /v1/stolen HTTP/1.1\r\nHost: attacker.example.test\r\n\r\n"
+	server := fixture.server(t, http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		received.Add(1)
+		body, err := io.ReadAll(request.Body)
+		if err != nil || string(body) != payload {
+			t.Errorf("safely chunked workload body = %q, error = %v", body, err)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	capability := newX509Capability(t, fixture.transport(t, server))
+	for _, knownLength := range []bool{false, true} {
+		request := x509TransportRequest(t, http.MethodPost, "https://"+x509TransportAPI+"/v1/models")
+		request.Header.Set("Authorization", "Bearer protected-synthetic-token")
+		request.Body = io.NopCloser(strings.NewReader(payload))
+		request.ContentLength = -1
+		if knownLength {
+			request.ContentLength = int64(len(payload))
+		}
+		response, err := capability.Do(request)
+		if err != nil {
+			t.Fatalf("safely framed streaming request (known length=%t): %v", knownLength, err)
+		}
+		if closeErr := response.Body.Close(); closeErr != nil {
+			t.Fatalf("close safely chunked streaming response: %v", closeErr)
+		}
+	}
+	if got := received.Load(); got != 2 {
+		t.Errorf("safe chunked streams delivered %d HTTP requests, want exactly two", got)
+	}
+}
+
+func TestX509TransportRejectsSessionKeyLoggingBeforeTLS(t *testing.T) {
+	fixture := newX509TransportFixture(t)
+	var received atomic.Int32
+	server := fixture.server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		received.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	var leaked bytes.Buffer
+	template := fixture.transport(t, server)
+	template.TLSClientConfig.KeyLogWriter = &leaked
+	if capability, err := auth.NewX509Transport(template); capability != nil || err == nil ||
+		!strings.Contains(err.Error(), "session key logging") {
+		t.Fatalf("attest caller-controlled TLS key logger = capability:%v error:%v", capability, err)
+	}
+	template.TLSClientConfig.KeyLogWriter = nil
+	capability := newX509Capability(t, template)
+	template.TLSClientConfig.KeyLogWriter = &leaked
+	request := x509TransportRequest(t, http.MethodGet, "https://"+x509TransportAPI+"/v1/models")
+	request.Header.Set("Authorization", "Bearer protected-synthetic-token")
+	if err := x509Rejected(t, capability, request); !strings.Contains(err.Error(), "session key logging") {
+		t.Fatalf("post-attestation TLS key logger error = %v", err)
+	}
+	if leaked.Len() != 0 || received.Load() != 0 {
+		t.Errorf("rejected TLS key logger captured %d bytes and delivered %d requests", leaked.Len(), received.Load())
+	}
+}
+
+func TestX509TransportFreezesMutableTLSPolicySlices(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		prepare func(*http.Transport)
+		mutate  func(*http.Transport)
+	}{
+		{
+			name: "cipher suite preferences",
+			prepare: func(template *http.Transport) {
+				template.TLSClientConfig.MinVersion = tls.VersionTLS12
+				template.TLSClientConfig.MaxVersion = tls.VersionTLS12
+				template.TLSClientConfig.CipherSuites = []uint16{tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256}
+			},
+			mutate: func(template *http.Transport) {
+				template.TLSClientConfig.CipherSuites[0] = tls.TLS_RSA_WITH_AES_128_CBC_SHA
+			},
+		},
+		{
+			name: "curve preferences",
+			prepare: func(template *http.Transport) {
+				template.TLSClientConfig.CurvePreferences = []tls.CurveID{tls.CurveP256}
+			},
+			mutate: func(template *http.Transport) {
+				template.TLSClientConfig.CurvePreferences[0] = tls.CurveID(0xffff)
+			},
+		},
+		{
+			name: "TLS application protocol preferences",
+			prepare: func(template *http.Transport) {
+				template.TLSClientConfig.NextProtos = []string{"http/1.1"}
+			},
+			mutate: func(template *http.Transport) {
+				template.TLSClientConfig.NextProtos[0] = "synthetic-attacker-protocol"
+			},
+		},
+		{
+			name: "client certificate signature algorithms",
+			prepare: func(template *http.Transport) {
+				template.TLSClientConfig.Certificates[0].SupportedSignatureAlgorithms = []tls.SignatureScheme{
+					tls.ECDSAWithP256AndSHA256,
+				}
+			},
+			mutate: func(template *http.Transport) {
+				template.TLSClientConfig.Certificates[0].SupportedSignatureAlgorithms[0] = tls.PKCS1WithSHA256
+			},
+		},
+		{
+			name: "parsed client certificate leaf",
+			mutate: func(template *http.Transport) {
+				template.TLSClientConfig.Certificates[0].Leaf.RawIssuer = []byte("synthetic-untrusted-issuer")
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newX509TransportFixture(t)
+			var received atomic.Int32
+			server := fixture.server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				received.Add(1)
+				w.WriteHeader(http.StatusOK)
+			}))
+			template := fixture.transport(t, server)
+			if test.prepare != nil {
+				test.prepare(template)
+			}
+			capability := newX509Capability(t, template)
+			test.mutate(template)
+			request := x509TransportRequest(t, http.MethodGet, "https://"+x509TransportAPI+"/v1/models")
+			request.Header.Set("Authorization", "Bearer protected-synthetic-token")
+			response, err := capability.Do(request)
+			if err != nil {
+				t.Fatalf("caller TLS-policy slice mutation changed the attested handshake: %v", err)
+			}
+			if closeErr := response.Body.Close(); closeErr != nil {
+				t.Fatalf("close isolated TLS-policy response: %v", closeErr)
+			}
+			if got := received.Load(); got != 1 {
+				t.Errorf("isolated TLS-policy mutation delivered %d requests", got)
+			}
+		})
+	}
+}
+
+func TestX509TransportPreservesSanitizedNetworkTimeoutClassification(t *testing.T) {
+	for _, test := range []struct {
+		name             string
+		handshakeTimeout bool
+		contextDeadline  bool
+	}{
+		{name: "TLS handshake timeout", handshakeTimeout: true},
+		{name: "response header timeout"},
+		{name: "request context deadline", contextDeadline: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newX509TransportFixture(t)
+			var template *http.Transport
+			if test.handshakeTimeout {
+				listener, err := net.Listen("tcp", "127.0.0.1:0")
+				if err != nil {
+					t.Fatalf("start stalled TLS handshake listener: %v", err)
+				}
+				release := make(chan struct{})
+				finished := make(chan struct{})
+				go func() {
+					defer close(finished)
+					connection, acceptErr := listener.Accept()
+					if acceptErr != nil {
+						return
+					}
+					defer func() { _ = connection.Close() }()
+					<-release
+				}()
+				t.Cleanup(func() {
+					close(release)
+					_ = listener.Close()
+					<-finished
+				})
+				template = fixture.transport(t, nil)
+				template.DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
+					return (&net.Dialer{}).DialContext(ctx, network, listener.Addr().String())
+				}
+				template.TLSHandshakeTimeout = 75 * time.Millisecond
+			} else {
+				server := fixture.server(t, http.HandlerFunc(func(_ http.ResponseWriter, request *http.Request) {
+					<-request.Context().Done()
+				}))
+				template = fixture.transport(t, server)
+				if !test.contextDeadline {
+					template.ResponseHeaderTimeout = 75 * time.Millisecond
+				}
+			}
+			capability := newX509Capability(t, template)
+			request := x509TransportRequest(t, http.MethodGet,
+				"https://"+x509TransportAPI+"/v1/models?private-query-token=synthetic-secret")
+			request.Header.Set("Authorization", "Bearer private-header-token")
+			if test.contextDeadline {
+				ctx, cancel := context.WithTimeout(request.Context(), 75*time.Millisecond)
+				defer cancel()
+				request = request.WithContext(ctx)
+			}
+			err := x509Rejected(t, capability, request)
+			var networkError net.Error
+			if !errors.As(err, &networkError) || !networkError.Timeout() || !os.IsTimeout(err) {
+				t.Errorf("sanitized timeout classification = error:%v net.Error:%t os.IsTimeout:%t",
+					err, networkError != nil && networkError.Timeout(), os.IsTimeout(err))
+			}
+			if test.contextDeadline && !errors.Is(err, context.DeadlineExceeded) {
+				t.Errorf("request deadline lost context identity: %v", err)
+			}
+			if cause := errors.Unwrap(err); cause != nil && !errors.Is(cause, context.DeadlineExceeded) {
+				t.Errorf("native timeout retained its potentially sensitive underlying cause: %v", err)
+			}
+			for cause := err; cause != nil; cause = errors.Unwrap(cause) {
+				if strings.Contains(cause.Error(), "private-") || strings.Contains(cause.Error(), "synthetic-secret") {
+					t.Errorf("network timeout exposed request credentials: %q", cause.Error())
+				}
+			}
+		})
+	}
+}

--- a/auth/x509transport_protocol_test.go
+++ b/auth/x509transport_protocol_test.go
@@ -368,6 +368,114 @@ func TestX509TransportRejectsALPNDisabledByEffectiveHTTPProtocols(t *testing.T) 
 	}
 }
 
+func TestX509TransportRejectsHTTP2WhenRuntimeDisablesItsNativeHandler(t *testing.T) {
+	t.Setenv("GODEBUG", "http2client=0")
+	for _, test := range []struct {
+		name         string
+		http2Only    bool
+		wantRequests int32
+	}{
+		{name: "HTTP/2 ALPN without runtime handler", http2Only: true},
+		{name: "mixed policy safely falls back to HTTP/1", wantRequests: 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newX509TransportFixture(t)
+			var received atomic.Int32
+			server := newX509HTTP2TransportServer(t, fixture, http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+				received.Add(1)
+				if request.ProtoMajor != 1 {
+					t.Errorf("runtime-disabled HTTP/2 delivered an HTTP/%d request", request.ProtoMajor)
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			template := fixture.transport(t, server)
+			template.ForceAttemptHTTP2 = true
+			if test.http2Only {
+				template.Protocols = new(http.Protocols)
+				template.Protocols.SetHTTP2(true)
+				template.TLSClientConfig.NextProtos = []string{"h2"}
+			}
+			capability := newX509Capability(t, template)
+			request := x509TransportRequest(t, http.MethodGet,
+				"https://"+x509TransportAPI+"/v1/models?private-query-token=synthetic-secret")
+			request.Header.Set("Authorization", "Bearer private-header-token")
+			if test.http2Only {
+				err := x509Rejected(t, capability, request)
+				if strings.Contains(err.Error(), "private-") || strings.Contains(err.Error(), "synthetic-secret") {
+					t.Errorf("runtime-disabled protocol error disclosed request credentials: %q", err.Error())
+				}
+			} else {
+				response, err := capability.Do(request)
+				if err != nil {
+					t.Fatalf("mixed HTTP policy did not safely fall back to HTTP/1: %v", err)
+				}
+				if closeErr := response.Body.Close(); closeErr != nil {
+					t.Fatalf("close fallback HTTP/1 response: %v", closeErr)
+				}
+			}
+			if got := received.Load(); got != test.wantRequests {
+				t.Errorf("runtime-disabled HTTP/2 delivered %d authenticated requests, want %d", got, test.wantRequests)
+			}
+		})
+	}
+}
+
+func TestX509TransportPreservesCallerTLSConnectionVerification(t *testing.T) {
+	for _, reject := range []bool{false, true} {
+		name := "caller certificate verifier succeeds"
+		if reject {
+			name = "caller certificate verifier fails safely"
+		}
+		t.Run(name, func(t *testing.T) {
+			fixture := newX509TransportFixture(t)
+			var received, verified atomic.Int32
+			server := fixture.server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				received.Add(1)
+				w.WriteHeader(http.StatusOK)
+			}))
+			template := fixture.transport(t, server)
+			sensitive := errors.New("private-caller-verifier-secret")
+			template.TLSClientConfig.VerifyConnection = func(state tls.ConnectionState) error {
+				verified.Add(1)
+				if len(state.PeerCertificates) == 0 {
+					t.Error("caller verifier did not receive a validated server certificate")
+				}
+				if reject {
+					return sensitive
+				}
+				return nil
+			}
+			capability := newX509Capability(t, template)
+			request := x509TransportRequest(t, http.MethodGet, "https://"+x509TransportAPI+"/v1/models")
+			request.Header.Set("Authorization", "Bearer private-header-token")
+			if reject {
+				err := x509Rejected(t, capability, request)
+				if errors.Is(err, sensitive) || strings.Contains(err.Error(), "private-") {
+					t.Errorf("caller verifier leaked its sensitive rejection: %v", err)
+				}
+			} else {
+				response, err := capability.Do(request)
+				if err != nil {
+					t.Fatalf("mutual TLS with the caller's connection verifier: %v", err)
+				}
+				if closeErr := response.Body.Close(); closeErr != nil {
+					t.Fatalf("close caller-verified response: %v", closeErr)
+				}
+			}
+			if got := verified.Load(); got != 1 {
+				t.Errorf("caller connection verifier invoked %d times, want once", got)
+			}
+			want := int32(1)
+			if reject {
+				want = 0
+			}
+			if got := received.Load(); got != want {
+				t.Errorf("caller-verified TLS delivered %d authenticated requests, want %d", got, want)
+			}
+		})
+	}
+}
+
 func TestX509TransportRequiresPrivateKeySignerWithoutEagerHardwareCalls(t *testing.T) {
 	fixture := newX509TransportFixture(t)
 	var received atomic.Int32

--- a/auth/x509transport_protocol_test.go
+++ b/auth/x509transport_protocol_test.go
@@ -3,6 +3,7 @@ package auth_test
 import (
 	"bytes"
 	"context"
+	"crypto"
 	"crypto/tls"
 	"errors"
 	"io"
@@ -255,6 +256,178 @@ func TestX509TransportFreezesMutableTLSPolicySlices(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestX509TransportRejectsALPNDisabledByEffectiveHTTPProtocols(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		configure func(*http.Transport)
+		wantMajor int
+	}{
+		{
+			name: "HTTP/2 ALPN with explicit HTTP/1 only",
+			configure: func(template *http.Transport) {
+				template.Protocols = new(http.Protocols)
+				template.Protocols.SetHTTP1(true)
+				template.TLSClientConfig.NextProtos = []string{"h2"}
+			},
+		},
+		{
+			name: "HTTP/2 ALPN with protocol map disabling forced HTTP/2",
+			configure: func(template *http.Transport) {
+				template.ForceAttemptHTTP2 = true
+				template.TLSNextProto = make(map[string]func(string, *tls.Conn) http.RoundTripper)
+				template.TLSClientConfig.NextProtos = []string{"h2"}
+			},
+		},
+		{
+			name: "HTTP/1 ALPN with explicit HTTP/2 only",
+			configure: func(template *http.Transport) {
+				template.Protocols = new(http.Protocols)
+				template.Protocols.SetHTTP2(true)
+				template.TLSClientConfig.NextProtos = []string{"http/1.1"}
+			},
+		},
+		{
+			name: "plaintext-only HTTP/2 protocols",
+			configure: func(template *http.Transport) {
+				template.Protocols = new(http.Protocols)
+				template.Protocols.SetUnencryptedHTTP2(true)
+			},
+		},
+		{
+			name: "explicit compatible HTTP/2 ALPN",
+			configure: func(template *http.Transport) {
+				template.Protocols = new(http.Protocols)
+				template.Protocols.SetHTTP2(true)
+				template.TLSClientConfig.NextProtos = []string{"h2"}
+			},
+			wantMajor: 2,
+		},
+		{
+			name: "implicit compatible HTTP/2 ALPN",
+			configure: func(template *http.Transport) {
+				template.ForceAttemptHTTP2 = true
+				template.TLSClientConfig.NextProtos = []string{"h2"}
+			},
+			wantMajor: 2,
+		},
+		{
+			name: "explicit compatible HTTP/1 ALPN",
+			configure: func(template *http.Transport) {
+				template.Protocols = new(http.Protocols)
+				template.Protocols.SetHTTP1(true)
+				template.TLSClientConfig.NextProtos = []string{"http/1.1"}
+			},
+			wantMajor: 1,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newX509TransportFixture(t)
+			var received atomic.Int32
+			server := newX509HTTP2TransportServer(t, fixture, http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+				received.Add(1)
+				if request.ProtoMajor != test.wantMajor {
+					t.Errorf("negotiated HTTPS protocol = HTTP/%d, want HTTP/%d", request.ProtoMajor, test.wantMajor)
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			template := fixture.transport(t, server)
+			test.configure(template)
+			capability, err := auth.NewX509Transport(template)
+			if test.wantMajor == 0 {
+				if err == nil || capability != nil {
+					t.Fatalf("inconsistent TLS/HTTP protocol configuration was accepted: capability:%v error:%v", capability, err)
+				}
+				if got := received.Load(); got != 0 {
+					t.Errorf("inconsistent protocol negotiation leaked %d authenticated requests", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("attest compatible TLS/HTTP protocols: %v", err)
+			}
+			t.Cleanup(func() {
+				if closeErr := capability.Close(); closeErr != nil {
+					t.Errorf("close protocol-compatible capability: %v", closeErr)
+				}
+			})
+			request := x509TransportRequest(t, http.MethodGet, "https://"+x509TransportAPI+"/v1/models")
+			request.Header.Set("Authorization", "Bearer protected-synthetic-token")
+			response, err := capability.Do(request)
+			if err != nil {
+				t.Fatalf("dispatch with consistent TLS/HTTP negotiation: %v", err)
+			}
+			if closeErr := response.Body.Close(); closeErr != nil {
+				t.Fatalf("close protocol-compatible response: %v", closeErr)
+			}
+			if got := received.Load(); got != 1 {
+				t.Errorf("compatible negotiated protocol delivered %d authenticated requests", got)
+			}
+		})
+	}
+}
+
+func TestX509TransportRequiresPrivateKeySignerWithoutEagerHardwareCalls(t *testing.T) {
+	fixture := newX509TransportFixture(t)
+	var received atomic.Int32
+	server := fixture.server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		received.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	template := fixture.transport(t, server)
+	original := template.TLSClientConfig.Certificates[0].PrivateKey
+	template.TLSClientConfig.Certificates[0].PrivateKey = struct{}{}
+	if capability, err := auth.NewX509Transport(template); capability != nil || err == nil ||
+		!strings.Contains(err.Error(), "static certificate and private key") {
+		t.Fatalf("non-signer private key was accepted: capability:%v error:%v", capability, err)
+	}
+	signer, ok := original.(crypto.Signer)
+	if !ok {
+		t.Fatal("synthetic workload key does not implement crypto.Signer")
+	}
+	observed := &x509ObservedSigner{signer: signer}
+	template.TLSClientConfig.Certificates[0].PrivateKey = observed
+	capability := newX509Capability(t, template)
+	if observed.publicCalls.Load() != 0 || observed.signCalls.Load() != 0 {
+		t.Fatalf("attestation eagerly invoked a caller-owned signer Public/Sign %d/%d times",
+			observed.publicCalls.Load(), observed.signCalls.Load())
+	}
+	template.TLSClientConfig.Certificates[0].PrivateKey = struct{}{}
+	request := x509TransportRequest(t, http.MethodGet, "https://"+x509TransportAPI+"/v1/models")
+	request.Header.Set("Authorization", "Bearer protected-synthetic-token")
+	_ = x509Rejected(t, capability, request)
+	if got := received.Load(); got != 0 {
+		t.Errorf("post-attestation non-signer delivered %d authenticated requests", got)
+	}
+	template.TLSClientConfig.Certificates[0].PrivateKey = observed
+	response, err := capability.Do(request)
+	if err != nil {
+		t.Fatalf("mutual TLS using a caller-owned hardware-style crypto.Signer: %v", err)
+	}
+	if closeErr := response.Body.Close(); closeErr != nil {
+		t.Fatalf("close caller-owned signer response: %v", closeErr)
+	}
+	if observed.publicCalls.Load() == 0 || observed.signCalls.Load() == 0 || received.Load() != 1 {
+		t.Errorf("caller-owned signer Public/Sign/API invocations = %d/%d/%d",
+			observed.publicCalls.Load(), observed.signCalls.Load(), received.Load())
+	}
+}
+
+type x509ObservedSigner struct {
+	signer      crypto.Signer
+	publicCalls atomic.Int32
+	signCalls   atomic.Int32
+}
+
+func (signer *x509ObservedSigner) Public() crypto.PublicKey {
+	signer.publicCalls.Add(1)
+	return signer.signer.Public()
+}
+
+func (signer *x509ObservedSigner) Sign(random io.Reader, digest []byte, options crypto.SignerOpts) ([]byte, error) {
+	signer.signCalls.Add(1)
+	return signer.signer.Sign(random, digest, options)
 }
 
 func TestX509TransportPreservesSanitizedNetworkTimeoutClassification(t *testing.T) {

--- a/auth/x509transport_test.go
+++ b/auth/x509transport_test.go
@@ -1,10 +1,12 @@
 package auth_test
 
 import (
+	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -16,6 +18,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/http/httptrace"
 	"net/url"
 	"strings"
 	"sync"
@@ -115,6 +118,15 @@ func TestNewX509TransportRequiresStaticNativeConfiguration(t *testing.T) {
 			want: "direct connections",
 		},
 		{
+			name: "custom TLS protocol handler",
+			change: func(transport *http.Transport) {
+				transport.TLSNextProto = map[string]func(string, *tls.Conn) http.RoundTripper{
+					"attacker": func(string, *tls.Conn) http.RoundTripper { return nil },
+				}
+			},
+			want: "TLS protocol handlers",
+		},
+		{
 			name:   "disabled certificate verification",
 			change: func(transport *http.Transport) { transport.TLSClientConfig.InsecureSkipVerify = true },
 			want:   "hostname verification",
@@ -158,6 +170,21 @@ func TestX509TransportAttestationDetectsUnsafeMutations(t *testing.T) {
 			change: func(transport *http.Transport) { transport.TLSClientConfig = transport.TLSClientConfig.Clone() },
 		},
 		{
+			name: "replace static certificate generation",
+			change: func(transport *http.Transport) {
+				transport.TLSClientConfig.Certificates = []tls.Certificate{fixture.certificate(t, "rotated-workload", nil, true)}
+			},
+		},
+		{
+			name: "replace certificate chain",
+			change: func(transport *http.Transport) {
+				transport.TLSClientConfig.Certificates[0].Certificate = append(
+					transport.TLSClientConfig.Certificates[0].Certificate,
+					[]byte("synthetic alternate intermediate"),
+				)
+			},
+		},
+		{
 			name: "install dynamic certificate callback",
 			change: func(transport *http.Transport) {
 				transport.TLSClientConfig.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
@@ -185,19 +212,52 @@ func TestX509TransportAttestationDetectsUnsafeMutations(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "install custom TLS protocol handler",
+			change: func(transport *http.Transport) {
+				transport.TLSNextProto = map[string]func(string, *tls.Conn) http.RoundTripper{
+					"attacker": func(string, *tls.Conn) http.RoundTripper { return nil },
+				}
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			transport := fixture.transport(t, nil)
-			capability, err := auth.NewX509Transport(transport)
-			if err != nil {
-				t.Fatalf("create initial capability: %v", err)
-			}
+			capability := newX509Capability(t, transport)
 			test.change(transport)
 			request := x509TransportRequest(t, http.MethodGet, "https://"+x509TransportAPI+"/v1/models")
 			_ = x509Rejected(t, capability, request)
 		})
+	}
+}
+
+func TestX509TransportRejectsCertificateRotationBeforeMutualTLS(t *testing.T) {
+	fixture := newX509TransportFixture(t)
+	var requests atomic.Int32
+	server := fixture.server(t, http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	template := fixture.transport(t, server)
+	capability := newX509Capability(t, template)
+	request := x509TransportRequest(t, http.MethodGet, "https://"+x509TransportAPI+"/v1/models")
+	request.Header.Set("Authorization", "Bearer initial-workload-token")
+	first, err := capability.Do(request)
+	if err != nil {
+		t.Fatalf("initial hostname-verified mTLS request: %v", err)
+	}
+	if closeErr := first.Body.Close(); closeErr != nil {
+		t.Fatalf("close initial mTLS response: %v", closeErr)
+	}
+
+	template.TLSClientConfig.Certificates[0] = fixture.certificate(t, "rotated-workload", nil, true)
+	if rotationErr := x509Rejected(t, capability, request); !strings.Contains(rotationErr.Error(), "certificate changed") {
+		t.Fatalf("certificate rotation error = %v, want changed-generation refusal", rotationErr)
+	}
+	if got := requests.Load(); got != 1 {
+		t.Errorf("mTLS server received %d requests after unauthorized rotation, want one original request", got)
 	}
 }
 
@@ -279,10 +339,20 @@ func TestX509TransportRejectsUnsafeCredentialAliases(t *testing.T) {
 		{name: "issuer AWS credential", host: x509TransportIssuer, header: "X-Amz-Security-Token", values: []string{"synthetic"}},
 		{name: "issuer forged Host", host: x509TransportIssuer, header: "Host", values: []string{"attacker.test"}},
 		{name: "issuer pseudo authority", host: x509TransportIssuer, header: ":authority", values: []string{"attacker.test"}},
+		{name: "issuer organization", host: x509TransportIssuer, header: "OpenAI-Organization", values: []string{"synthetic-org"}},
+		{name: "issuer organization alias", host: x509TransportIssuer, header: "openai_organization", values: []string{"synthetic-org"}},
+		{name: "issuer project", host: x509TransportIssuer, header: "OpenAI-Project", values: []string{"synthetic-project"}},
+		{name: "issuer project alias", host: x509TransportIssuer, header: "openai_project", values: []string{"synthetic-project"}},
 		{name: "API API key", host: x509TransportAPI, header: "api_key", values: []string{"synthetic"}},
 		{name: "API proxy authorization", host: x509TransportAPI, header: "Proxy_Authorization", values: []string{"synthetic"}},
 		{name: "API cookie", host: x509TransportAPI, header: "Cookie", values: []string{"session=synthetic"}},
 		{name: "multiple API bearers", host: x509TransportAPI, header: "Authorization", values: []string{"Bearer one", "Bearer two"}},
+		{name: "API Basic credential", host: x509TransportAPI, header: "Authorization", values: []string{"Basic synthetic"}},
+		{name: "API comma-separated bearer", host: x509TransportAPI, header: "Authorization", values: []string{"Bearer first,Bearer second"}},
+		{name: "API whitespace bearer", host: x509TransportAPI, header: "Authorization", values: []string{"Bearer token with spaces"}},
+		{name: "API empty bearer", host: x509TransportAPI, header: "Authorization", values: []string{"Bearer "}},
+		{name: "API malformed bearer padding", host: x509TransportAPI, header: "Authorization", values: []string{"Bearer token=unsafe"}},
+		{name: "API padding-only bearer", host: x509TransportAPI, header: "Authorization", values: []string{"Bearer ==="}},
 	}
 
 	for _, test := range tests {
@@ -307,7 +377,7 @@ func TestX509TransportRejectsUnsafeCredentialAliases(t *testing.T) {
 	})
 }
 
-func TestX509TransportUsesCallerOwnedTransportAndRequestContext(t *testing.T) {
+func TestX509TransportUsesIsolatedNativePoolAndCallerOwnedCredentials(t *testing.T) {
 	fixture := newX509TransportFixture(t)
 	type requestRecord struct {
 		host          string
@@ -389,6 +459,162 @@ func TestX509TransportUsesCallerOwnedTransportAndRequestContext(t *testing.T) {
 	}
 	if received[0].authorization != "" || received[1].authorization != "Bearer synthetic-access-token" {
 		t.Errorf("issuer/API authorization = %q/%q", received[0].authorization, received[1].authorization)
+	}
+}
+
+func TestX509TransportIgnoresHiddenRegisteredHTTPSProtocol(t *testing.T) {
+	fixture := newX509TransportFixture(t)
+	var delivered atomic.Int32
+	server := fixture.server(t, http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		if request.Header.Get("Authorization") == "Bearer safe-workload-token" {
+			delivered.Add(1)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	template := fixture.transport(t, server)
+	var captured atomic.Int32
+	template.RegisterProtocol("https", &closureTransport{fn: func(request *http.Request) (*http.Response, error) {
+		captured.Add(1)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("{}")),
+			Request:    request,
+		}, nil
+	}})
+	capability := newX509Capability(t, template)
+	request := x509TransportRequest(t, http.MethodGet, "https://"+x509TransportAPI+"/v1/models")
+	request.Header.Set("Authorization", "Bearer safe-workload-token")
+
+	response, err := capability.Do(request)
+	if err != nil {
+		t.Fatalf("dispatch through clean native adapter: %v", err)
+	}
+	if closeErr := response.Body.Close(); closeErr != nil {
+		t.Fatalf("close clean-adapter response: %v", closeErr)
+	}
+	if got := captured.Load(); got != 0 {
+		t.Fatalf("caller template's hidden HTTPS handler captured %d protected requests", got)
+	}
+	if got := delivered.Load(); got != 1 {
+		t.Fatalf("real mutually authenticated server received %d protected requests", got)
+	}
+
+	originalRequest := x509TransportRequest(t, http.MethodGet, "https://"+x509TransportAPI+"/v1/original")
+	originalResponse, err := (&http.Client{Transport: template}).Do(originalRequest)
+	if err != nil {
+		t.Fatalf("caller-owned original transport: %v", err)
+	}
+	if err := originalResponse.Body.Close(); err != nil {
+		t.Fatalf("close original transport response: %v", err)
+	}
+	if got := captured.Load(); got != 1 {
+		t.Errorf("original caller-owned HTTPS handler was changed or removed; calls = %d", got)
+	}
+}
+
+func TestX509TransportSnapshotsRequestBeforeTraceMutation(t *testing.T) {
+	fixture := newX509TransportFixture(t)
+	type observedRequest struct {
+		host          string
+		authorization string
+		serverName    string
+	}
+	observed := make(chan observedRequest, 1)
+	server := fixture.server(t, http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		observed <- observedRequest{
+			host:          request.Host,
+			authorization: request.Header.Get("Authorization"),
+			serverName:    request.TLS.ServerName,
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	capability := newX509Capability(t, fixture.transport(t, server))
+	request := x509TransportRequest(t, http.MethodGet, "https://"+x509TransportAPI+"/v1/models")
+	request.Header.Set("Authorization", "Bearer original-workload-token")
+	trace := &httptrace.ClientTrace{
+		GotConn: func(httptrace.GotConnInfo) {
+			request.URL.Host = "attacker.example.test"
+			request.Host = "attacker.example.test"
+			request.Header.Set("Authorization", "Bearer attacker-replaced-token")
+		},
+	}
+	request = request.WithContext(httptrace.WithClientTrace(request.Context(), trace))
+
+	response, err := capability.Do(request)
+	if err != nil {
+		t.Fatalf("dispatch with late request-mutating trace: %v", err)
+	}
+	if err := response.Body.Close(); err != nil {
+		t.Fatalf("close trace-mutating response: %v", err)
+	}
+	select {
+	case record := <-observed:
+		if record.host != x509TransportAPI || record.serverName != x509TransportAPI {
+			t.Errorf("protected Host/SNI = %q/%q", record.host, record.serverName)
+		}
+		if record.authorization != "Bearer original-workload-token" {
+			t.Errorf("protected bearer was changed by late trace: %q", record.authorization)
+		}
+	default:
+		t.Fatal("real mTLS server did not receive the protected request")
+	}
+	if request.Host != "attacker.example.test" ||
+		request.Header.Get("Authorization") != "Bearer attacker-replaced-token" {
+		t.Fatal("negative-control trace did not mutate the original caller request")
+	}
+}
+
+func TestX509TransportCloseOwnsOnlyItsIsolatedPool(t *testing.T) {
+	fixture := newX509TransportFixture(t)
+	var mu sync.Mutex
+	var connections []string
+	server := fixture.server(t, http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		mu.Lock()
+		connections = append(connections, request.RemoteAddr)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	template := fixture.transport(t, server)
+	caller := &http.Client{Transport: template}
+	request := x509TransportRequest(t, http.MethodGet, "https://"+x509TransportAPI+"/v1/models")
+	original, err := caller.Do(request)
+	if err != nil {
+		t.Fatalf("initial caller-owned request: %v", err)
+	}
+	if closeErr := original.Body.Close(); closeErr != nil {
+		t.Fatalf("close caller-owned response: %v", closeErr)
+	}
+
+	capability := newX509Capability(t, template)
+	protected, err := capability.Do(request)
+	if err != nil {
+		t.Fatalf("capability-owned request: %v", err)
+	}
+	if closeErr := protected.Body.Close(); closeErr != nil {
+		t.Fatalf("close capability-owned response: %v", closeErr)
+	}
+	if closeErr := capability.Close(); closeErr != nil {
+		t.Fatalf("close capability-owned pool: %v", closeErr)
+	}
+	if closeErr := capability.Close(); closeErr != nil {
+		t.Fatalf("idempotent capability close: %v", closeErr)
+	}
+	if rejectedErr := x509Rejected(t, capability, request); !strings.Contains(rejectedErr.Error(), "closed") {
+		t.Fatalf("closed capability error = %v", rejectedErr)
+	}
+
+	remaining, err := caller.Do(request)
+	if err != nil {
+		t.Fatalf("caller-owned request after capability close: %v", err)
+	}
+	if err := remaining.Body.Close(); err != nil {
+		t.Fatalf("close remaining caller-owned response: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(connections) != 3 || connections[0] != connections[2] || connections[0] == connections[1] {
+		t.Errorf("original/capability/original connection pools = %v; want original reuse around an isolated pool", connections)
 	}
 }
 
@@ -506,6 +732,11 @@ func newX509Capability(t *testing.T, transport *http.Transport) *auth.X509Transp
 	if err != nil {
 		t.Fatalf("NewX509Transport: %v", err)
 	}
+	t.Cleanup(func() {
+		if err := capability.Close(); err != nil {
+			t.Errorf("close isolated X.509 transport: %v", err)
+		}
+	})
 	return capability
 }
 
@@ -564,14 +795,21 @@ func (fixture *x509TransportFixture) certificate(t *testing.T, name string, host
 	if err != nil {
 		t.Fatalf("generate ephemeral %q serial: %v", name, err)
 	}
+	publicKey, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	if err != nil {
+		t.Fatalf("encode ephemeral %q public key: %v", name, err)
+	}
+	keyID := sha256.Sum256(publicKey)
 	template := &x509.Certificate{
-		SerialNumber: serial,
-		Subject:      pkix.Name{CommonName: name},
-		NotBefore:    time.Now().Add(-time.Minute),
-		NotAfter:     time.Now().Add(time.Hour),
-		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
-		DNSNames:     hostnames,
-		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		SerialNumber:   serial,
+		Subject:        pkix.Name{CommonName: name},
+		NotBefore:      time.Now().Add(-time.Minute),
+		NotAfter:       time.Now().Add(time.Hour),
+		KeyUsage:       x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		DNSNames:       hostnames,
+		ExtKeyUsage:    []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		SubjectKeyId:   keyID[:],
+		AuthorityKeyId: fixture.root.SubjectKeyId,
 	}
 	if client {
 		template.DNSNames = []string{name + ".workload.example.test"}
@@ -584,6 +822,13 @@ func (fixture *x509TransportFixture) certificate(t *testing.T, name string, host
 	certificate, err := x509.ParseCertificate(encoded)
 	if err != nil {
 		t.Fatalf("parse ephemeral %q certificate: %v", name, err)
+	}
+	if client && (len(certificate.DNSNames) == 0 || len(certificate.SubjectKeyId) == 0 ||
+		!bytes.Equal(certificate.AuthorityKeyId, fixture.root.SubjectKeyId) ||
+		certificate.KeyUsage&(x509.KeyUsageDigitalSignature|x509.KeyUsageKeyEncipherment) !=
+			(x509.KeyUsageDigitalSignature|x509.KeyUsageKeyEncipherment) ||
+		len(certificate.ExtKeyUsage) != 1 || certificate.ExtKeyUsage[0] != x509.ExtKeyUsageClientAuth) {
+		t.Fatalf("ephemeral workload certificate %q does not satisfy X.509 enrollment requirements", name)
 	}
 	return tls.Certificate{Certificate: [][]byte{encoded}, PrivateKey: key, Leaf: certificate}
 }

--- a/auth/x509transport_test.go
+++ b/auth/x509transport_test.go
@@ -75,6 +75,14 @@ func TestNewX509TransportRequiresStaticNativeConfiguration(t *testing.T) {
 			want:   "exactly one static certificate",
 		},
 		{
+			name: "typed nil private key",
+			change: func(transport *http.Transport) {
+				var privateKey *ecdsa.PrivateKey
+				transport.TLSClientConfig.Certificates[0].PrivateKey = privateKey
+			},
+			want: "exactly one static certificate",
+		},
+		{
 			name: "dynamic certificate callback",
 			change: func(transport *http.Transport) {
 				transport.TLSClientConfig.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
@@ -184,6 +192,13 @@ func TestX509TransportAttestationDetectsUnsafeMutations(t *testing.T) {
 			},
 		},
 		{
+			name: "replace private key with typed nil",
+			change: func(transport *http.Transport) {
+				var privateKey *ecdsa.PrivateKey
+				transport.TLSClientConfig.Certificates[0].PrivateKey = privateKey
+			},
+		},
+		{
 			name: "install dynamic certificate callback",
 			change: func(transport *http.Transport) {
 				transport.TLSClientConfig.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
@@ -208,14 +223,6 @@ func TestX509TransportAttestationDetectsUnsafeMutations(t *testing.T) {
 			change: func(transport *http.Transport) {
 				transport.DialTLSContext = func(context.Context, string, string) (net.Conn, error) {
 					return nil, errors.New("synthetic TLS dialer")
-				}
-			},
-		},
-		{
-			name: "install custom TLS protocol handler",
-			change: func(transport *http.Transport) {
-				transport.TLSNextProto = map[string]func(string, *tls.Conn) http.RoundTripper{
-					"attacker": func(string, *tls.Conn) http.RoundTripper { return nil },
 				}
 			},
 		},

--- a/auth/x509transport_test.go
+++ b/auth/x509transport_test.go
@@ -18,7 +18,6 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"net/http/httptrace"
 	"net/url"
 	"strings"
 	"sync"
@@ -513,7 +512,7 @@ func TestX509TransportIgnoresHiddenRegisteredHTTPSProtocol(t *testing.T) {
 	}
 }
 
-func TestX509TransportSnapshotsRequestBeforeTraceMutation(t *testing.T) {
+func TestX509TransportSnapshotsRequestBeforeDialMutation(t *testing.T) {
 	fixture := newX509TransportFixture(t)
 	type observedRequest struct {
 		host          string
@@ -529,24 +528,24 @@ func TestX509TransportSnapshotsRequestBeforeTraceMutation(t *testing.T) {
 		}
 		w.WriteHeader(http.StatusOK)
 	}))
-	capability := newX509Capability(t, fixture.transport(t, server))
 	request := x509TransportRequest(t, http.MethodGet, "https://"+x509TransportAPI+"/v1/models")
 	request.Header.Set("Authorization", "Bearer original-workload-token")
-	trace := &httptrace.ClientTrace{
-		GetConn: func(string) {
-			request.URL.Host = "attacker.example.test"
-			request.Host = "attacker.example.test"
-			request.Header.Set("Authorization", "Bearer attacker-replaced-token")
-		},
+	template := fixture.transport(t, server)
+	dial := template.DialContext
+	template.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		request.URL.Host = "attacker.example.test"
+		request.Host = "attacker.example.test"
+		request.Header.Set("Authorization", "Bearer attacker-replaced-token")
+		return dial(ctx, network, address)
 	}
-	request = request.WithContext(httptrace.WithClientTrace(request.Context(), trace))
+	capability := newX509Capability(t, template)
 
 	response, err := capability.Do(request)
 	if err != nil {
-		t.Fatalf("dispatch with late request-mutating trace: %v", err)
+		t.Fatalf("dispatch with late request-mutating dialer: %v", err)
 	}
 	if err := response.Body.Close(); err != nil {
-		t.Fatalf("close trace-mutating response: %v", err)
+		t.Fatalf("close dialer-mutating response: %v", err)
 	}
 	select {
 	case record := <-observed:
@@ -554,14 +553,14 @@ func TestX509TransportSnapshotsRequestBeforeTraceMutation(t *testing.T) {
 			t.Errorf("protected Host/SNI = %q/%q", record.host, record.serverName)
 		}
 		if record.authorization != "Bearer original-workload-token" {
-			t.Errorf("protected bearer was changed by late trace: %q", record.authorization)
+			t.Errorf("protected bearer was changed by late dialer: %q", record.authorization)
 		}
 	default:
 		t.Fatal("real mTLS server did not receive the protected request")
 	}
 	if request.Host != "attacker.example.test" ||
 		request.Header.Get("Authorization") != "Bearer attacker-replaced-token" {
-		t.Fatal("negative-control trace did not mutate the original caller request")
+		t.Fatal("negative-control dialer did not mutate the original caller request")
 	}
 }
 

--- a/auth/x509transport_test.go
+++ b/auth/x509transport_test.go
@@ -533,7 +533,7 @@ func TestX509TransportSnapshotsRequestBeforeTraceMutation(t *testing.T) {
 	request := x509TransportRequest(t, http.MethodGet, "https://"+x509TransportAPI+"/v1/models")
 	request.Header.Set("Authorization", "Bearer original-workload-token")
 	trace := &httptrace.ClientTrace{
-		GotConn: func(httptrace.GotConnInfo) {
+		GetConn: func(string) {
 			request.URL.Host = "attacker.example.test"
 			request.Host = "attacker.example.test"
 			request.Header.Set("Authorization", "Bearer attacker-replaced-token")

--- a/auth/x509transport_test.go
+++ b/auth/x509transport_test.go
@@ -1,0 +1,628 @@
+package auth_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/openai/openai-go/v3/auth"
+)
+
+const (
+	x509TransportIssuer = "mtls.auth.openai.com"
+	x509TransportAPI    = "mtls.api.openai.com"
+)
+
+func TestNewX509TransportRequiresStaticNativeConfiguration(t *testing.T) {
+	fixture := newX509TransportFixture(t)
+	tests := []struct {
+		name   string
+		change func(*http.Transport)
+		want   string
+	}{
+		{
+			name:   "missing TLS configuration",
+			change: func(transport *http.Transport) { transport.TLSClientConfig = nil },
+			want:   "TLS configuration",
+		},
+		{
+			name:   "missing client certificate",
+			change: func(transport *http.Transport) { transport.TLSClientConfig.Certificates = nil },
+			want:   "exactly one static certificate",
+		},
+		{
+			name: "multiple client certificates",
+			change: func(transport *http.Transport) {
+				transport.TLSClientConfig.Certificates = append(transport.TLSClientConfig.Certificates, fixture.client)
+			},
+			want: "exactly one static certificate",
+		},
+		{
+			name:   "empty certificate chain",
+			change: func(transport *http.Transport) { transport.TLSClientConfig.Certificates[0].Certificate = nil },
+			want:   "exactly one static certificate",
+		},
+		{
+			name: "empty leaf certificate",
+			change: func(transport *http.Transport) {
+				transport.TLSClientConfig.Certificates[0].Certificate = [][]byte{{}}
+			},
+			want: "exactly one static certificate",
+		},
+		{
+			name:   "missing private key",
+			change: func(transport *http.Transport) { transport.TLSClientConfig.Certificates[0].PrivateKey = nil },
+			want:   "exactly one static certificate",
+		},
+		{
+			name: "dynamic certificate callback",
+			change: func(transport *http.Transport) {
+				transport.TLSClientConfig.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+					return &fixture.client, nil
+				}
+			},
+			want: "dynamic client-certificate",
+		},
+		{
+			name: "custom TLS context dialer",
+			change: func(transport *http.Transport) {
+				transport.DialTLSContext = func(context.Context, string, string) (net.Conn, error) {
+					return nil, errors.New("synthetic TLS dialer")
+				}
+			},
+			want: "custom TLS dialers",
+		},
+		{
+			name: "deprecated TLS dialer",
+			change: func(transport *http.Transport) {
+				//nolint:staticcheck // The regression must exercise the deprecated dialer that bypasses TLSClientConfig.
+				transport.DialTLS = func(string, string) (net.Conn, error) {
+					return nil, errors.New("synthetic deprecated TLS dialer")
+				}
+			},
+			want: "deprecated TLS dialers",
+		},
+		{
+			name: "shared TLS session cache",
+			change: func(transport *http.Transport) {
+				transport.TLSClientConfig.ClientSessionCache = tls.NewLRUClientSessionCache(1)
+			},
+			want: "session caches",
+		},
+		{
+			name: "configured proxy",
+			change: func(transport *http.Transport) {
+				transport.Proxy = http.ProxyURL(&url.URL{Scheme: "http", Host: "proxy.example.test"})
+			},
+			want: "direct connections",
+		},
+		{
+			name:   "disabled certificate verification",
+			change: func(transport *http.Transport) { transport.TLSClientConfig.InsecureSkipVerify = true },
+			want:   "hostname verification",
+		},
+		{
+			name:   "fixed TLS server name",
+			change: func(transport *http.Transport) { transport.TLSClientConfig.ServerName = x509TransportIssuer },
+			want:   "TLS server name",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			transport := fixture.transport(t, nil)
+			test.change(transport)
+			capability, err := auth.NewX509Transport(transport)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("NewX509Transport error = %v, want %q", err, test.want)
+			}
+			if capability != nil {
+				t.Error("invalid transport returned a non-nil capability")
+			}
+		})
+	}
+
+	t.Run("nil native transport", func(t *testing.T) {
+		if capability, err := auth.NewX509Transport(nil); err == nil || capability != nil {
+			t.Fatalf("NewX509Transport(nil) = %v, %v; want nil capability and error", capability, err)
+		}
+	})
+}
+
+func TestX509TransportAttestationDetectsUnsafeMutations(t *testing.T) {
+	fixture := newX509TransportFixture(t)
+	tests := []struct {
+		name   string
+		change func(*http.Transport)
+	}{
+		{
+			name:   "replace TLS configuration",
+			change: func(transport *http.Transport) { transport.TLSClientConfig = transport.TLSClientConfig.Clone() },
+		},
+		{
+			name: "install dynamic certificate callback",
+			change: func(transport *http.Transport) {
+				transport.TLSClientConfig.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+					return &fixture.client, nil
+				}
+			},
+		},
+		{
+			name: "install TLS session cache",
+			change: func(transport *http.Transport) {
+				transport.TLSClientConfig.ClientSessionCache = tls.NewLRUClientSessionCache(1)
+			},
+		},
+		{
+			name: "install proxy",
+			change: func(transport *http.Transport) {
+				transport.Proxy = http.ProxyURL(&url.URL{Scheme: "https", Host: "proxy.example.test"})
+			},
+		},
+		{
+			name: "install custom TLS dialer",
+			change: func(transport *http.Transport) {
+				transport.DialTLSContext = func(context.Context, string, string) (net.Conn, error) {
+					return nil, errors.New("synthetic TLS dialer")
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			transport := fixture.transport(t, nil)
+			capability, err := auth.NewX509Transport(transport)
+			if err != nil {
+				t.Fatalf("create initial capability: %v", err)
+			}
+			test.change(transport)
+			request := x509TransportRequest(t, http.MethodGet, "https://"+x509TransportAPI+"/v1/models")
+			_ = x509Rejected(t, capability, request)
+		})
+	}
+}
+
+func TestX509TransportRejectsUnsafeOriginsBeforeDial(t *testing.T) {
+	fixture := newX509TransportFixture(t)
+	tests := []struct {
+		name   string
+		method string
+		target string
+		change func(*http.Request)
+	}{
+		{name: "plaintext API", method: http.MethodGet, target: "http://" + x509TransportAPI + "/v1/models"},
+		{name: "unapproved API host", method: http.MethodGet, target: "https://api.openai.com/v1/models"},
+		{name: "lookalike host", method: http.MethodGet, target: "https://mtls.api.openai.com.attacker.test/v1/models"},
+		{name: "Azure host", method: http.MethodGet, target: "https://resource.openai.azure.com/v1/models"},
+		{name: "URL user credentials", method: http.MethodGet, target: "https://user:password@" + x509TransportAPI + "/v1/models"},
+		{name: "nondefault API port", method: http.MethodGet, target: "https://" + x509TransportAPI + ":444/v1/models"},
+		{name: "URL fragment", method: http.MethodGet, target: "https://" + x509TransportAPI + "/v1/models#private"},
+		{name: "outside API version", method: http.MethodGet, target: "https://" + x509TransportAPI + "/v2/models"},
+		{name: "API path traversal", method: http.MethodGet, target: "https://" + x509TransportAPI + "/v1/../private"},
+		{name: "encoded API traversal", method: http.MethodGet, target: "https://" + x509TransportAPI + "/v1/%2e%2e/private"},
+		{name: "wrong exchange method", method: http.MethodGet, target: "https://" + x509TransportIssuer + "/oauth/token"},
+		{name: "wrong exchange path", method: http.MethodPost, target: "https://" + x509TransportIssuer + "/oauth/other"},
+		{name: "encoded exchange path", method: http.MethodPost, target: "https://" + x509TransportIssuer + "/oauth/%74oken"},
+		{name: "exchange query", method: http.MethodPost, target: "https://" + x509TransportIssuer + "/oauth/token?audience=unsafe"},
+		{
+			name:   "mismatched Host authority",
+			method: http.MethodGet,
+			target: "https://" + x509TransportAPI + "/v1/models",
+			change: func(request *http.Request) { request.Host = "attacker.example.test" },
+		},
+		{
+			name:   "URL opaque authority",
+			method: http.MethodGet,
+			target: "https://" + x509TransportAPI + "/v1/models",
+			change: func(request *http.Request) { request.URL.Opaque = "//attacker.example.test/v1/models" },
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var dials atomic.Int32
+			transport := fixture.transport(t, nil)
+			transport.DialContext = func(context.Context, string, string) (net.Conn, error) {
+				dials.Add(1)
+				return nil, errors.New("unexpected network dial")
+			}
+			capability := newX509Capability(t, transport)
+			request := x509TransportRequest(t, test.method, test.target)
+			if test.change != nil {
+				test.change(request)
+			}
+			_ = x509Rejected(t, capability, request)
+			if count := dials.Load(); count != 0 {
+				t.Errorf("unsafe request opened %d network connections", count)
+			}
+		})
+	}
+}
+
+func TestX509TransportRejectsUnsafeCredentialAliases(t *testing.T) {
+	fixture := newX509TransportFixture(t)
+	tests := []struct {
+		name   string
+		host   string
+		header string
+		values []string
+	}{
+		{name: "issuer bearer", host: x509TransportIssuer, header: "Authorization", values: []string{"Bearer synthetic"}},
+		{name: "issuer bearer alias", host: x509TransportIssuer, header: "aUtHoRiZaTiOn", values: []string{"Bearer synthetic"}},
+		{name: "issuer cookie", host: x509TransportIssuer, header: "Cookie", values: []string{"session=synthetic"}},
+		{name: "issuer Set-Cookie", host: x509TransportIssuer, header: "Set-Cookie", values: []string{"session=synthetic"}},
+		{name: "issuer API key", host: x509TransportIssuer, header: "Api-Key", values: []string{"synthetic"}},
+		{name: "issuer API key underscore", host: x509TransportIssuer, header: "API_KEY", values: []string{"synthetic"}},
+		{name: "issuer X API key", host: x509TransportIssuer, header: "X-Api-Key", values: []string{"synthetic"}},
+		{name: "issuer X API key underscore", host: x509TransportIssuer, header: "x_api_key", values: []string{"synthetic"}},
+		{name: "issuer proxy bearer", host: x509TransportIssuer, header: "Proxy-Authorization", values: []string{"Basic synthetic"}},
+		{name: "issuer proxy bearer underscore", host: x509TransportIssuer, header: "proxy_authorization", values: []string{"Basic synthetic"}},
+		{name: "issuer AWS credential", host: x509TransportIssuer, header: "X-Amz-Security-Token", values: []string{"synthetic"}},
+		{name: "issuer forged Host", host: x509TransportIssuer, header: "Host", values: []string{"attacker.test"}},
+		{name: "issuer pseudo authority", host: x509TransportIssuer, header: ":authority", values: []string{"attacker.test"}},
+		{name: "API API key", host: x509TransportAPI, header: "api_key", values: []string{"synthetic"}},
+		{name: "API proxy authorization", host: x509TransportAPI, header: "Proxy_Authorization", values: []string{"synthetic"}},
+		{name: "API cookie", host: x509TransportAPI, header: "Cookie", values: []string{"session=synthetic"}},
+		{name: "multiple API bearers", host: x509TransportAPI, header: "Authorization", values: []string{"Bearer one", "Bearer two"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			capability := newX509Capability(t, fixture.transport(t, nil))
+			method, requestPath := http.MethodPost, "/oauth/token"
+			if test.host == x509TransportAPI {
+				method, requestPath = http.MethodGet, "/v1/models"
+			}
+			request := x509TransportRequest(t, method, "https://"+test.host+requestPath)
+			request.Header[test.header] = test.values
+			_ = x509Rejected(t, capability, request)
+		})
+	}
+
+	t.Run("API bearer duplicated across differently cased keys", func(t *testing.T) {
+		capability := newX509Capability(t, fixture.transport(t, nil))
+		request := x509TransportRequest(t, http.MethodGet, "https://"+x509TransportAPI+"/v1/models")
+		request.Header["Authorization"] = []string{"Bearer first-synthetic-token"}
+		request.Header["authorization"] = []string{"Bearer second-synthetic-token"}
+		_ = x509Rejected(t, capability, request)
+	})
+}
+
+func TestX509TransportUsesCallerOwnedTransportAndRequestContext(t *testing.T) {
+	fixture := newX509TransportFixture(t)
+	type requestRecord struct {
+		host          string
+		path          string
+		serverName    string
+		peer          string
+		authorization string
+	}
+	var mu sync.Mutex
+	var received []requestRecord
+	server := fixture.server(t, http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		mu.Lock()
+		received = append(received, requestRecord{
+			host:          request.Host,
+			path:          request.URL.Path,
+			serverName:    request.TLS.ServerName,
+			peer:          request.TLS.PeerCertificates[0].Subject.CommonName,
+			authorization: request.Header.Get("Authorization"),
+		})
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	transport := fixture.transport(t, server)
+	config := transport.TLSClientConfig
+	type contextKey struct{}
+	var contextValues sync.Map
+	dialer := &net.Dialer{Timeout: 5 * time.Second}
+	transport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		contextValues.Store(address, ctx.Value(contextKey{}))
+		return dialer.DialContext(ctx, network, server.Listener.Addr().String())
+	}
+	capability := newX509Capability(t, transport)
+	if transport.TLSClientConfig != config || transport.Proxy != nil {
+		t.Fatal("creating an X.509 capability mutated its caller-owned transport")
+	}
+	if next := newX509Capability(t, transport); capability == next {
+		t.Error("separate attestations unexpectedly share a capability generation")
+	}
+
+	for _, test := range []struct {
+		host          string
+		method        string
+		path          string
+		authorization string
+	}{
+		{host: x509TransportIssuer, method: http.MethodPost, path: "/oauth/token"},
+		{host: x509TransportAPI, method: http.MethodGet, path: "/v1/models", authorization: "Bearer synthetic-access-token"},
+	} {
+		ctx := context.WithValue(t.Context(), contextKey{}, "caller-context-value")
+		request := x509TransportRequest(t, test.method, "https://"+test.host+test.path).WithContext(ctx)
+		if test.authorization != "" {
+			request.Header.Set("Authorization", test.authorization)
+		}
+		response, err := capability.Do(request)
+		if err != nil {
+			t.Fatalf("%s request: %v", test.host, err)
+		}
+		if err := response.Body.Close(); err != nil {
+			t.Fatalf("close %s response: %v", test.host, err)
+		}
+		if got, ok := contextValues.Load(test.host + ":443"); !ok || got != "caller-context-value" {
+			t.Errorf("%s dial context value = %v, want preserved caller context", test.host, got)
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(received) != 2 {
+		t.Fatalf("mTLS server received %d requests, want two", len(received))
+	}
+	for _, record := range received {
+		if record.host != record.serverName {
+			t.Errorf("request Host/SNI = %q/%q", record.host, record.serverName)
+		}
+		if record.peer != "static-workload" {
+			t.Errorf("request client certificate = %q, want static-workload", record.peer)
+		}
+	}
+	if received[0].authorization != "" || received[1].authorization != "Bearer synthetic-access-token" {
+		t.Errorf("issuer/API authorization = %q/%q", received[0].authorization, received[1].authorization)
+	}
+}
+
+func TestX509TransportRejectsRedirectsWithConcreteError(t *testing.T) {
+	for _, source := range []string{x509TransportIssuer, x509TransportAPI} {
+		t.Run(source, func(t *testing.T) {
+			fixture := newX509TransportFixture(t)
+			var requests atomic.Int32
+			server := fixture.server(t, http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+				requests.Add(1)
+				target := "https://" + x509TransportAPI + "/v1/capture"
+				if source == x509TransportAPI {
+					target = "https://" + x509TransportIssuer + "/oauth/token"
+				}
+				http.Redirect(w, request, target, http.StatusTemporaryRedirect)
+			}))
+			capability := newX509Capability(t, fixture.transport(t, server))
+			method, requestPath := http.MethodPost, "/oauth/token"
+			if source == x509TransportAPI {
+				method, requestPath = http.MethodGet, "/v1/models"
+			}
+			request := x509TransportRequest(t, method, "https://"+source+requestPath)
+			if source == x509TransportAPI {
+				request.Header.Set("Authorization", "Bearer synthetic-access-token")
+			}
+
+			err := x509Rejected(t, capability, request)
+			refused := errors.Unwrap(err)
+			if refused == nil || !strings.Contains(refused.Error(), "does not follow redirects") ||
+				!errors.Is(err, refused) {
+				t.Fatalf("redirect error = %v, want preserved concrete refusal error", err)
+			}
+			var unsafeURL *url.Error
+			if errors.As(err, &unsafeURL) {
+				t.Error("redirect error retained an unsafe native URL error")
+			}
+			if errors.Is(err, http.ErrUseLastResponse) {
+				t.Error("redirect refusal incorrectly used http.ErrUseLastResponse")
+			}
+			if count := requests.Load(); count != 1 {
+				t.Errorf("redirect chain received %d requests, want only the original", count)
+			}
+		})
+	}
+}
+
+func TestX509TransportRedactsNativeTransportFailures(t *testing.T) {
+	fixture := newX509TransportFixture(t)
+	transport := fixture.transport(t, nil)
+	sensitiveCause := errors.New("Authorization: Bearer synthetic-private-transport-token")
+	transport.DialContext = func(context.Context, string, string) (net.Conn, error) {
+		return nil, sensitiveCause
+	}
+	capability := newX509Capability(t, transport)
+	request := x509TransportRequest(
+		t,
+		http.MethodGet,
+		"https://"+x509TransportAPI+"/v1/models?signature=synthetic-private-url-token",
+	)
+
+	err := x509Rejected(t, capability, request)
+	if errors.Is(err, sensitiveCause) {
+		t.Fatal("native transport error retained its sensitive underlying cause")
+	}
+	for cause := err; cause != nil; cause = errors.Unwrap(cause) {
+		if strings.Contains(cause.Error(), "synthetic-private-transport-token") ||
+			strings.Contains(cause.Error(), "synthetic-private-url-token") || strings.Contains(cause.Error(), "Authorization") {
+			t.Errorf("transport error chain disclosed sensitive native details: %q", cause.Error())
+		}
+	}
+	var unsafeURL *url.Error
+	if errors.As(err, &unsafeURL) {
+		t.Error("redacted transport error retained an unsafe native URL error")
+	}
+}
+
+func TestX509TransportRejectsInvalidCapabilitiesAndCanceledRequests(t *testing.T) {
+	fixture := newX509TransportFixture(t)
+	request := x509TransportRequest(t, http.MethodGet, "https://"+x509TransportAPI+"/v1/models")
+
+	var nilCapability *auth.X509Transport
+	_ = x509Rejected(t, nilCapability, request)
+	var forged auth.X509Transport
+	_ = x509Rejected(t, &forged, request)
+	capability := newX509Capability(t, fixture.transport(t, nil))
+	_ = x509Rejected(t, capability, nil)
+	withoutURL := request.Clone(request.Context())
+	withoutURL.URL = nil
+	_ = x509Rejected(t, capability, withoutURL)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	if err := x509Rejected(t, capability, request.WithContext(ctx)); !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled request error = %v, want context.Canceled", err)
+	}
+}
+
+func x509Rejected(t *testing.T, capability *auth.X509Transport, request *http.Request) error {
+	t.Helper()
+	response, err := capability.Do(request)
+	if response != nil {
+		if closeErr := response.Body.Close(); closeErr != nil {
+			t.Fatalf("close unexpected X.509 response: %v", closeErr)
+		}
+		t.Fatalf("rejected X.509 request returned an unexpected response: %v", response.Status)
+	}
+	if err == nil {
+		t.Fatal("unsafe X.509 request unexpectedly succeeded")
+	}
+	return err
+}
+
+func newX509Capability(t *testing.T, transport *http.Transport) *auth.X509Transport {
+	t.Helper()
+	capability, err := auth.NewX509Transport(transport)
+	if err != nil {
+		t.Fatalf("NewX509Transport: %v", err)
+	}
+	return capability
+}
+
+func x509TransportRequest(t *testing.T, method, target string) *http.Request {
+	t.Helper()
+	request, err := http.NewRequestWithContext(t.Context(), method, target, nil)
+	if err != nil {
+		t.Fatalf("create %s %s: %v", method, target, err)
+	}
+	return request
+}
+
+type x509TransportFixture struct {
+	root    *x509.Certificate
+	rootKey *ecdsa.PrivateKey
+	trust   *x509.CertPool
+	client  tls.Certificate
+}
+
+func newX509TransportFixture(t *testing.T) *x509TransportFixture {
+	t.Helper()
+	rootKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate ephemeral root key: %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "synthetic X.509 transport root"},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	encoded, err := x509.CreateCertificate(rand.Reader, template, template, &rootKey.PublicKey, rootKey)
+	if err != nil {
+		t.Fatalf("issue ephemeral root certificate: %v", err)
+	}
+	root, err := x509.ParseCertificate(encoded)
+	if err != nil {
+		t.Fatalf("parse ephemeral root certificate: %v", err)
+	}
+	fixture := &x509TransportFixture{root: root, rootKey: rootKey, trust: x509.NewCertPool()}
+	fixture.trust.AddCert(root)
+	fixture.client = fixture.certificate(t, "static-workload", nil, true)
+	return fixture
+}
+
+func (fixture *x509TransportFixture) certificate(t *testing.T, name string, hostnames []string, client bool) tls.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate ephemeral %q key: %v", name, err)
+	}
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		t.Fatalf("generate ephemeral %q serial: %v", name, err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: name},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		DNSNames:     hostnames,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	if client {
+		template.DNSNames = []string{name + ".workload.example.test"}
+		template.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+	}
+	encoded, err := x509.CreateCertificate(rand.Reader, template, fixture.root, &key.PublicKey, fixture.rootKey)
+	if err != nil {
+		t.Fatalf("issue ephemeral %q certificate: %v", name, err)
+	}
+	certificate, err := x509.ParseCertificate(encoded)
+	if err != nil {
+		t.Fatalf("parse ephemeral %q certificate: %v", name, err)
+	}
+	return tls.Certificate{Certificate: [][]byte{encoded}, PrivateKey: key, Leaf: certificate}
+}
+
+func (fixture *x509TransportFixture) transport(t *testing.T, server *httptest.Server) *http.Transport {
+	t.Helper()
+	certificate := fixture.client
+	certificate.Certificate = append([][]byte(nil), certificate.Certificate...)
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			MinVersion:   tls.VersionTLS12,
+			RootCAs:      fixture.trust,
+			Certificates: []tls.Certificate{certificate},
+		},
+	}
+	if server != nil {
+		dialer := &net.Dialer{Timeout: 5 * time.Second}
+		transport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+			if address != x509TransportIssuer+":443" && address != x509TransportAPI+":443" {
+				return nil, fmt.Errorf("unexpected hermetic X.509 address %q", address)
+			}
+			return dialer.DialContext(ctx, network, server.Listener.Addr().String())
+		}
+	}
+	t.Cleanup(transport.CloseIdleConnections)
+	return transport
+}
+
+func (fixture *x509TransportFixture) server(t *testing.T, handler http.Handler) *httptest.Server {
+	t.Helper()
+	server := httptest.NewUnstartedServer(handler)
+	server.TLS = &tls.Config{
+		MinVersion:   tls.VersionTLS12,
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    fixture.trust,
+		Certificates: []tls.Certificate{fixture.certificate(t, "synthetic server", []string{x509TransportIssuer, x509TransportAPI}, false)},
+	}
+	server.Config.ErrorLog = log.New(io.Discard, "", 0)
+	server.StartTLS()
+	t.Cleanup(server.Close)
+	return server
+}

--- a/auth/x509transport_test.go
+++ b/auth/x509transport_test.go
@@ -92,6 +92,48 @@ func TestNewX509TransportRequiresStaticNativeConfiguration(t *testing.T) {
 			want: "dynamic client-certificate",
 		},
 		{
+			name: "TLS session key logger",
+			change: func(transport *http.Transport) {
+				transport.TLSClientConfig.KeyLogWriter = new(bytes.Buffer)
+			},
+			want: "session key logging",
+		},
+		{
+			name: "custom TLS randomness",
+			change: func(transport *http.Transport) {
+				transport.TLSClientConfig.Rand = strings.NewReader("synthetic-attacker-controlled-entropy")
+			},
+			want: "TLS randomness",
+		},
+		{
+			name: "custom TLS verification clock",
+			change: func(transport *http.Transport) {
+				transport.TLSClientConfig.Time = func() time.Time { return time.Unix(0, 0) }
+			},
+			want: "verification clock",
+		},
+		{
+			name: "legacy TLS minimum",
+			change: func(transport *http.Transport) {
+				transport.TLSClientConfig.MinVersion = tls.VersionTLS11
+			},
+			want: "version 1.2",
+		},
+		{
+			name: "legacy TLS maximum",
+			change: func(transport *http.Transport) {
+				transport.TLSClientConfig.MaxVersion = tls.VersionTLS11
+			},
+			want: "version 1.2",
+		},
+		{
+			name: "custom TLS application protocol",
+			change: func(transport *http.Transport) {
+				transport.TLSClientConfig.NextProtos = []string{"synthetic-attacker-protocol"}
+			},
+			want: "non-HTTP TLS application protocols",
+		},
+		{
 			name: "custom TLS context dialer",
 			change: func(transport *http.Transport) {
 				transport.DialTLSContext = func(context.Context, string, string) (net.Conn, error) {
@@ -210,6 +252,36 @@ func TestX509TransportAttestationDetectsUnsafeMutations(t *testing.T) {
 			name: "install TLS session cache",
 			change: func(transport *http.Transport) {
 				transport.TLSClientConfig.ClientSessionCache = tls.NewLRUClientSessionCache(1)
+			},
+		},
+		{
+			name: "install TLS session key logger",
+			change: func(transport *http.Transport) {
+				transport.TLSClientConfig.KeyLogWriter = new(bytes.Buffer)
+			},
+		},
+		{
+			name: "install custom TLS randomness",
+			change: func(transport *http.Transport) {
+				transport.TLSClientConfig.Rand = strings.NewReader("synthetic-attacker-controlled-entropy")
+			},
+		},
+		{
+			name: "install custom TLS verification clock",
+			change: func(transport *http.Transport) {
+				transport.TLSClientConfig.Time = func() time.Time { return time.Unix(0, 0) }
+			},
+		},
+		{
+			name: "lower TLS minimum",
+			change: func(transport *http.Transport) {
+				transport.TLSClientConfig.MinVersion = tls.VersionTLS11
+			},
+		},
+		{
+			name: "lower TLS maximum",
+			change: func(transport *http.Transport) {
+				transport.TLSClientConfig.MaxVersion = tls.VersionTLS11
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

Second of five focused Go X.509 workload-identity changes, stacked on #854. Introduces only the explicit, caller-attested native transport capability; OAuth exchange and OpenAI client integration remain separate PRs.

- Add `auth.NewX509Transport(*http.Transport) (*auth.X509Transport, error)` for one directly connected, static client-certificate generation.
- Treat the caller's transport as an immutable configuration template and construct a clean native adapter with a separate pool; private `RegisterProtocol("https", ...)` handlers and custom TLS protocol dispatchers cannot intercept authenticated traffic.
- Deep-copy certificate-chain bytes and trusted roots, retain caller ownership of the private signer, and detect identity rotation with an opaque, unexported certificate-generation digest.
- Restrict requests to the exact global OpenAI mTLS issuer/API authorities, reject redirects, custom TLS dialers, proxies, session caches, HTTP traces, request trailers, ambiguous authorities, alternate credentials, and malformed bearer tokens.
- Preserve context cancellation, redact transport failures throughout the error chain, and expose bounded, idempotent capability-owned pool cleanup without mutating or closing the caller's transport.

The capability is a caller attestation and workload-isolation boundary; it does **not** claim that ordinary OAuth bearer tokens are cryptographically certificate-bound.

## Stack

1. #854 — real-wire transport conformance foundation.
2. This PR — explicit static transport capability.
3. Pinned X.509 OAuth exchange and strict protocol validation.
4. Minimal OpenAI HTTP authentication integration.
5. Credential lifecycle, compatibility, and documentation.

## Verification

- `go test ./...` — complete root module passes.
- `go test -race ./auth ./option ./azure ./bedrock` — authentication and provider compatibility passes.
- `go test -race -count=10 -run '^TestX509Transport' ./auth` — real mTLS and adversarial capability tests pass repeatedly.
- Repository-configured `golangci-lint run ./auth`, `go vet ./auth`, and `git diff --check` pass.
- Two independent immutable-diff reviews: no remaining findings after resolving all reproduced hidden-dispatcher, mutable-certificate, callback, trailer, and credential-policy bypasses.
- Exact-head Codex Security diff scan `e1e138fb-3d82-4c55-b1ad-0772813c4eac`: complete changed-file coverage and zero findings.
