### PR TITLE
feat(option): add attested X.509 workload identity authentication

### DIFF
--- a/auth/x509transport.go
+++ b/auth/x509transport.go
@@ -245,6 +245,9 @@ func validateX509TLSConfig(config *tls.Config) error {
 	if config.GetClientCertificate != nil {
 		return errors.New("X.509 transport does not support dynamic client-certificate callbacks")
 	}
+	if len(config.EncryptedClientHelloConfigList) != 0 || config.EncryptedClientHelloRejectionVerify != nil {
+		return errors.New("X.509 transport does not support encrypted client hello")
+	}
 	if config.KeyLogWriter != nil {
 		return errors.New("X.509 transport does not support TLS session key logging")
 	}

--- a/auth/x509transport_test.go
+++ b/auth/x509transport_test.go
@@ -99,6 +99,20 @@ func TestNewX509TransportRequiresStaticNativeConfiguration(t *testing.T) {
 			want: "session key logging",
 		},
 		{
+			name: "encrypted client hello configuration",
+			change: func(transport *http.Transport) {
+				transport.TLSClientConfig.EncryptedClientHelloConfigList = []byte("synthetic configuration")
+			},
+			want: "encrypted client hello",
+		},
+		{
+			name: "encrypted client hello callback",
+			change: func(transport *http.Transport) {
+				transport.TLSClientConfig.EncryptedClientHelloRejectionVerify = func(tls.ConnectionState) error { return nil }
+			},
+			want: "encrypted client hello",
+		},
+		{
 			name: "custom TLS randomness",
 			change: func(transport *http.Transport) {
 				transport.TLSClientConfig.Rand = strings.NewReader("synthetic-attacker-controlled-entropy")
@@ -252,6 +266,18 @@ func TestX509TransportAttestationDetectsUnsafeMutations(t *testing.T) {
 			name: "install TLS session cache",
 			change: func(transport *http.Transport) {
 				transport.TLSClientConfig.ClientSessionCache = tls.NewLRUClientSessionCache(1)
+			},
+		},
+		{
+			name: "install encrypted client hello configuration",
+			change: func(transport *http.Transport) {
+				transport.TLSClientConfig.EncryptedClientHelloConfigList = []byte("synthetic configuration")
+			},
+		},
+		{
+			name: "install encrypted client hello callback",
+			change: func(transport *http.Transport) {
+				transport.TLSClientConfig.EncryptedClientHelloRejectionVerify = func(tls.ConnectionState) error { return nil }
 			},
 		},
 		{

--- a/auth/x509workloadidentity.go
+++ b/auth/x509workloadidentity.go
@@ -1,0 +1,58 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+)
+
+// X509WorkloadIdentity configures an OpenAI workload authenticated with a
+// caller-owned X.509 certificate and an explicitly attested native transport.
+type X509WorkloadIdentity struct {
+	IdentityProviderID string
+	ServiceAccountID   string
+	RefreshBuffer      time.Duration
+	Transport          *X509Transport
+}
+
+// X509WorkloadIdentityAuth exchanges a static, attested X.509 workload identity
+// for an ordinary OpenAI bearer token.
+type X509WorkloadIdentityAuth struct {
+	config X509WorkloadIdentity
+}
+
+// NewX509WorkloadIdentityAuth validates and binds a workload identity to one
+// attested X.509 transport generation.
+func NewX509WorkloadIdentityAuth(config X509WorkloadIdentity) (*X509WorkloadIdentityAuth, error) {
+	if strings.TrimSpace(config.IdentityProviderID) == "" {
+		return nil, errors.New("X.509 workload identity requires an identity-provider ID")
+	}
+	if strings.TrimSpace(config.ServiceAccountID) == "" {
+		return nil, errors.New("X.509 workload identity requires a service-account ID")
+	}
+	if config.RefreshBuffer < 0 || config.RefreshBuffer >= x509MaximumTokenLifetime*time.Second {
+		return nil, errors.New("X.509 workload identity requires a non-negative refresh buffer shorter than one hour")
+	}
+	if err := config.Transport.validateAttestation(); err != nil {
+		return nil, err
+	}
+	return &X509WorkloadIdentityAuth{config: config}, nil
+}
+
+// GetToken exchanges the workload identity over its exact configured transport.
+// A different HTTP client or transport cannot be substituted.
+func (identity *X509WorkloadIdentityAuth) GetToken(ctx context.Context, doer HTTPDoer) (string, error) {
+	if identity == nil {
+		return "", errors.New("X.509 workload identity authentication is invalid")
+	}
+	transport, ok := doer.(*X509Transport)
+	if !ok || transport != identity.config.Transport {
+		return "", errors.New("X.509 workload identity requires its exact attested transport")
+	}
+	token, err := x509Exchange(ctx, transport, identity.config.IdentityProviderID, identity.config.ServiceAccountID)
+	if err != nil {
+		return "", err
+	}
+	return token.value, nil
+}

--- a/auth/x509workloadidentity_test.go
+++ b/auth/x509workloadidentity_test.go
@@ -1,0 +1,98 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestNewX509WorkloadIdentityAuthValidatesConfiguration(t *testing.T) {
+	fixture := newX509ExchangeFixture(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, x509ValidExchangeResponse())
+	}))
+	valid := X509WorkloadIdentity{
+		IdentityProviderID: "synthetic-identity-provider",
+		ServiceAccountID:   "synthetic-service-account",
+		Transport:          fixture.capability,
+	}
+	for _, test := range []struct {
+		name   string
+		change func(*X509WorkloadIdentity)
+	}{
+		{name: "missing identity provider", change: func(config *X509WorkloadIdentity) { config.IdentityProviderID = "" }},
+		{name: "blank identity provider", change: func(config *X509WorkloadIdentity) { config.IdentityProviderID = "  " }},
+		{name: "missing service account", change: func(config *X509WorkloadIdentity) { config.ServiceAccountID = "" }},
+		{name: "blank service account", change: func(config *X509WorkloadIdentity) { config.ServiceAccountID = "\t" }},
+		{name: "missing transport", change: func(config *X509WorkloadIdentity) { config.Transport = nil }},
+		{name: "negative refresh buffer", change: func(config *X509WorkloadIdentity) { config.RefreshBuffer = -time.Second }},
+		{name: "excessive refresh buffer", change: func(config *X509WorkloadIdentity) { config.RefreshBuffer = time.Hour }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			config := valid
+			test.change(&config)
+			identity, err := NewX509WorkloadIdentityAuth(config)
+			if identity != nil || err == nil {
+				t.Fatalf("invalid X.509 workload configuration returned identity=%v error=%v", identity, err)
+			}
+		})
+	}
+	if _, err := NewX509WorkloadIdentityAuth(valid); err != nil {
+		t.Fatalf("valid X.509 workload configuration: %v", err)
+	}
+}
+
+func TestX509WorkloadIdentityAuthExchangesOnlyOnItsAttestedTransport(t *testing.T) {
+	var exchanges atomic.Int32
+	fixture := newX509ExchangeFixture(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		exchanges.Add(1)
+		_, _ = io.WriteString(w, x509ValidExchangeResponse())
+	}))
+	identity, err := NewX509WorkloadIdentityAuth(X509WorkloadIdentity{
+		IdentityProviderID: "synthetic-identity-provider",
+		ServiceAccountID:   "synthetic-service-account",
+		Transport:          fixture.capability,
+	})
+	if err != nil {
+		t.Fatalf("construct X.509 workload identity: %v", err)
+	}
+	for range 2 {
+		token, tokenErr := identity.GetToken(t.Context(), fixture.capability)
+		if tokenErr != nil || token != x509ExchangeSyntheticToken {
+			t.Fatalf("exchange on attested transport token=%q error=%v", token, tokenErr)
+		}
+	}
+	if got := exchanges.Load(); got != 2 {
+		t.Errorf("pre-cache integration made %d exchanges, want one per GetToken call", got)
+	}
+	for _, doer := range []HTTPDoer{nil, http.DefaultClient} {
+		if token, tokenErr := identity.GetToken(t.Context(), doer); token != "" || tokenErr == nil {
+			t.Errorf("unattested HTTP client returned token=%q error=%v", token, tokenErr)
+		}
+	}
+	another, err := NewX509Transport(fixture.template)
+	if err != nil {
+		t.Fatalf("attest a separate certificate generation: %v", err)
+	}
+	t.Cleanup(func() { _ = another.Close() })
+	if token, tokenErr := identity.GetToken(t.Context(), another); token != "" || tokenErr == nil {
+		t.Errorf("different attested generation returned token=%q error=%v", token, tokenErr)
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	if token, tokenErr := identity.GetToken(ctx, fixture.capability); token != "" || !errors.Is(tokenErr, context.Canceled) {
+		t.Errorf("canceled X.509 exchange returned token=%q error=%v", token, tokenErr)
+	}
+	var invalid *X509WorkloadIdentityAuth
+	if token, tokenErr := invalid.GetToken(t.Context(), fixture.capability); token != "" ||
+		tokenErr == nil || !strings.Contains(tokenErr.Error(), "invalid") {
+		t.Errorf("nil X.509 identity returned token=%q error=%v", token, tokenErr)
+	}
+	if got := exchanges.Load(); got != 2 {
+		t.Errorf("rejected transports/cancellation caused unexpected exchanges: %d", got)
+	}
+}

--- a/bedrock/x509_workload_identity_test.go
+++ b/bedrock/x509_workload_identity_test.go
@@ -1,0 +1,76 @@
+package bedrock
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"math/big"
+	"net"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/openai/openai-go/v3/auth"
+	"github.com/openai/openai-go/v3/option"
+)
+
+func TestSkipAuthRejectsX509WorkloadIdentityBeforeNetwork(t *testing.T) {
+	t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate synthetic workload private key: %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	certificate, err := x509.CreateCertificate(rand.Reader, template, template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		t.Fatalf("issue synthetic workload certificate: %v", err)
+	}
+	var connections atomic.Int32
+	transport, err := auth.NewX509Transport(&http.Transport{
+		DialContext: func(context.Context, string, string) (net.Conn, error) {
+			connections.Add(1)
+			return nil, errors.New("unexpected synthetic workload connection")
+		},
+		TLSClientConfig: &tls.Config{
+			Certificates: []tls.Certificate{{Certificate: [][]byte{certificate}, PrivateKey: privateKey}},
+			MinVersion:   tls.VersionTLS12,
+		},
+	})
+	if err != nil {
+		t.Fatalf("attest synthetic workload transport: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := transport.Close(); closeErr != nil {
+			t.Errorf("close synthetic workload transport: %v", closeErr)
+		}
+	})
+
+	client, err := NewClient(t.Context(), Config{AWSRegion: "us-east-1", SkipAuth: true},
+		option.WithX509WorkloadIdentity(auth.X509WorkloadIdentity{
+			IdentityProviderID: "synthetic-identity-provider",
+			ServiceAccountID:   "synthetic-service-account",
+			Transport:          transport,
+		}),
+		option.WithMaxRetries(0),
+	)
+	if err == nil {
+		_, err = client.Models.List(t.Context())
+	}
+	if err == nil {
+		t.Fatal("Bedrock SkipAuth accepted an X.509 workload identity")
+	}
+	if got := connections.Load(); got != 0 {
+		t.Errorf("rejected workload identity attempted %d issuer or API connections", got)
+	}
+}

--- a/default_http_client.go
+++ b/default_http_client.go
@@ -3,6 +3,8 @@ package openai
 import (
 	"net/http"
 	"time"
+
+	"github.com/openai/openai-go/v3/internal/requestconfig"
 )
 
 // defaultResponseHeaderTimeout bounds the time between a fully written request
@@ -11,18 +13,19 @@ import (
 // the connection but never responds would hang the request indefinitely.
 const defaultResponseHeaderTimeout = 10 * time.Minute
 
-// defaultHTTPClient returns an [*http.Client] used when the caller does not
-// supply one via [option.WithHTTPClient]. When [http.DefaultTransport] is the
-// stdlib [*http.Transport], it is cloned and a [http.Transport.ResponseHeaderTimeout]
-// is set so stuck connections fail fast instead of compounding across retries.
+// defaultHTTPClient returns an internally marked [*http.Client] used when the
+// caller does not supply one via [option.WithHTTPClient]. When
+// [http.DefaultTransport] is the stdlib [*http.Transport], it is cloned and a
+// [http.Transport.ResponseHeaderTimeout] is set so stuck connections fail fast
+// instead of compounding across retries.
 // If [http.DefaultTransport] has been wrapped (for example by otelhttp for
 // distributed tracing), the wrapping is preserved and the header timeout is
 // skipped.
-func defaultHTTPClient() *http.Client {
+func defaultHTTPClient() *requestconfig.DefaultHTTPClient {
 	if t, ok := http.DefaultTransport.(*http.Transport); ok {
 		t = t.Clone()
 		t.ResponseHeaderTimeout = defaultResponseHeaderTimeout
-		return &http.Client{Transport: t}
+		return &requestconfig.DefaultHTTPClient{Client: &http.Client{Transport: t}}
 	}
-	return &http.Client{Transport: http.DefaultTransport}
+	return &requestconfig.DefaultHTTPClient{Client: &http.Client{Transport: http.DefaultTransport}}
 }

--- a/internal/requestconfig/option_layers.go
+++ b/internal/requestconfig/option_layers.go
@@ -15,8 +15,12 @@ type optionLayerIdentity byte
 
 type authenticationState struct {
 	currentLayer             *optionLayerIdentity
+	layerDepth               int
 	providerInCurrentLayer   *ProviderAuthOption
 	selectedProvider         *ProviderAuthOption
+	httpClientSelections     int
+	httpClientLayer          *optionLayerIdentity
+	httpClientNested         bool
 	apiKeyLayer              *optionLayerIdentity
 	adminAPIKeyLayer         *optionLayerIdentity
 	authorizationHeaderLayer *optionLayerIdentity
@@ -28,11 +32,14 @@ type authenticationState struct {
 
 func (state *authenticationState) enterLayer() func() {
 	previousLayer := state.currentLayer
+	previousDepth := state.layerDepth
 	previousProvider := state.providerInCurrentLayer
 	state.currentLayer = new(optionLayerIdentity)
+	state.layerDepth++
 	state.providerInCurrentLayer = nil
 	return func() {
 		state.currentLayer = previousLayer
+		state.layerDepth = previousDepth
 		state.providerInCurrentLayer = previousProvider
 	}
 }
@@ -160,6 +167,23 @@ func (cfg *RequestConfig) AuthorizationHeaderOverridden() bool {
 	return cfg.authentication.headerOverride || cfg.authentication.authorizationExplicit
 }
 
+// RecordHTTPClientSelection records the request-option provenance of a native
+// or custom HTTP client without inspecting or wrapping the caller-owned client.
+func (cfg *RequestConfig) RecordHTTPClientSelection() {
+	state := &cfg.authentication
+	state.httpClientSelections++
+	state.httpClientLayer = state.currentLayer
+	state.httpClientNested = state.layerDepth > 1
+}
+
+// HTTPClientExplicitlySelected distinguishes the generated client's one nested
+// default from explicit caller selections, including standalone services.
+func (cfg *RequestConfig) HTTPClientExplicitlySelected() bool {
+	state := &cfg.authentication
+	return state.httpClientSelections > 1 || state.httpClientSelections == 1 &&
+		(!state.httpClientNested || state.httpClientLayer == state.currentLayer)
+}
+
 // ProviderAuthOption identifies one provider authentication mode. Instances are
 // immutable and can be shared across concurrent requests.
 type ProviderAuthOption struct {
@@ -229,6 +253,7 @@ func (state *authenticationState) recordAdminAPIKey() {
 
 func (state authenticationState) cloneAsInherited(cfg *RequestConfig) authenticationState {
 	state.currentLayer = nil
+	state.layerDepth = 0
 	state.providerInCurrentLayer = nil
 	state.apiKeyLayer = nil
 	state.adminAPIKeyLayer = nil

--- a/internal/requestconfig/option_layers.go
+++ b/internal/requestconfig/option_layers.go
@@ -22,6 +22,7 @@ type authenticationState struct {
 	authorizationHeaderLayer *optionLayerIdentity
 	apiKeyHeaderLayer        *optionLayerIdentity
 	headerOverride           bool
+	authorizationExplicit    bool
 	preference               authCredentialPreference
 }
 
@@ -156,7 +157,7 @@ func (cfg *RequestConfig) EndpointProvider() string {
 // AuthorizationHeaderOverridden reports whether an explicit request option
 // selected or deleted the Authorization header.
 func (cfg *RequestConfig) AuthorizationHeaderOverridden() bool {
-	return cfg.authentication.headerOverride
+	return cfg.authentication.headerOverride || cfg.authentication.authorizationExplicit
 }
 
 // ProviderAuthOption identifies one provider authentication mode. Instances are
@@ -207,6 +208,7 @@ func (state *authenticationState) recordHeader(name string) {
 	switch {
 	case strings.EqualFold(name, "Authorization"):
 		state.headerOverride = true
+		state.authorizationExplicit = true
 		state.authorizationHeaderLayer = state.currentLayer
 	case strings.EqualFold(name, "Api-Key"):
 		state.apiKeyHeaderLayer = state.currentLayer
@@ -233,7 +235,8 @@ func (state authenticationState) cloneAsInherited(cfg *RequestConfig) authentica
 	state.authorizationHeaderLayer = nil
 	state.apiKeyHeaderLayer = nil
 
-	hasAuthorizationOverride := state.headerOverride || len(cfg.Request.Header.Values("Authorization")) != 0
+	hasAuthorizationOverride := state.headerOverride || state.authorizationExplicit ||
+		len(cfg.Request.Header.Values("Authorization")) != 0
 	hasAPIKeyHeader := len(cfg.Request.Header.Values("Api-Key")) != 0
 	if cfg.APIKey == "" && cfg.AdminAPIKey == "" && !hasAuthorizationOverride && !hasAPIKeyHeader {
 		return state
@@ -276,6 +279,7 @@ func (cfg *RequestConfig) ClearInheritedAuthentication() {
 		cfg.Request.Header.Del("Authorization")
 		state.authorizationHeaderLayer = nil
 		state.headerOverride = false
+		state.authorizationExplicit = false
 	}
 	if state.apiKeyHeaderLayer != state.currentLayer {
 		cfg.Request.Header.Del("Api-Key")

--- a/internal/requestconfig/option_layers.go
+++ b/internal/requestconfig/option_layers.go
@@ -153,6 +153,12 @@ func (cfg *RequestConfig) EndpointProvider() string {
 	return cfg.endpointProvider
 }
 
+// AuthorizationHeaderOverridden reports whether an explicit request option
+// selected or deleted the Authorization header.
+func (cfg *RequestConfig) AuthorizationHeaderOverridden() bool {
+	return cfg.authentication.headerOverride
+}
+
 // ProviderAuthOption identifies one provider authentication mode. Instances are
 // immutable and can be shared across concurrent requests.
 type ProviderAuthOption struct {

--- a/internal/requestconfig/option_layers.go
+++ b/internal/requestconfig/option_layers.go
@@ -147,6 +147,12 @@ func (cfg *RequestConfig) ProviderEndpointConfigured(provider string) bool {
 	return cfg.configuredProviderEndpoint == provider
 }
 
+// EndpointProvider reports the third-party provider associated with this
+// request's routing, including providers that intentionally skip authentication.
+func (cfg *RequestConfig) EndpointProvider() string {
+	return cfg.endpointProvider
+}
+
 // ProviderAuthOption identifies one provider authentication mode. Instances are
 // immutable and can be shared across concurrent requests.
 type ProviderAuthOption struct {

--- a/internal/requestconfig/option_layers.go
+++ b/internal/requestconfig/option_layers.go
@@ -2,6 +2,7 @@ package requestconfig
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"slices"
 	"strings"
@@ -15,12 +16,9 @@ type optionLayerIdentity byte
 
 type authenticationState struct {
 	currentLayer             *optionLayerIdentity
-	layerDepth               int
 	providerInCurrentLayer   *ProviderAuthOption
 	selectedProvider         *ProviderAuthOption
-	httpClientSelections     int
-	httpClientLayer          *optionLayerIdentity
-	httpClientNested         bool
+	httpClientExplicit       bool
 	apiKeyLayer              *optionLayerIdentity
 	adminAPIKeyLayer         *optionLayerIdentity
 	authorizationHeaderLayer *optionLayerIdentity
@@ -32,14 +30,11 @@ type authenticationState struct {
 
 func (state *authenticationState) enterLayer() func() {
 	previousLayer := state.currentLayer
-	previousDepth := state.layerDepth
 	previousProvider := state.providerInCurrentLayer
 	state.currentLayer = new(optionLayerIdentity)
-	state.layerDepth++
 	state.providerInCurrentLayer = nil
 	return func() {
 		state.currentLayer = previousLayer
-		state.layerDepth = previousDepth
 		state.providerInCurrentLayer = previousProvider
 	}
 }
@@ -167,21 +162,24 @@ func (cfg *RequestConfig) AuthorizationHeaderOverridden() bool {
 	return cfg.authentication.headerOverride || cfg.authentication.authorizationExplicit
 }
 
-// RecordHTTPClientSelection records the request-option provenance of a native
-// or custom HTTP client without inspecting or wrapping the caller-owned client.
-func (cfg *RequestConfig) RecordHTTPClientSelection() {
-	state := &cfg.authentication
-	state.httpClientSelections++
-	state.httpClientLayer = state.currentLayer
-	state.httpClientNested = state.layerDepth > 1
+// DefaultHTTPClient marks a native client created by the SDK's own defaults.
+// Applications outside the SDK cannot construct this internal marker.
+type DefaultHTTPClient struct {
+	*http.Client
 }
 
-// HTTPClientExplicitlySelected distinguishes the generated client's one nested
-// default from explicit caller selections, including standalone services.
+// RecordHTTPClientSelection records whether an HTTP client was explicitly
+// supplied. A trusted SDK default never clears an earlier explicit selection.
+func (cfg *RequestConfig) RecordHTTPClientSelection(trustedDefault bool) {
+	if !trustedDefault {
+		cfg.authentication.httpClientExplicit = true
+	}
+}
+
+// HTTPClientExplicitlySelected reports whether any caller supplied a native or
+// custom client, regardless of option-layer nesting or later SDK defaults.
 func (cfg *RequestConfig) HTTPClientExplicitlySelected() bool {
-	state := &cfg.authentication
-	return state.httpClientSelections > 1 || state.httpClientSelections == 1 &&
-		(!state.httpClientNested || state.httpClientLayer == state.currentLayer)
+	return cfg.authentication.httpClientExplicit
 }
 
 // ProviderAuthOption identifies one provider authentication mode. Instances are
@@ -253,7 +251,6 @@ func (state *authenticationState) recordAdminAPIKey() {
 
 func (state authenticationState) cloneAsInherited(cfg *RequestConfig) authenticationState {
 	state.currentLayer = nil
-	state.layerDepth = 0
 	state.providerInCurrentLayer = nil
 	state.apiKeyLayer = nil
 	state.adminAPIKeyLayer = nil

--- a/internal/requestconfig/option_layers_test.go
+++ b/internal/requestconfig/option_layers_test.go
@@ -92,6 +92,22 @@ func TestEnvironmentDefaultsDisabledWrapperPreservesOptionBehavior(t *testing.T)
 	}
 }
 
+func TestEndpointProviderReportsProviderRouting(t *testing.T) {
+	for _, provider := range []string{"", "Azure", "Bedrock"} {
+		t.Run(provider, func(t *testing.T) {
+			cfg := RequestConfig{}
+			if provider != "" {
+				if err := WithEndpointProvider(provider).Apply(&cfg); err != nil {
+					t.Fatalf("configure provider routing: %v", err)
+				}
+			}
+			if got := cfg.EndpointProvider(); got != provider {
+				t.Errorf("endpoint provider = %q, want %q", got, provider)
+			}
+		})
+	}
+}
+
 func TestProviderAuthOptionsPreserveConfigurationLayers(t *testing.T) {
 	apiKey := NewProviderAuthOption("Azure", "azure.WithAPIKey")
 	secondAPIKey := NewProviderAuthOption("Azure", "azure.WithAPIKey")

--- a/internal/requestconfig/option_layers_test.go
+++ b/internal/requestconfig/option_layers_test.go
@@ -121,6 +121,33 @@ func TestAuthorizationHeaderOverriddenPreservesExplicitDeletion(t *testing.T) {
 	if !cfg.AuthorizationHeaderOverridden() || len(cfg.Request.Header.Values("Authorization")) != 0 {
 		t.Error("explicit header deletion was not preserved as an Authorization override")
 	}
+	for _, test := range []struct {
+		name string
+		set  func(*RequestConfig)
+	}{
+		{name: "empty API key", set: func(config *RequestConfig) { config.SetAPIKey("") }},
+		{name: "empty admin API key", set: func(config *RequestConfig) { config.SetAdminAPIKey("") }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			current := RequestConfig{Request: request.Clone(request.Context())}
+			current.DelHeader("Authorization")
+			test.set(&current)
+			if current.authentication.headerOverride || current.authentication.authorizationHeaderLayer != nil {
+				t.Error("negative control did not erase the ordinary override and nil-layer marker")
+			}
+			if !current.AuthorizationHeaderOverridden() {
+				t.Error("empty credential selection erased explicit headerless-request provenance")
+			}
+			cloned := current.Clone(request.Context())
+			if cloned == nil || !cloned.AuthorizationHeaderOverridden() {
+				t.Fatal("request clone lost explicit headerless-request provenance")
+			}
+			cloned.ClearInheritedAuthentication()
+			if cloned.AuthorizationHeaderOverridden() {
+				t.Error("request clone did not clear inherited headerless-request provenance")
+			}
+		})
+	}
 	inherited := RequestConfig{Request: request.Clone(request.Context())}
 	if err := inherited.Apply(InheritedOptions(RequestOptionFunc(func(config *RequestConfig) error {
 		config.DelHeader("Authorization")

--- a/internal/requestconfig/option_layers_test.go
+++ b/internal/requestconfig/option_layers_test.go
@@ -162,8 +162,12 @@ func TestAuthorizationHeaderOverriddenPreservesExplicitDeletion(t *testing.T) {
 }
 
 func TestHTTPClientSelectionProvenanceDistinguishesDefaultsAndOverrides(t *testing.T) {
-	record := RequestOptionFunc(func(cfg *RequestConfig) error {
-		cfg.RecordHTTPClientSelection()
+	trusted := RequestOptionFunc(func(cfg *RequestConfig) error {
+		cfg.RecordHTTPClientSelection(true)
+		return nil
+	})
+	explicit := RequestOptionFunc(func(cfg *RequestConfig) error {
+		cfg.RecordHTTPClientSelection(false)
 		return nil
 	})
 	t.Run("implicit native default", func(t *testing.T) {
@@ -172,44 +176,49 @@ func TestHTTPClientSelectionProvenanceDistinguishesDefaultsAndOverrides(t *testi
 			t.Error("unselected implicit native HTTP client was classified as explicit")
 		}
 	})
-	t.Run("nested generated default", func(t *testing.T) {
+	t.Run("marked generated default", func(t *testing.T) {
 		cfg := RequestConfig{}
-		if err := cfg.Apply(InheritedOptions(InheritedOptions(record)...)...); err != nil {
-			t.Fatalf("apply nested generated HTTP client default: %v", err)
+		if err := cfg.Apply(InheritedOptions(InheritedOptions(trusted)...)...); err != nil {
+			t.Fatalf("apply marked generated HTTP client default: %v", err)
 		}
 		if cfg.HTTPClientExplicitlySelected() {
-			t.Error("one nested generated HTTP client default was classified as explicit")
+			t.Error("marked generated HTTP client default was classified as explicit")
 		}
 	})
 	t.Run("standalone inherited custom client", func(t *testing.T) {
 		cfg := RequestConfig{}
-		if err := cfg.Apply(InheritedOptions(record)...); err != nil {
+		if err := cfg.Apply(InheritedOptions(explicit)...); err != nil {
 			t.Fatalf("apply standalone inherited custom HTTP client: %v", err)
 		}
 		if !cfg.HTTPClientExplicitlySelected() {
 			t.Error("standalone inherited custom HTTP client lost its explicit provenance")
 		}
 	})
-	t.Run("same nested layer", func(t *testing.T) {
+	t.Run("arbitrarily nested custom client", func(t *testing.T) {
 		cfg := RequestConfig{}
-		check := RequestOptionFunc(func(current *RequestConfig) error {
-			if !current.HTTPClientExplicitlySelected() {
-				t.Error("same-layer custom HTTP client was classified as an inherited default")
-			}
-			return nil
-		})
-		if err := cfg.Apply(InheritedOptions(InheritedOptions(record, check)...)...); err != nil {
-			t.Fatalf("apply same-layer custom HTTP client: %v", err)
+		if err := cfg.Apply(InheritedOptions(InheritedOptions(InheritedOptions(explicit)...)...)...); err != nil {
+			t.Fatalf("apply arbitrarily nested custom HTTP client: %v", err)
+		}
+		if !cfg.HTTPClientExplicitlySelected() {
+			t.Error("nested custom HTTP client was misclassified as a trusted SDK default")
 		}
 	})
-	t.Run("explicit override after nested default", func(t *testing.T) {
+	t.Run("explicit override after marked default", func(t *testing.T) {
 		cfg := RequestConfig{}
-		if err := cfg.Apply(InheritedOptions(InheritedOptions(record)...)...); err != nil {
-			t.Fatalf("apply nested HTTP client default: %v", err)
+		if err := cfg.Apply(InheritedOptions(trusted)...); err != nil {
+			t.Fatalf("apply marked HTTP client default: %v", err)
 		}
-		cfg.RecordHTTPClientSelection()
+		cfg.RecordHTTPClientSelection(false)
 		if !cfg.HTTPClientExplicitlySelected() {
-			t.Error("second HTTP client selection was not classified as explicit")
+			t.Error("HTTP client override was not classified as explicit")
+		}
+	})
+	t.Run("later default cannot erase explicit client", func(t *testing.T) {
+		cfg := RequestConfig{}
+		cfg.RecordHTTPClientSelection(false)
+		cfg.RecordHTTPClientSelection(true)
+		if !cfg.HTTPClientExplicitlySelected() {
+			t.Error("later trusted default erased explicit HTTP client provenance")
 		}
 	})
 	t.Run("clone preserves custom-client provenance", func(t *testing.T) {
@@ -218,7 +227,7 @@ func TestHTTPClientSelectionProvenanceDistinguishesDefaultsAndOverrides(t *testi
 			t.Fatalf("construct clone provenance request: %v", err)
 		}
 		cfg := RequestConfig{Request: request}
-		cfg.RecordHTTPClientSelection()
+		cfg.RecordHTTPClientSelection(false)
 		cloned := cfg.Clone(t.Context())
 		if cloned == nil || !cloned.HTTPClientExplicitlySelected() {
 			t.Fatal("request clone lost explicit HTTP client selection provenance")

--- a/internal/requestconfig/option_layers_test.go
+++ b/internal/requestconfig/option_layers_test.go
@@ -108,6 +108,32 @@ func TestEndpointProviderReportsProviderRouting(t *testing.T) {
 	}
 }
 
+func TestAuthorizationHeaderOverriddenPreservesExplicitDeletion(t *testing.T) {
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://example.com", nil)
+	if err != nil {
+		t.Fatalf("construct synthetic request: %v", err)
+	}
+	cfg := RequestConfig{Request: request}
+	if cfg.AuthorizationHeaderOverridden() {
+		t.Error("unmodified request unexpectedly has an explicit Authorization override")
+	}
+	cfg.DelHeader("Authorization")
+	if !cfg.AuthorizationHeaderOverridden() || len(cfg.Request.Header.Values("Authorization")) != 0 {
+		t.Error("explicit header deletion was not preserved as an Authorization override")
+	}
+	inherited := RequestConfig{Request: request.Clone(request.Context())}
+	if err := inherited.Apply(InheritedOptions(RequestOptionFunc(func(config *RequestConfig) error {
+		config.DelHeader("Authorization")
+		return nil
+	}))...); err != nil {
+		t.Fatalf("configure inherited Authorization override: %v", err)
+	}
+	inherited.ClearInheritedAuthentication()
+	if inherited.AuthorizationHeaderOverridden() {
+		t.Error("inherited Authorization override was not cleared")
+	}
+}
+
 func TestProviderAuthOptionsPreserveConfigurationLayers(t *testing.T) {
 	apiKey := NewProviderAuthOption("Azure", "azure.WithAPIKey")
 	secondAPIKey := NewProviderAuthOption("Azure", "azure.WithAPIKey")

--- a/internal/requestconfig/option_layers_test.go
+++ b/internal/requestconfig/option_layers_test.go
@@ -161,6 +161,71 @@ func TestAuthorizationHeaderOverriddenPreservesExplicitDeletion(t *testing.T) {
 	}
 }
 
+func TestHTTPClientSelectionProvenanceDistinguishesDefaultsAndOverrides(t *testing.T) {
+	record := RequestOptionFunc(func(cfg *RequestConfig) error {
+		cfg.RecordHTTPClientSelection()
+		return nil
+	})
+	t.Run("implicit native default", func(t *testing.T) {
+		cfg := RequestConfig{}
+		if cfg.HTTPClientExplicitlySelected() {
+			t.Error("unselected implicit native HTTP client was classified as explicit")
+		}
+	})
+	t.Run("nested generated default", func(t *testing.T) {
+		cfg := RequestConfig{}
+		if err := cfg.Apply(InheritedOptions(InheritedOptions(record)...)...); err != nil {
+			t.Fatalf("apply nested generated HTTP client default: %v", err)
+		}
+		if cfg.HTTPClientExplicitlySelected() {
+			t.Error("one nested generated HTTP client default was classified as explicit")
+		}
+	})
+	t.Run("standalone inherited custom client", func(t *testing.T) {
+		cfg := RequestConfig{}
+		if err := cfg.Apply(InheritedOptions(record)...); err != nil {
+			t.Fatalf("apply standalone inherited custom HTTP client: %v", err)
+		}
+		if !cfg.HTTPClientExplicitlySelected() {
+			t.Error("standalone inherited custom HTTP client lost its explicit provenance")
+		}
+	})
+	t.Run("same nested layer", func(t *testing.T) {
+		cfg := RequestConfig{}
+		check := RequestOptionFunc(func(current *RequestConfig) error {
+			if !current.HTTPClientExplicitlySelected() {
+				t.Error("same-layer custom HTTP client was classified as an inherited default")
+			}
+			return nil
+		})
+		if err := cfg.Apply(InheritedOptions(InheritedOptions(record, check)...)...); err != nil {
+			t.Fatalf("apply same-layer custom HTTP client: %v", err)
+		}
+	})
+	t.Run("explicit override after nested default", func(t *testing.T) {
+		cfg := RequestConfig{}
+		if err := cfg.Apply(InheritedOptions(InheritedOptions(record)...)...); err != nil {
+			t.Fatalf("apply nested HTTP client default: %v", err)
+		}
+		cfg.RecordHTTPClientSelection()
+		if !cfg.HTTPClientExplicitlySelected() {
+			t.Error("second HTTP client selection was not classified as explicit")
+		}
+	})
+	t.Run("clone preserves custom-client provenance", func(t *testing.T) {
+		request, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://example.com", nil)
+		if err != nil {
+			t.Fatalf("construct clone provenance request: %v", err)
+		}
+		cfg := RequestConfig{Request: request}
+		cfg.RecordHTTPClientSelection()
+		cloned := cfg.Clone(t.Context())
+		if cloned == nil || !cloned.HTTPClientExplicitlySelected() {
+			t.Fatal("request clone lost explicit HTTP client selection provenance")
+		}
+	})
+}
+
 func TestProviderAuthOptionsPreserveConfigurationLayers(t *testing.T) {
 	apiKey := NewProviderAuthOption("Azure", "azure.WithAPIKey")
 	secondAPIKey := NewProviderAuthOption("Azure", "azure.WithAPIKey")

--- a/option/requestoption.go
+++ b/option/requestoption.go
@@ -63,12 +63,23 @@ func WithHTTPClient(client HTTPClient) RequestOption {
 			return fmt.Errorf("requestoption: custom http client cannot be nil")
 		}
 
-		r.RecordHTTPClientSelection()
-		if c, ok := client.(*http.Client); ok {
-			// Prefer the native client if possible.
-			r.HTTPClient = c
+		switch selected := client.(type) {
+		case *requestconfig.DefaultHTTPClient:
+			if selected == nil || selected.Client == nil {
+				return fmt.Errorf("requestoption: custom http client cannot be nil")
+			}
+			r.RecordHTTPClientSelection(true)
+			r.HTTPClient = selected.Client
 			r.CustomHTTPDoer = nil
-		} else {
+		case *http.Client:
+			if selected == nil {
+				return fmt.Errorf("requestoption: custom http client cannot be nil")
+			}
+			r.RecordHTTPClientSelection(false)
+			r.HTTPClient = selected
+			r.CustomHTTPDoer = nil
+		default:
+			r.RecordHTTPClientSelection(false)
 			r.CustomHTTPDoer = client
 		}
 

--- a/option/requestoption.go
+++ b/option/requestoption.go
@@ -63,6 +63,7 @@ func WithHTTPClient(client HTTPClient) RequestOption {
 			return fmt.Errorf("requestoption: custom http client cannot be nil")
 		}
 
+		r.RecordHTTPClientSelection()
 		if c, ok := client.(*http.Client); ok {
 			// Prefer the native client if possible.
 			r.HTTPClient = c

--- a/option/x509workloadidentity.go
+++ b/option/x509workloadidentity.go
@@ -28,9 +28,6 @@ func WithX509WorkloadIdentity(config auth.X509WorkloadIdentity) RequestOption {
 			return err
 		}
 		cfg.ClearInheritedAuthentication()
-		if err := requestconfig.WithDefaultBaseURL(x509WorkloadAPIBaseURL).Apply(cfg); err != nil {
-			return err
-		}
 		return requestconfig.WithRequestFinalizer(func(final *requestconfig.RequestConfig) error {
 			if !selected.Selected(final) {
 				return nil

--- a/option/x509workloadidentity.go
+++ b/option/x509workloadidentity.go
@@ -24,15 +24,6 @@ func WithX509WorkloadIdentity(config auth.X509WorkloadIdentity) RequestOption {
 	var initializationError error
 
 	return requestconfig.RequestOptionFunc(func(cfg *requestconfig.RequestConfig) error {
-		initialize.Do(func() {
-			identity, initializationError = auth.NewX509WorkloadIdentityAuth(config)
-		})
-		if initializationError != nil {
-			return initializationError
-		}
-		if cfg.HTTPClient == nil || cfg.CustomHTTPDoer != nil {
-			return errors.New("X.509 workload identity requires its attested transport without custom HTTP clients")
-		}
 		if err := selected.Apply(cfg); err != nil {
 			return err
 		}
@@ -41,10 +32,14 @@ func WithX509WorkloadIdentity(config auth.X509WorkloadIdentity) RequestOption {
 			return err
 		}
 		originalHTTPClient := cfg.HTTPClient
-		cfg.CustomHTTPDoer = config.Transport
+		customHTTPClient := cfg.HTTPClientExplicitlySelected()
 		return requestconfig.WithRequestFinalizer(func(final *requestconfig.RequestConfig) error {
 			if !selected.Selected(final) {
 				return nil
+			}
+			if final.HTTPClient == nil || final.HTTPClient != originalHTTPClient || final.CustomHTTPDoer != nil ||
+				customHTTPClient || final.HTTPClientExplicitlySelected() {
+				return errors.New("X.509 workload identity requires its attested transport without custom HTTP clients")
 			}
 			if final.EndpointProvider() != "" {
 				return errors.New("X.509 workload identity cannot be combined with another API provider")
@@ -52,12 +47,12 @@ func WithX509WorkloadIdentity(config auth.X509WorkloadIdentity) RequestOption {
 			if !final.Security.BearerAuth {
 				return errors.New("X.509 workload identity cannot authenticate an admin-only API operation")
 			}
+			if final.Request == nil || final.Request.Header == nil {
+				return errors.New("X.509 workload identity requires a non-nil request and header map")
+			}
 			if final.APIKey != "" || final.AdminAPIKey != "" || final.AuthorizationHeaderOverridden() ||
 				unsafeX509CredentialHeaders(final.Request.Header) {
 				return errors.New("X.509 workload identity cannot be combined with other credentials")
-			}
-			if final.HTTPClient != originalHTTPClient || final.CustomHTTPDoer != config.Transport {
-				return errors.New("X.509 workload identity requires its exact attested transport")
 			}
 			base := final.BaseURL
 			if base == nil {
@@ -66,6 +61,13 @@ func WithX509WorkloadIdentity(config auth.X509WorkloadIdentity) RequestOption {
 			if !validX509WorkloadAPIBaseURL(base) {
 				return errors.New("X.509 workload identity requires the global OpenAI mTLS API endpoint")
 			}
+			initialize.Do(func() {
+				identity, initializationError = auth.NewX509WorkloadIdentityAuth(config)
+			})
+			if initializationError != nil {
+				return initializationError
+			}
+			final.CustomHTTPDoer = config.Transport
 			return WithMiddleware(func(request *http.Request, next MiddlewareNext) (*http.Response, error) {
 				if !validX509WorkloadAPIRequest(request) || unsafeX509CredentialHeaders(request.Header) {
 					return nil, requestconfig.WithNoRetryError(
@@ -91,7 +93,7 @@ func validX509WorkloadAPIBaseURL(base *url.URL) bool {
 }
 
 func validX509WorkloadAPIRequest(request *http.Request) bool {
-	if request == nil || request.URL == nil || request.URL.Scheme != "https" ||
+	if request == nil || request.Header == nil || request.URL == nil || request.URL.Scheme != "https" ||
 		request.URL.Host != "mtls.api.openai.com" || request.URL.User != nil ||
 		request.URL.Fragment != "" || request.URL.RawFragment != "" || request.URL.Opaque != "" ||
 		(request.Host != "" && request.Host != request.URL.Host) || len(request.Trailer) != 0 {

--- a/option/x509workloadidentity.go
+++ b/option/x509workloadidentity.go
@@ -1,0 +1,109 @@
+package option
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+	"sync"
+
+	"github.com/openai/openai-go/v3/auth"
+	"github.com/openai/openai-go/v3/internal/requestconfig"
+)
+
+const x509WorkloadAPIBaseURL = "https://mtls.api.openai.com/v1/"
+
+// WithX509WorkloadIdentity authenticates OpenAI API requests by exchanging an
+// attested workload certificate for short-lived bearer credentials. Only the
+// global OpenAI mTLS endpoint and the configured transport are supported.
+func WithX509WorkloadIdentity(config auth.X509WorkloadIdentity) RequestOption {
+	selected := requestconfig.NewProviderAuthOption("OpenAI", "option.WithX509WorkloadIdentity")
+	var initialize sync.Once
+	var identity *auth.X509WorkloadIdentityAuth
+	var initializationError error
+
+	return requestconfig.RequestOptionFunc(func(cfg *requestconfig.RequestConfig) error {
+		initialize.Do(func() {
+			identity, initializationError = auth.NewX509WorkloadIdentityAuth(config)
+		})
+		if initializationError != nil {
+			return initializationError
+		}
+		if cfg.HTTPClient == nil || cfg.CustomHTTPDoer != nil {
+			return errors.New("X.509 workload identity requires its attested transport without custom HTTP clients")
+		}
+		if err := selected.Apply(cfg); err != nil {
+			return err
+		}
+		cfg.ClearInheritedAuthentication()
+		if err := requestconfig.WithDefaultBaseURL(x509WorkloadAPIBaseURL).Apply(cfg); err != nil {
+			return err
+		}
+		originalHTTPClient := cfg.HTTPClient
+		cfg.CustomHTTPDoer = config.Transport
+		return requestconfig.WithRequestFinalizer(func(final *requestconfig.RequestConfig) error {
+			if !selected.Selected(final) {
+				return nil
+			}
+			if final.EndpointProvider() != "" {
+				return errors.New("X.509 workload identity cannot be combined with another API provider")
+			}
+			if final.APIKey != "" || final.AdminAPIKey != "" || unsafeX509CredentialHeaders(final.Request.Header) {
+				return errors.New("X.509 workload identity cannot be combined with other credentials")
+			}
+			if final.HTTPClient != originalHTTPClient || final.CustomHTTPDoer != config.Transport {
+				return errors.New("X.509 workload identity requires its exact attested transport")
+			}
+			base := final.BaseURL
+			if base == nil {
+				base = final.DefaultBaseURL
+			}
+			if !validX509WorkloadAPIBaseURL(base) {
+				return errors.New("X.509 workload identity requires the global OpenAI mTLS API endpoint")
+			}
+			return WithMiddleware(func(request *http.Request, next MiddlewareNext) (*http.Response, error) {
+				if !validX509WorkloadAPIRequest(request) || unsafeX509CredentialHeaders(request.Header) {
+					return nil, errors.New("X.509 workload identity rejected an unsafe final API request")
+				}
+				token, err := identity.GetToken(request.Context(), config.Transport)
+				if err != nil {
+					return nil, err
+				}
+				request.Header.Set("Authorization", "Bearer "+token)
+				return next(request)
+			}).Apply(final)
+		}).Apply(cfg)
+	})
+}
+
+func validX509WorkloadAPIBaseURL(base *url.URL) bool {
+	return base != nil && base.Scheme == "https" && base.Host == "mtls.api.openai.com" &&
+		base.Path == "/v1/" && base.EscapedPath() == "/v1/" && base.User == nil &&
+		base.RawQuery == "" && !base.ForceQuery && base.Fragment == "" && base.RawFragment == "" && base.Opaque == ""
+}
+
+func validX509WorkloadAPIRequest(request *http.Request) bool {
+	if request == nil || request.URL == nil || request.URL.Scheme != "https" ||
+		request.URL.Host != "mtls.api.openai.com" || request.URL.User != nil ||
+		request.URL.Fragment != "" || request.URL.RawFragment != "" || request.URL.Opaque != "" ||
+		(request.Host != "" && request.Host != request.URL.Host) || len(request.Trailer) != 0 {
+		return false
+	}
+	return strings.HasPrefix(request.URL.Path, "/v1/") && strings.HasPrefix(request.URL.EscapedPath(), "/v1/") &&
+		path.Clean(request.URL.Path) == request.URL.Path
+}
+
+func unsafeX509CredentialHeaders(headers http.Header) bool {
+	for name := range headers {
+		normalized := strings.ToLower(strings.ReplaceAll(name, "_", "-"))
+		switch normalized {
+		case "authorization", "api-key", "x-api-key", "proxy-authorization", "cookie", "set-cookie", "host", "x-amz-security-token":
+			return true
+		}
+		if strings.HasPrefix(normalized, ":") {
+			return true
+		}
+	}
+	return false
+}

--- a/option/x509workloadidentity.go
+++ b/option/x509workloadidentity.go
@@ -18,12 +18,12 @@ const x509WorkloadAPIBaseURL = "https://mtls.api.openai.com/v1/"
 // attested workload certificate for short-lived bearer credentials. Only the
 // global OpenAI mTLS endpoint and the configured transport are supported.
 func WithX509WorkloadIdentity(config auth.X509WorkloadIdentity) RequestOption {
-	selected := requestconfig.NewProviderAuthOption("OpenAI", "option.WithX509WorkloadIdentity")
 	var initialize sync.Once
 	var identity *auth.X509WorkloadIdentityAuth
 	var initializationError error
 
 	return requestconfig.RequestOptionFunc(func(cfg *requestconfig.RequestConfig) error {
+		selected := requestconfig.NewProviderAuthOption("OpenAI", "option.WithX509WorkloadIdentity")
 		if err := selected.Apply(cfg); err != nil {
 			return err
 		}
@@ -32,13 +32,12 @@ func WithX509WorkloadIdentity(config auth.X509WorkloadIdentity) RequestOption {
 			return err
 		}
 		originalHTTPClient := cfg.HTTPClient
-		customHTTPClient := cfg.HTTPClientExplicitlySelected()
 		return requestconfig.WithRequestFinalizer(func(final *requestconfig.RequestConfig) error {
 			if !selected.Selected(final) {
 				return nil
 			}
 			if final.HTTPClient == nil || final.HTTPClient != originalHTTPClient || final.CustomHTTPDoer != nil ||
-				customHTTPClient || final.HTTPClientExplicitlySelected() {
+				final.HTTPClientExplicitlySelected() {
 				return errors.New("X.509 workload identity requires its attested transport without custom HTTP clients")
 			}
 			if final.EndpointProvider() != "" {

--- a/option/x509workloadidentity.go
+++ b/option/x509workloadidentity.go
@@ -31,12 +31,11 @@ func WithX509WorkloadIdentity(config auth.X509WorkloadIdentity) RequestOption {
 		if err := requestconfig.WithDefaultBaseURL(x509WorkloadAPIBaseURL).Apply(cfg); err != nil {
 			return err
 		}
-		originalHTTPClient := cfg.HTTPClient
 		return requestconfig.WithRequestFinalizer(func(final *requestconfig.RequestConfig) error {
 			if !selected.Selected(final) {
 				return nil
 			}
-			if final.HTTPClient == nil || final.HTTPClient != originalHTTPClient || final.CustomHTTPDoer != nil ||
+			if final.HTTPClient == nil || final.CustomHTTPDoer != nil ||
 				final.HTTPClientExplicitlySelected() {
 				return errors.New("X.509 workload identity requires its attested transport without custom HTTP clients")
 			}

--- a/option/x509workloadidentity.go
+++ b/option/x509workloadidentity.go
@@ -80,10 +80,26 @@ func WithX509WorkloadIdentity(config auth.X509WorkloadIdentity) RequestOption {
 				}
 				authenticated := request.Clone(request.Context())
 				authenticated.Header.Set("Authorization", "Bearer "+token)
-				return next(authenticated)
+				response, dispatchErr := next(authenticated)
+				return redactX509Response(response), dispatchErr
 			}).Apply(final)
 		}).Apply(cfg)
 	})
+}
+
+func redactX509Response(response *http.Response) *http.Response {
+	if response == nil || response.Request == nil {
+		return response
+	}
+	redacted := *response
+	redacted.Request = response.Request.Clone(response.Request.Context())
+	for name := range redacted.Request.Header {
+		switch strings.ToLower(strings.ReplaceAll(name, "_", "-")) {
+		case "authorization", "proxy-authorization", "cookie", "set-cookie", "api-key", "x-api-key", "x-amz-security-token":
+			delete(redacted.Request.Header, name)
+		}
+	}
+	return &redacted
 }
 
 func validX509WorkloadAPIBaseURL(base *url.URL) bool {

--- a/option/x509workloadidentity.go
+++ b/option/x509workloadidentity.go
@@ -97,11 +97,21 @@ func validX509WorkloadAPIBaseURL(base *url.URL) bool {
 
 func validX509WorkloadAPIRequest(request *http.Request) bool {
 	if request == nil || request.Header == nil || request.URL == nil || request.URL.Scheme != "https" ||
-		request.URL.Host != "mtls.api.openai.com" || request.URL.User != nil ||
+		request.URL.Host != "mtls.api.openai.com" || request.URL.User != nil || request.RequestURI != "" ||
 		request.URL.Fragment != "" || request.URL.RawFragment != "" || request.URL.Opaque != "" ||
 		(request.Host != "" && request.Host != request.URL.Host) || len(request.Trailer) != 0 ||
 		len(request.TransferEncoding) != 0 {
 		return false
+	}
+	//nolint:staticcheck // Legacy cancellation bypasses the issuer context and has no nondeprecated accessor.
+	if request.Cancel != nil {
+		return false
+	}
+	for index := 0; index < len(request.URL.RawQuery); index++ {
+		value := request.URL.RawQuery[index]
+		if value < ' ' || value == 0x7f {
+			return false
+		}
 	}
 	switch request.Method {
 	case http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch,
@@ -113,7 +123,15 @@ func validX509WorkloadAPIRequest(request *http.Request) bool {
 	if request.ContentLength < -1 || (!hasBody && request.ContentLength != 0) {
 		return false
 	}
-	for name := range request.Header {
+	for name, values := range request.Header {
+		if !validX509HeaderName(name) {
+			return false
+		}
+		for _, value := range values {
+			if !validX509HeaderValue(value) {
+				return false
+			}
+		}
 		switch strings.ToLower(strings.ReplaceAll(name, "_", "-")) {
 		case "transfer-encoding", "content-length", "connection", "upgrade", "trailer", "te",
 			"proxy-connection", "keep-alive", "http2-settings":
@@ -122,6 +140,31 @@ func validX509WorkloadAPIRequest(request *http.Request) bool {
 	}
 	return strings.HasPrefix(request.URL.Path, "/v1/") && strings.HasPrefix(request.URL.EscapedPath(), "/v1/") &&
 		path.Clean(request.URL.Path) == request.URL.Path
+}
+
+func validX509HeaderName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for index := 0; index < len(name); index++ {
+		value := name[index]
+		if value >= 'A' && value <= 'Z' || value >= 'a' && value <= 'z' || value >= '0' && value <= '9' {
+			continue
+		}
+		if !strings.ContainsRune("!#$%&'*+-.^_`|~", rune(value)) {
+			return false
+		}
+	}
+	return true
+}
+
+func validX509HeaderValue(value string) bool {
+	for index := 0; index < len(value); index++ {
+		if value[index] < ' ' && value[index] != '\t' || value[index] == 0x7f {
+			return false
+		}
+	}
+	return true
 }
 
 func unsafeX509CredentialHeaders(headers http.Header) bool {

--- a/option/x509workloadidentity.go
+++ b/option/x509workloadidentity.go
@@ -52,6 +52,11 @@ func WithX509WorkloadIdentity(config auth.X509WorkloadIdentity) RequestOption {
 				unsafeX509CredentialHeaders(final.Request.Header) {
 				return errors.New("X.509 workload identity cannot be combined with other credentials")
 			}
+			if final.BaseURL == nil {
+				if err := requestconfig.WithDefaultBaseURL(x509WorkloadAPIBaseURL).Apply(final); err != nil {
+					return err
+				}
+			}
 			base := final.BaseURL
 			if base == nil {
 				base = final.DefaultBaseURL

--- a/option/x509workloadidentity.go
+++ b/option/x509workloadidentity.go
@@ -49,7 +49,11 @@ func WithX509WorkloadIdentity(config auth.X509WorkloadIdentity) RequestOption {
 			if final.EndpointProvider() != "" {
 				return errors.New("X.509 workload identity cannot be combined with another API provider")
 			}
-			if final.APIKey != "" || final.AdminAPIKey != "" || unsafeX509CredentialHeaders(final.Request.Header) {
+			if !final.Security.BearerAuth {
+				return errors.New("X.509 workload identity cannot authenticate an admin-only API operation")
+			}
+			if final.APIKey != "" || final.AdminAPIKey != "" || final.AuthorizationHeaderOverridden() ||
+				unsafeX509CredentialHeaders(final.Request.Header) {
 				return errors.New("X.509 workload identity cannot be combined with other credentials")
 			}
 			if final.HTTPClient != originalHTTPClient || final.CustomHTTPDoer != config.Transport {
@@ -64,14 +68,17 @@ func WithX509WorkloadIdentity(config auth.X509WorkloadIdentity) RequestOption {
 			}
 			return WithMiddleware(func(request *http.Request, next MiddlewareNext) (*http.Response, error) {
 				if !validX509WorkloadAPIRequest(request) || unsafeX509CredentialHeaders(request.Header) {
-					return nil, errors.New("X.509 workload identity rejected an unsafe final API request")
+					return nil, requestconfig.WithNoRetryError(
+						errors.New("X.509 workload identity rejected an unsafe final API request"),
+					)
 				}
 				token, err := identity.GetToken(request.Context(), config.Transport)
 				if err != nil {
-					return nil, err
+					return nil, requestconfig.WithNoRetryError(err)
 				}
-				request.Header.Set("Authorization", "Bearer "+token)
-				return next(request)
+				authenticated := request.Clone(request.Context())
+				authenticated.Header.Set("Authorization", "Bearer "+token)
+				return next(authenticated)
 			}).Apply(final)
 		}).Apply(cfg)
 	})

--- a/option/x509workloadidentity.go
+++ b/option/x509workloadidentity.go
@@ -99,8 +99,26 @@ func validX509WorkloadAPIRequest(request *http.Request) bool {
 	if request == nil || request.Header == nil || request.URL == nil || request.URL.Scheme != "https" ||
 		request.URL.Host != "mtls.api.openai.com" || request.URL.User != nil ||
 		request.URL.Fragment != "" || request.URL.RawFragment != "" || request.URL.Opaque != "" ||
-		(request.Host != "" && request.Host != request.URL.Host) || len(request.Trailer) != 0 {
+		(request.Host != "" && request.Host != request.URL.Host) || len(request.Trailer) != 0 ||
+		len(request.TransferEncoding) != 0 {
 		return false
+	}
+	switch request.Method {
+	case http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch,
+		http.MethodDelete, http.MethodHead, http.MethodOptions:
+	default:
+		return false
+	}
+	hasBody := request.Body != nil && request.Body != http.NoBody
+	if request.ContentLength < -1 || (!hasBody && request.ContentLength != 0) {
+		return false
+	}
+	for name := range request.Header {
+		switch strings.ToLower(strings.ReplaceAll(name, "_", "-")) {
+		case "transfer-encoding", "content-length", "connection", "upgrade", "trailer", "te",
+			"proxy-connection", "keep-alive", "http2-settings":
+			return false
+		}
 	}
 	return strings.HasPrefix(request.URL.Path, "/v1/") && strings.HasPrefix(request.URL.EscapedPath(), "/v1/") &&
 		path.Clean(request.URL.Path) == request.URL.Path

--- a/option/x509workloadidentity_test.go
+++ b/option/x509workloadidentity_test.go
@@ -54,3 +54,34 @@ func TestX509WorkloadIdentityDetectsCredentialHeaderAliases(t *testing.T) {
 		t.Error("safe API organization metadata was rejected")
 	}
 }
+
+func TestX509WorkloadIdentityRedactsResponseRequestCredentials(t *testing.T) {
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodGet,
+		"https://mtls.api.openai.com/v1/models", nil)
+	if err != nil {
+		t.Fatalf("construct synthetic response request: %v", err)
+	}
+	request.Header = http.Header{
+		"Authorization":       {"Bearer synthetic-token"},
+		"authorization":       {"Bearer synthetic-alias"},
+		"proxy_authorization": {"synthetic-proxy"},
+		"api_key":             {"synthetic-api-key"},
+		"Cookie":              {"synthetic-cookie"},
+		"Openai-Project":      {"synthetic-project"},
+	}
+	response := &http.Response{StatusCode: http.StatusUnauthorized, Request: request, Body: http.NoBody}
+	redacted := redactX509Response(response)
+	defer func() { _ = redacted.Body.Close() }()
+	if redacted == response || redacted.Request == request {
+		t.Fatal("response metadata was not independently cloned")
+	}
+	if len(redacted.Request.Header) != 1 || redacted.Request.Header.Get("OpenAI-Project") != "synthetic-project" {
+		t.Errorf("redacted response headers = %v, want only safe project metadata", redacted.Request.Header)
+	}
+	if request.Header.Get("Authorization") != "Bearer synthetic-token" || len(request.Header) != 6 {
+		t.Error("redacting returned metadata changed the original wire request")
+	}
+	if redacted.StatusCode != response.StatusCode || redacted.Request.URL.String() != request.URL.String() {
+		t.Error("response status or request URL changed during metadata redaction")
+	}
+}

--- a/option/x509workloadidentity_test.go
+++ b/option/x509workloadidentity_test.go
@@ -1,0 +1,56 @@
+package option
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func TestX509WorkloadIdentityRequiresExactGlobalBaseURL(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		target string
+		valid  bool
+	}{
+		{name: "exact global endpoint", target: "https://mtls.api.openai.com/v1/", valid: true},
+		{name: "non-mTLS global endpoint", target: "https://api.openai.com/v1/"},
+		{name: "regional endpoint", target: "https://eu.api.openai.com/v1/"},
+		{name: "attacker suffix", target: "https://mtls.api.openai.com.attacker.test/v1/"},
+		{name: "explicit port", target: "https://mtls.api.openai.com:443/v1/"},
+		{name: "plaintext", target: "http://mtls.api.openai.com/v1/"},
+		{name: "credentials", target: "https://user@mtls.api.openai.com/v1/"},
+		{name: "query", target: "https://mtls.api.openai.com/v1/?signature=synthetic"},
+		{name: "fragment", target: "https://mtls.api.openai.com/v1/#unsafe"},
+		{name: "wrong path", target: "https://mtls.api.openai.com/other/"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			target, err := url.Parse(test.target)
+			if err != nil {
+				t.Fatalf("parse synthetic endpoint: %v", err)
+			}
+			if got := validX509WorkloadAPIBaseURL(target); got != test.valid {
+				t.Errorf("endpoint validation = %v, want %v", got, test.valid)
+			}
+		})
+	}
+	if validX509WorkloadAPIBaseURL(nil) {
+		t.Error("nil endpoint unexpectedly validated")
+	}
+}
+
+func TestX509WorkloadIdentityDetectsCredentialHeaderAliases(t *testing.T) {
+	for _, name := range []string{
+		"Authorization", "authorization", "Api-Key", "api_key", "X-Api-Key", "x_api_key",
+		"Proxy-Authorization", "proxy_authorization", "Cookie", "Set-Cookie", "Host",
+		"X-Amz-Security-Token", ":authority",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if !unsafeX509CredentialHeaders(http.Header{name: []string{"synthetic-credential"}}) {
+				t.Errorf("credential header alias %q was accepted", name)
+			}
+		})
+	}
+	if unsafeX509CredentialHeaders(http.Header{"OpenAI-Organization": []string{"synthetic-organization"}}) {
+		t.Error("safe API organization metadata was rejected")
+	}
+}

--- a/x509_workload_identity_integration_test.go
+++ b/x509_workload_identity_integration_test.go
@@ -201,6 +201,26 @@ func TestX509WorkloadIdentityRejectsMethodLevelOverridesBeforeExchange(t *testin
 	}
 }
 
+func TestX509WorkloadIdentityPreservesHeaderlessRequestAfterEmptyCredentials(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		opt  option.RequestOption
+	}{
+		{name: "empty API key", opt: option.WithAPIKey("")},
+		{name: "empty admin API key", opt: option.WithAdminAPIKey("")},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+			config, issuer, api := newX509WorkloadIdentityIntegration(t)
+			client := openai.NewClient(option.WithX509WorkloadIdentity(config))
+			if _, err := client.Models.List(t.Context(), option.WithHeaderDel("Authorization"), test.opt); err == nil {
+				t.Fatal("empty credentials erased the caller's explicit headerless-request policy")
+			}
+			assertX509WorkloadNoRequests(t, issuer, api)
+		})
+	}
+}
+
 func TestX509WorkloadIdentityRejectsAdminOnlyOperationsBeforeExchange(t *testing.T) {
 	t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
 	config, issuer, api := newX509WorkloadIdentityIntegration(t)

--- a/x509_workload_identity_integration_test.go
+++ b/x509_workload_identity_integration_test.go
@@ -567,6 +567,126 @@ func TestX509WorkloadIdentityUsesOnlyTheLastAuthenticationOption(t *testing.T) {
 	})
 }
 
+func TestX509WorkloadIdentityOnlySelectedAuthenticationControlsEndpoint(t *testing.T) {
+	ordinary := auth.WorkloadIdentity{
+		IdentityProviderID: "synthetic-ordinary-identity-provider",
+		ServiceAccountID:   "synthetic-ordinary-service-account",
+		Provider:           originTestSubjectTokenProvider{},
+	}
+	for _, test := range []struct {
+		name        string
+		environment string
+		methodURL   string
+		wantHost    string
+	}{
+		{name: "ordinary method restores production default", wantHost: "api.openai.com"},
+		{name: "ordinary method preserves explicit environment", environment: "https://gateway.example.test/v1/",
+			wantHost: "gateway.example.test"},
+		{name: "ordinary method preserves explicit method endpoint", methodURL: "https://method.example.test/v1/",
+			wantHost: "method.example.test"},
+		{name: "ordinary method endpoint overrides environment", environment: "https://gateway.example.test/v1/",
+			methodURL: "https://method.example.test/v1/", wantHost: "method.example.test"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("OPENAI_API_KEY", "")
+			t.Setenv("OPENAI_ADMIN_KEY", "")
+			t.Setenv("OPENAI_CUSTOM_HEADERS", "")
+			t.Setenv("OPENAI_BASE_URL", "synthetic-placeholder")
+			if test.environment == "" {
+				if err := os.Unsetenv("OPENAI_BASE_URL"); err != nil {
+					t.Fatalf("remove configured endpoint before selecting authentication: %v", err)
+				}
+			} else {
+				t.Setenv("OPENAI_BASE_URL", test.environment)
+			}
+			config, issuer, api := newX509WorkloadIdentityIntegration(t)
+			var requests, mtlsCredentials atomic.Int32
+			ordinaryClient := originTestHTTPClient(originTestRoundTripper(
+				func(request *http.Request) (*http.Response, error) {
+					requests.Add(1)
+					if request.URL.Host == x509ConformanceAPIHost && request.Header.Get("Authorization") != "" {
+						mtlsCredentials.Add(1)
+					}
+					if got := request.URL.Host; got != test.wantHost {
+						t.Errorf("ordinary workload API host = %q, want %q", got, test.wantHost)
+					}
+					if got := request.Header.Get("Authorization"); got != "Bearer workload-token" {
+						t.Errorf("ordinary workload authorization = %q, want its selected bearer", got)
+					}
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Header:     http.Header{"Content-Type": {"application/json"}},
+						Body:       io.NopCloser(strings.NewReader(`{"data":[]}`)),
+						Request:    request,
+					}, nil
+				},
+			))
+			client := openai.NewClient(option.WithX509WorkloadIdentity(config), option.WithMaxRetries(0))
+			opts := []option.RequestOption{
+				option.WithWorkloadIdentity(ordinary),
+				option.WithHTTPClient(ordinaryClient),
+			}
+			if test.methodURL != "" {
+				opts = append(opts, option.WithBaseURL(test.methodURL))
+			}
+			if _, err := client.Models.List(t.Context(), opts...); err != nil {
+				t.Fatalf("ordinary method workload did not replace X.509 authentication: %v", err)
+			}
+			if got := requests.Load(); got != 1 {
+				t.Errorf("ordinary workload dispatched %d API requests, want one", got)
+			}
+			if got := mtlsCredentials.Load(); got != 0 {
+				t.Errorf("losing X.509 option routed %d ordinary workload credentials to the mTLS endpoint", got)
+			}
+			assertX509WorkloadNoRequests(t, issuer, api)
+		})
+	}
+
+	t.Run("standalone service preserves its absent endpoint", func(t *testing.T) {
+		config, issuer, api := newX509WorkloadIdentityIntegration(t)
+		var dispatched atomic.Int32
+		ordinaryClient := originTestHTTPClient(originTestRoundTripper(
+			func(request *http.Request) (*http.Response, error) {
+				dispatched.Add(1)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": {"application/json"}},
+					Body:       io.NopCloser(strings.NewReader(`{"data":[]}`)),
+					Request:    request,
+				}, nil
+			},
+		))
+		service := openai.NewModelService(option.WithX509WorkloadIdentity(config))
+		_, err := service.List(t.Context(), option.WithWorkloadIdentity(ordinary), option.WithHTTPClient(ordinaryClient))
+		if err == nil || !strings.Contains(err.Error(), "base url is not set") {
+			t.Errorf("standalone losing workload endpoint error = %v, want the original missing endpoint", err)
+		}
+		if got := dispatched.Load(); got != 0 {
+			t.Errorf("standalone service without a default endpoint dispatched %d API requests", got)
+		}
+		assertX509WorkloadNoRequests(t, issuer, api)
+	})
+
+	t.Run("method X.509 replaces ordinary workload", func(t *testing.T) {
+		t.Setenv("OPENAI_API_KEY", "")
+		t.Setenv("OPENAI_ADMIN_KEY", "")
+		t.Setenv("OPENAI_CUSTOM_HEADERS", "")
+		t.Setenv("OPENAI_BASE_URL", "synthetic-placeholder")
+		if err := os.Unsetenv("OPENAI_BASE_URL"); err != nil {
+			t.Fatalf("remove configured endpoint before selecting X.509 workload: %v", err)
+		}
+		config, issuer, api := newX509WorkloadIdentityIntegration(t)
+		client := openai.NewClient(option.WithWorkloadIdentity(ordinary), option.WithMaxRetries(0))
+		if _, err := client.Models.List(t.Context(), option.WithX509WorkloadIdentity(config)); err != nil {
+			t.Fatalf("method X.509 workload did not replace ordinary authentication: %v", err)
+		}
+		if len(issuer.requests()) != 1 || len(api.requests()) != 1 {
+			t.Errorf("winning method X.509 issuer/API requests = %d/%d, want 1/1",
+				len(issuer.requests()), len(api.requests()))
+		}
+	})
+}
+
 func TestX509WorkloadIdentityRejectsMethodLevelOverridesBeforeExchange(t *testing.T) {
 	for _, test := range []struct {
 		name string

--- a/x509_workload_identity_integration_test.go
+++ b/x509_workload_identity_integration_test.go
@@ -63,6 +63,8 @@ func TestX509WorkloadIdentityPreservesNativeHTTPBodyFraming(t *testing.T) {
 				option.WithX509WorkloadIdentity(config),
 				option.WithMaxRetries(0),
 				option.WithMiddleware(func(request *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+					request.Header.Set("X-Synthetic-Metadata", "synthetic\tmetadata\xff")
+					request.URL.RawQuery = "synthetic=safe%20value"
 					if test.streaming {
 						if err := request.Body.Close(); err != nil {
 							return nil, err
@@ -203,6 +205,24 @@ func TestX509WorkloadIdentityRejectsLateMiddlewareMutationBeforeExchange(t *test
 		{name: "attacker host", mutate: func(request *http.Request) { request.URL.Host = "attacker.example.test" }},
 		{name: "explicit authority port", mutate: func(request *http.Request) { request.URL.Host = "mtls.api.openai.com:443" }},
 		{name: "attacker Host header", mutate: func(request *http.Request) { request.Host = "attacker.example.test" }},
+		{name: "relative RequestURI override", mutate: func(request *http.Request) { request.RequestURI = "/v1/attacker" }},
+		{name: "absolute RequestURI override", mutate: func(request *http.Request) {
+			request.RequestURI = "https://attacker.example.test/v1/models"
+		}},
+		{name: "query newline", mutate: func(request *http.Request) { request.URL.RawQuery = "synthetic=line\nnext" }},
+		{name: "query carriage return", mutate: func(request *http.Request) { request.URL.RawQuery = "synthetic=line\rnext" }},
+		{name: "query NUL", mutate: func(request *http.Request) { request.URL.RawQuery = "synthetic=line\x00next" }},
+		{name: "query DEL", mutate: func(request *http.Request) { request.URL.RawQuery = "synthetic=line\x7fnext" }},
+		{name: "closed legacy cancellation", mutate: func(request *http.Request) {
+			canceled := make(chan struct{})
+			close(canceled)
+			//nolint:staticcheck // Exercise legacy cancellation, which bypasses context and has no replacement accessor.
+			request.Cancel = canceled
+		}},
+		{name: "open legacy cancellation", mutate: func(request *http.Request) {
+			//nolint:staticcheck // Exercise legacy cancellation, which bypasses context and has no replacement accessor.
+			request.Cancel = make(chan struct{})
+		}},
 		{name: "URL fragment", mutate: func(request *http.Request) { request.URL.Fragment = "attacker" }},
 		{name: "opaque URL", mutate: func(request *http.Request) { request.URL.Opaque = "//attacker.example.test/v1/models" }},
 		{name: "CONNECT tunnel", mutate: func(request *http.Request) { request.Method = http.MethodConnect }},
@@ -244,6 +264,18 @@ func TestX509WorkloadIdentityRejectsLateMiddlewareMutationBeforeExchange(t *test
 		{name: "keep-alive framing", mutate: unsafeHeader("Keep-Alive", "timeout=5")},
 		{name: "hop-by-hop TE", mutate: unsafeHeader("te", "trailers")},
 		{name: "framing trailer header", mutate: unsafeHeader("trailer", "Authorization")},
+		{name: "empty header name", mutate: unsafeHeader("", "synthetic")},
+		{name: "header name space", mutate: unsafeHeader("Invalid Header", "synthetic")},
+		{name: "header name colon", mutate: unsafeHeader("Invalid:Header", "synthetic")},
+		{name: "header name NUL", mutate: unsafeHeader("Invalid\x00Header", "synthetic")},
+		{name: "non-ASCII header name", mutate: unsafeHeader("Invalid-\u00e9", "synthetic")},
+		{name: "header value CRLF bearer injection", mutate: unsafeHeader(
+			"X-Synthetic", "line1\r\nAuthorization: Bearer injected",
+		)},
+		{name: "header value newline", mutate: unsafeHeader("X-Synthetic", "line1\nline2")},
+		{name: "header value NUL", mutate: unsafeHeader("X-Synthetic", "line1\x00line2")},
+		{name: "header value vertical tab", mutate: unsafeHeader("X-Synthetic", "line1\vline2")},
+		{name: "header value DEL", mutate: unsafeHeader("X-Synthetic", "line1\x7fline2")},
 		{name: "lowercase Host alias", mutate: unsafeHeader("host", "attacker.example.test")},
 		{name: "authority pseudo-header", mutate: unsafeHeader(":authority", "attacker.example.test")},
 		{name: "attacker Authorization", mutate: func(request *http.Request) {

--- a/x509_workload_identity_integration_test.go
+++ b/x509_workload_identity_integration_test.go
@@ -212,6 +212,16 @@ func TestX509WorkloadIdentityPreservesStandaloneHTTPClientProvenance(t *testing.
 			},
 		},
 		{
+			name: "deeply nested standalone custom client",
+			service: func(auth.X509WorkloadIdentity) openai.ModelService {
+				inner := openai.NewModelService(option.WithHTTPClient(&http.Client{}))
+				return openai.NewModelService(inner.Options...)
+			},
+			method: func(config auth.X509WorkloadIdentity) []option.RequestOption {
+				return []option.RequestOption{option.WithX509WorkloadIdentity(config)}
+			},
+		},
+		{
 			name: "standalone later custom client",
 			service: func(config auth.X509WorkloadIdentity) openai.ModelService {
 				return openai.NewModelService(option.WithX509WorkloadIdentity(config), option.WithHTTPClient(&http.Client{}))
@@ -244,6 +254,53 @@ func TestX509WorkloadIdentityPreservesStandaloneHTTPClientProvenance(t *testing.
 }
 
 func TestX509WorkloadIdentityUsesOnlyTheLastAuthenticationOption(t *testing.T) {
+	t.Run("same option reused in one layer", func(t *testing.T) {
+		t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+		config, issuer, api := newX509WorkloadIdentityIntegration(t)
+		selected := option.WithX509WorkloadIdentity(config)
+		client := openai.NewClient(selected, selected)
+		if _, err := client.Models.List(t.Context()); err != nil {
+			t.Fatalf("reused same-layer X.509 option did not select only its last application: %v", err)
+		}
+		if len(issuer.requests()) != 1 || len(api.requests()) != 1 {
+			t.Errorf("reused X.509 option issuer/API calls = %d/%d", len(issuer.requests()), len(api.requests()))
+		}
+	})
+	t.Run("same option reused as a method override", func(t *testing.T) {
+		t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+		config, issuer, api := newX509WorkloadIdentityIntegration(t)
+		selected := option.WithX509WorkloadIdentity(config)
+		client := openai.NewClient(selected)
+		if _, err := client.Models.List(t.Context(), selected); err != nil {
+			t.Fatalf("reused method X.509 option did not replace its inherited application: %v", err)
+		}
+		if len(issuer.requests()) != 1 || len(api.requests()) != 1 {
+			t.Errorf("reused method X.509 option issuer/API calls = %d/%d", len(issuer.requests()), len(api.requests()))
+		}
+	})
+	t.Run("same option reused concurrently", func(t *testing.T) {
+		t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+		config, issuer, api := newX509WorkloadIdentityIntegration(t)
+		selected := option.WithX509WorkloadIdentity(config)
+		client := openai.NewClient(selected, selected)
+		const requests = 8
+		results := make(chan error, requests)
+		for range requests {
+			go func() {
+				_, err := client.Models.List(t.Context(), selected)
+				results <- err
+			}()
+		}
+		for range requests {
+			if err := <-results; err != nil {
+				t.Errorf("concurrent reused X.509 option request: %v", err)
+			}
+		}
+		if len(issuer.requests()) != requests || len(api.requests()) != requests {
+			t.Errorf("concurrently reused X.509 option issuer/API calls = %d/%d",
+				len(issuer.requests()), len(api.requests()))
+		}
+	})
 	t.Run("invalid earlier identity is never initialized", func(t *testing.T) {
 		t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
 		config, issuer, api := newX509WorkloadIdentityIntegration(t)

--- a/x509_workload_identity_integration_test.go
+++ b/x509_workload_identity_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -44,6 +45,52 @@ func TestX509WorkloadIdentityAuthenticatesPublicClientOverMutualTLS(t *testing.T
 			request.peerCommonName != "integrated-workload" {
 			t.Errorf("API received unsafe workload request: %+v", request)
 		}
+	}
+}
+
+func TestX509WorkloadIdentityPreservesNativeHTTPBodyFraming(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		streaming bool
+	}{
+		{name: "known-length POST"},
+		{name: "implicitly chunked streaming POST", streaming: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+			config, issuer, api := newX509WorkloadIdentityIntegration(t)
+			client := openai.NewClient(
+				option.WithX509WorkloadIdentity(config),
+				option.WithMaxRetries(0),
+				option.WithMiddleware(func(request *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+					if test.streaming {
+						if err := request.Body.Close(); err != nil {
+							return nil, err
+						}
+						request.Body = io.NopCloser(strings.NewReader(`{"synthetic":"streaming-body"}`))
+						request.GetBody = nil
+						request.ContentLength = -1
+					}
+					if request.Body == nil || request.Body == http.NoBody || len(request.TransferEncoding) != 0 {
+						t.Error("public POST did not retain a natively framed request body")
+					}
+					if !test.streaming && request.ContentLength <= 0 {
+						t.Errorf("known-length POST content length = %d, want positive", request.ContentLength)
+					}
+					return next(request)
+				}),
+			)
+			if err := client.Post(t.Context(), "models", map[string]string{"synthetic": "body"}, nil); err != nil {
+				t.Fatalf("public POST rejected native HTTP body framing: %v", err)
+			}
+			if got := len(issuer.requests()); got != 1 {
+				t.Errorf("successful POST made %d token exchanges, want one", got)
+			}
+			requests := api.requests()
+			if len(requests) != 1 || requests[0].method != http.MethodPost {
+				t.Errorf("mutually authenticated API received requests = %+v, want one POST", requests)
+			}
+		})
 	}
 }
 
@@ -140,12 +187,65 @@ func TestX509WorkloadIdentityRejectsConflictingCredentialsAndClients(t *testing.
 }
 
 func TestX509WorkloadIdentityRejectsLateMiddlewareMutationBeforeExchange(t *testing.T) {
+	unsafeHeader := func(name, value string) func(*http.Request) {
+		return func(request *http.Request) {
+			request.Header[name] = []string{value}
+		}
+	}
 	for _, test := range []struct {
-		name   string
-		mutate func(*http.Request)
+		name       string
+		mutate     func(*http.Request)
+		nilRequest bool
 	}{
+		{name: "nil request", nilRequest: true},
+		{name: "nil URL", mutate: func(request *http.Request) { request.URL = nil }},
+		{name: "plaintext URL", mutate: func(request *http.Request) { request.URL.Scheme = "http" }},
 		{name: "attacker host", mutate: func(request *http.Request) { request.URL.Host = "attacker.example.test" }},
+		{name: "explicit authority port", mutate: func(request *http.Request) { request.URL.Host = "mtls.api.openai.com:443" }},
 		{name: "attacker Host header", mutate: func(request *http.Request) { request.Host = "attacker.example.test" }},
+		{name: "URL fragment", mutate: func(request *http.Request) { request.URL.Fragment = "attacker" }},
+		{name: "opaque URL", mutate: func(request *http.Request) { request.URL.Opaque = "//attacker.example.test/v1/models" }},
+		{name: "CONNECT tunnel", mutate: func(request *http.Request) { request.Method = http.MethodConnect }},
+		{name: "TRACE tunnel", mutate: func(request *http.Request) { request.Method = http.MethodTrace }},
+		{name: "HTTP/2 preface", mutate: func(request *http.Request) { request.Method = "PRI" }},
+		{name: "custom tunnel method", mutate: func(request *http.Request) { request.Method = "SYNTHETIC-TUNNEL" }},
+		{name: "identity transfer encoding", mutate: func(request *http.Request) {
+			request.TransferEncoding = []string{"identity"}
+		}},
+		{name: "explicit chunked transfer encoding", mutate: func(request *http.Request) {
+			request.TransferEncoding = []string{"chunked"}
+		}},
+		{name: "multiple transfer encodings", mutate: func(request *http.Request) {
+			request.TransferEncoding = []string{"chunked", "identity"}
+		}},
+		{name: "invalid negative content length", mutate: func(request *http.Request) { request.ContentLength = -2 }},
+		{name: "nil body with content length", mutate: func(request *http.Request) {
+			request.Body = nil
+			request.ContentLength = 5
+		}},
+		{name: "nil body with unknown content length", mutate: func(request *http.Request) {
+			request.Body = nil
+			request.ContentLength = -1
+		}},
+		{name: "NoBody with content length", mutate: func(request *http.Request) {
+			request.Body = http.NoBody
+			request.ContentLength = 5
+		}},
+		{name: "canonical transfer encoding header", mutate: unsafeHeader("Transfer-Encoding", "identity")},
+		{name: "lowercase transfer encoding alias", mutate: unsafeHeader("transfer-encoding", "identity")},
+		{name: "underscore transfer encoding alias", mutate: unsafeHeader("transfer_encoding", "identity")},
+		{name: "canonical content length header", mutate: unsafeHeader("Content-Length", "0")},
+		{name: "lowercase content length alias", mutate: unsafeHeader("content-length", "0")},
+		{name: "underscore content length alias", mutate: unsafeHeader("content_length", "0")},
+		{name: "connection upgrade", mutate: unsafeHeader("connection", "Upgrade")},
+		{name: "protocol upgrade", mutate: unsafeHeader("Upgrade", "attacker-protocol")},
+		{name: "HTTP/2 upgrade settings", mutate: unsafeHeader("http2_settings", "attacker-settings")},
+		{name: "proxy connection", mutate: unsafeHeader("proxy_connection", "keep-alive")},
+		{name: "keep-alive framing", mutate: unsafeHeader("Keep-Alive", "timeout=5")},
+		{name: "hop-by-hop TE", mutate: unsafeHeader("te", "trailers")},
+		{name: "framing trailer header", mutate: unsafeHeader("trailer", "Authorization")},
+		{name: "lowercase Host alias", mutate: unsafeHeader("host", "attacker.example.test")},
+		{name: "authority pseudo-header", mutate: unsafeHeader(":authority", "attacker.example.test")},
 		{name: "attacker Authorization", mutate: func(request *http.Request) {
 			request.Header.Set("Authorization", "Bearer attacker-token")
 		}},
@@ -168,6 +268,9 @@ func TestX509WorkloadIdentityRejectsLateMiddlewareMutationBeforeExchange(t *test
 				option.WithX509WorkloadIdentity(config),
 				option.WithMiddleware(func(request *http.Request, next option.MiddlewareNext) (*http.Response, error) {
 					invoked.Add(1)
+					if test.nilRequest {
+						return next(nil)
+					}
 					test.mutate(request)
 					return next(request)
 				}),

--- a/x509_workload_identity_integration_test.go
+++ b/x509_workload_identity_integration_test.go
@@ -1,0 +1,288 @@
+package openai_test
+
+import (
+	"errors"
+	"net/http"
+	"sync/atomic"
+	"testing"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/auth"
+	"github.com/openai/openai-go/v3/azure"
+	"github.com/openai/openai-go/v3/bedrock"
+	"github.com/openai/openai-go/v3/option"
+)
+
+func TestX509WorkloadIdentityAuthenticatesPublicClientOverMutualTLS(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "synthetic-ambient-api-key")
+	t.Setenv("OPENAI_ADMIN_KEY", "synthetic-ambient-admin-key")
+	t.Setenv("OPENAI_CUSTOM_HEADERS", "Authorization: Bearer synthetic-ambient-header")
+	t.Setenv("OPENAI_ORG_ID", "synthetic-ambient-organization")
+	t.Setenv("OPENAI_PROJECT_ID", "synthetic-ambient-project")
+	t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+	config, issuer, api := newX509WorkloadIdentityIntegration(t)
+	client := openai.NewClient(option.WithX509WorkloadIdentity(config), option.WithMaxRetries(0))
+	for range 2 {
+		if _, err := client.Models.List(t.Context()); err != nil {
+			t.Fatalf("mutually authenticated public client request: %v", err)
+		}
+	}
+	issuerRequests := issuer.requests()
+	apiRequests := api.requests()
+	if len(issuerRequests) != 2 || len(apiRequests) != 2 {
+		t.Fatalf("pre-cache client made issuer/API requests = %d/%d, want 2/2", len(issuerRequests), len(apiRequests))
+	}
+	for _, request := range issuerRequests {
+		if request.authorization != "" || request.host != x509ConformanceIssuerHost ||
+			request.peerCommonName != "integrated-workload" || len(request.exchangeFields) != 4 {
+			t.Errorf("issuer received unsafe workload exchange: %+v", request)
+		}
+	}
+	for _, request := range apiRequests {
+		if request.authorization != "Bearer "+x509ConformanceToken || request.host != x509ConformanceAPIHost ||
+			request.peerCommonName != "integrated-workload" {
+			t.Errorf("API received unsafe workload request: %+v", request)
+		}
+	}
+}
+
+func TestX509WorkloadIdentityRejectsUnsafeConfiguredOriginsBeforeExchange(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		env  string
+		opts []option.RequestOption
+	}{
+		{name: "environment attacker", env: "https://attacker.example.test/v1/"},
+		{name: "environment plaintext", env: "http://mtls.api.openai.com/v1/"},
+		{name: "environment Azure", env: "https://resource.openai.azure.com/v1/"},
+		{name: "environment EU", env: "https://eu.api.openai.com/v1/"},
+		{name: "explicit attacker", opts: []option.RequestOption{option.WithBaseURL("https://attacker.example.test/v1/")}},
+		{name: "explicit plaintext", opts: []option.RequestOption{option.WithBaseURL("http://mtls.api.openai.com/v1/")}},
+		{name: "data residency EU", opts: []option.RequestOption{option.WithDataResidency(option.DataResidencyEU)}},
+		{name: "data residency global", opts: []option.RequestOption{option.WithDataResidency(option.DataResidencyGlobal)}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("OPENAI_BASE_URL", test.env)
+			config, issuer, api := newX509WorkloadIdentityIntegration(t)
+			opts := []option.RequestOption{option.WithX509WorkloadIdentity(config), option.WithMaxRetries(0)}
+			opts = append(opts, test.opts...)
+			client := openai.NewClient(opts...)
+			if _, err := client.Models.List(t.Context()); err == nil {
+				t.Fatal("unsafe workload-identity endpoint was accepted")
+			}
+			assertX509WorkloadNoRequests(t, issuer, api)
+		})
+	}
+}
+
+func TestX509WorkloadIdentityRejectsConflictingCredentialsAndClients(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		before func(auth.X509WorkloadIdentity) []option.RequestOption
+		after  func(auth.X509WorkloadIdentity) []option.RequestOption
+	}{
+		{name: "later API key", after: func(auth.X509WorkloadIdentity) []option.RequestOption {
+			return []option.RequestOption{option.WithAPIKey("synthetic-explicit-api-key")}
+		}},
+		{name: "earlier API key", before: func(auth.X509WorkloadIdentity) []option.RequestOption {
+			return []option.RequestOption{option.WithAPIKey("synthetic-explicit-api-key")}
+		}},
+		{name: "later admin key", after: func(auth.X509WorkloadIdentity) []option.RequestOption {
+			return []option.RequestOption{option.WithAdminAPIKey("synthetic-explicit-admin-key")}
+		}},
+		{name: "custom Authorization", after: func(auth.X509WorkloadIdentity) []option.RequestOption {
+			return []option.RequestOption{option.WithHeader("Authorization", "Bearer synthetic-header-token")}
+		}},
+		{name: "custom API key alias", after: func(auth.X509WorkloadIdentity) []option.RequestOption {
+			return []option.RequestOption{option.WithHeader("x_api_key", "synthetic-header-key")}
+		}},
+		{name: "custom cookie", after: func(auth.X509WorkloadIdentity) []option.RequestOption {
+			return []option.RequestOption{option.WithHeader("Cookie", "synthetic=session")}
+		}},
+		{name: "native HTTP client override", after: func(auth.X509WorkloadIdentity) []option.RequestOption {
+			return []option.RequestOption{option.WithHTTPClient(&http.Client{})}
+		}},
+		{name: "opaque HTTP client override", after: func(auth.X509WorkloadIdentity) []option.RequestOption {
+			return []option.RequestOption{option.WithHTTPClient(x509WorkloadRejectedDoer{})}
+		}},
+		{name: "other workload identity", after: func(config auth.X509WorkloadIdentity) []option.RequestOption {
+			return []option.RequestOption{option.WithWorkloadIdentity(auth.WorkloadIdentity{
+				IdentityProviderID: config.IdentityProviderID,
+				ServiceAccountID:   config.ServiceAccountID,
+			})}
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+			config, issuer, api := newX509WorkloadIdentityIntegration(t)
+			var opts []option.RequestOption
+			if test.before != nil {
+				opts = append(opts, test.before(config)...)
+			}
+			opts = append(opts, option.WithX509WorkloadIdentity(config), option.WithMaxRetries(0))
+			if test.after != nil {
+				opts = append(opts, test.after(config)...)
+			}
+			client := openai.NewClient(opts...)
+			if _, err := client.Models.List(t.Context()); err == nil {
+				t.Fatal("conflicting X.509 credentials or client were accepted")
+			}
+			assertX509WorkloadNoRequests(t, issuer, api)
+		})
+	}
+}
+
+func TestX509WorkloadIdentityRejectsLateMiddlewareMutationBeforeExchange(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(*http.Request)
+	}{
+		{name: "attacker host", mutate: func(request *http.Request) { request.URL.Host = "attacker.example.test" }},
+		{name: "attacker Host header", mutate: func(request *http.Request) { request.Host = "attacker.example.test" }},
+		{name: "attacker Authorization", mutate: func(request *http.Request) {
+			request.Header.Set("Authorization", "Bearer attacker-token")
+		}},
+		{name: "attacker API key", mutate: func(request *http.Request) {
+			request.Header.Set("X-Api-Key", "synthetic-attacker-key")
+		}},
+		{name: "path traversal", mutate: func(request *http.Request) {
+			request.URL.Path = "/v1/../attacker"
+		}},
+		{name: "credential trailer", mutate: func(request *http.Request) {
+			request.Trailer = http.Header{"Authorization": []string{"Bearer attacker-token"}}
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+			config, issuer, api := newX509WorkloadIdentityIntegration(t)
+			var invoked atomic.Int32
+			client := openai.NewClient(
+				option.WithX509WorkloadIdentity(config),
+				option.WithMaxRetries(0),
+				option.WithMiddleware(func(request *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+					invoked.Add(1)
+					test.mutate(request)
+					return next(request)
+				}),
+			)
+			if _, err := client.Models.List(t.Context()); err == nil {
+				t.Fatal("unsafe late middleware mutation was accepted")
+			}
+			if got := invoked.Load(); got != 1 {
+				t.Errorf("adversarial middleware invoked %d times", got)
+			}
+			assertX509WorkloadNoRequests(t, issuer, api)
+		})
+	}
+}
+
+func TestX509WorkloadIdentityRejectsMethodLevelOverridesBeforeExchange(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		opt  option.RequestOption
+	}{
+		{name: "attacker endpoint", opt: option.WithBaseURL("https://attacker.example.test/v1/")},
+		{name: "regional endpoint", opt: option.WithDataResidency(option.DataResidencyEU)},
+		{name: "API key", opt: option.WithAPIKey("synthetic-method-api-key")},
+		{name: "admin API key", opt: option.WithAdminAPIKey("synthetic-method-admin-key")},
+		{name: "custom bearer", opt: option.WithHeader("Authorization", "Bearer synthetic-method-token")},
+		{name: "HTTP client", opt: option.WithHTTPClient(&http.Client{})},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+			config, issuer, api := newX509WorkloadIdentityIntegration(t)
+			client := openai.NewClient(option.WithX509WorkloadIdentity(config), option.WithMaxRetries(0))
+			if _, err := client.Models.List(t.Context(), test.opt); err == nil {
+				t.Fatal("unsafe method-level request option was accepted")
+			}
+			assertX509WorkloadNoRequests(t, issuer, api)
+		})
+	}
+}
+
+func TestX509WorkloadIdentityRejectsAzureAndBedrockBeforeExchange(t *testing.T) {
+	t.Run("Azure endpoint without credentials", func(t *testing.T) {
+		t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+		config, issuer, api := newX509WorkloadIdentityIntegration(t)
+		client := openai.NewClient(
+			azure.WithEndpoint("https://resource.openai.azure.com", "2024-06-01"),
+			option.WithX509WorkloadIdentity(config),
+			option.WithMaxRetries(0),
+		)
+		if _, err := client.Models.List(t.Context()); err == nil {
+			t.Fatal("Azure endpoint accepted an X.509 workload identity")
+		}
+		assertX509WorkloadNoRequests(t, issuer, api)
+	})
+	t.Run("Azure API key", func(t *testing.T) {
+		t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+		config, issuer, api := newX509WorkloadIdentityIntegration(t)
+		client := openai.NewClient(
+			azure.WithEndpoint("https://resource.openai.azure.com", "2024-06-01"),
+			azure.WithAPIKey("synthetic-azure-key"),
+			option.WithX509WorkloadIdentity(config),
+			option.WithMaxRetries(0),
+		)
+		if _, err := client.Models.List(t.Context()); err == nil {
+			t.Fatal("Azure API-key provider accepted an X.509 workload identity")
+		}
+		assertX509WorkloadNoRequests(t, issuer, api)
+	})
+	t.Run("Bedrock SkipAuth", func(t *testing.T) {
+		t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+		config, issuer, api := newX509WorkloadIdentityIntegration(t)
+		client, err := bedrock.NewClient(t.Context(), bedrock.Config{
+			AWSRegion: "us-east-1",
+			SkipAuth:  true,
+		}, option.WithX509WorkloadIdentity(config), option.WithMaxRetries(0))
+		if err == nil {
+			_, err = client.Models.List(t.Context())
+		}
+		if err == nil {
+			t.Fatal("Bedrock SkipAuth accepted an X.509 workload identity")
+		}
+		assertX509WorkloadNoRequests(t, issuer, api)
+	})
+}
+
+type x509WorkloadRejectedDoer struct{}
+
+func (x509WorkloadRejectedDoer) Do(*http.Request) (*http.Response, error) {
+	return nil, errors.New("opaque synthetic transport unexpectedly invoked")
+}
+
+func newX509WorkloadIdentityIntegration(t *testing.T) (
+	auth.X509WorkloadIdentity,
+	*x509ConformanceServer,
+	*x509ConformanceServer,
+) {
+	t.Helper()
+	lab := newX509ConformanceLab(t)
+	issuer := lab.server(t, x509ConformanceIssuerHost, true)
+	api := lab.server(t, x509ConformanceAPIHost, false)
+	template := lab.transport(t, x509ConformanceRoutes(issuer, api), lab.identity(t, "integrated-workload", true))
+	transport, err := auth.NewX509Transport(template)
+	if err != nil {
+		t.Fatalf("attest integration workload transport: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := transport.Close(); err != nil {
+			t.Errorf("close integration workload transport: %v", err)
+		}
+	})
+	return auth.X509WorkloadIdentity{
+		IdentityProviderID: "synthetic-identity-provider",
+		ServiceAccountID:   "synthetic-service-account",
+		Transport:          transport,
+	}, issuer, api
+}
+
+func assertX509WorkloadNoRequests(t *testing.T, issuer, api *x509ConformanceServer) {
+	t.Helper()
+	if requests := issuer.requests(); len(requests) != 0 {
+		t.Errorf("rejected configuration sent %d token-exchange requests", len(requests))
+	}
+	if requests := api.requests(); len(requests) != 0 {
+		t.Errorf("rejected configuration sent %d protected API requests", len(requests))
+	}
+}

--- a/x509_workload_identity_integration_test.go
+++ b/x509_workload_identity_integration_test.go
@@ -2,6 +2,7 @@ package openai_test
 
 import (
 	"errors"
+	"io"
 	"net/http"
 	"sync/atomic"
 	"testing"
@@ -158,7 +159,6 @@ func TestX509WorkloadIdentityRejectsLateMiddlewareMutationBeforeExchange(t *test
 			var invoked atomic.Int32
 			client := openai.NewClient(
 				option.WithX509WorkloadIdentity(config),
-				option.WithMaxRetries(0),
 				option.WithMiddleware(func(request *http.Request, next option.MiddlewareNext) (*http.Response, error) {
 					invoked.Add(1)
 					test.mutate(request)
@@ -186,6 +186,7 @@ func TestX509WorkloadIdentityRejectsMethodLevelOverridesBeforeExchange(t *testin
 		{name: "API key", opt: option.WithAPIKey("synthetic-method-api-key")},
 		{name: "admin API key", opt: option.WithAdminAPIKey("synthetic-method-admin-key")},
 		{name: "custom bearer", opt: option.WithHeader("Authorization", "Bearer synthetic-method-token")},
+		{name: "explicit headerless request", opt: option.WithHeaderDel("Authorization")},
 		{name: "HTTP client", opt: option.WithHTTPClient(&http.Client{})},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -197,6 +198,65 @@ func TestX509WorkloadIdentityRejectsMethodLevelOverridesBeforeExchange(t *testin
 			}
 			assertX509WorkloadNoRequests(t, issuer, api)
 		})
+	}
+}
+
+func TestX509WorkloadIdentityRejectsAdminOnlyOperationsBeforeExchange(t *testing.T) {
+	t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+	config, issuer, api := newX509WorkloadIdentityIntegration(t)
+	client := openai.NewClient(option.WithX509WorkloadIdentity(config))
+	if _, err := client.Admin.Organization.DataRetention.Get(t.Context()); err == nil {
+		t.Fatal("admin-only data-retention endpoint accepted X.509 bearer authentication")
+	}
+	assertX509WorkloadNoRequests(t, issuer, api)
+}
+
+func TestX509WorkloadIdentityDoesNotRetryPermanentIssuerFailure(t *testing.T) {
+	t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+	config, issuer, api := newX509WorkloadIdentityIntegration(t)
+	var requests atomic.Int32
+	issuer.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, `{"error":"invalid_grant","error_description":"synthetic-private-issuer-detail"}`)
+	})
+	client := openai.NewClient(option.WithX509WorkloadIdentity(config))
+	_, err := client.Models.List(t.Context())
+	var oauthError *auth.OAuthError
+	if !errors.As(err, &oauthError) || oauthError.StatusCode != http.StatusBadRequest {
+		t.Fatalf("permanent issuer error lost its typed OAuth identity: %v", err)
+	}
+	if got := requests.Load(); got != 1 {
+		t.Errorf("default SDK retries repeated a permanent issuer failure %d times", got)
+	}
+	if requests := api.requests(); len(requests) != 0 {
+		t.Errorf("permanent issuer failure sent %d protected API requests", len(requests))
+	}
+}
+
+func TestX509WorkloadIdentityDoesNotMutateCallerOwnedRequest(t *testing.T) {
+	t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+	config, issuer, api := newX509WorkloadIdentityIntegration(t)
+	var observed atomic.Int32
+	client := openai.NewClient(
+		option.WithX509WorkloadIdentity(config),
+		option.WithMiddleware(func(request *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+			response, err := next(request)
+			if request.Header.Get("Authorization") != "" {
+				t.Error("X.509 authentication wrote a bearer credential into the caller-owned request")
+			}
+			observed.Add(1)
+			return response, err
+		}),
+	)
+	if _, err := client.Models.List(t.Context()); err != nil {
+		t.Fatalf("request with observer middleware: %v", err)
+	}
+	if observed.Load() != 1 || len(issuer.requests()) != 1 || len(api.requests()) != 1 {
+		t.Errorf("request observer/issuer/API calls = %d/%d/%d", observed.Load(), len(issuer.requests()), len(api.requests()))
+	}
+	if request := api.requests()[0]; request.authorization != "Bearer "+x509ConformanceToken {
+		t.Error("cloned API request did not receive its expected bearer credential")
 	}
 }
 

--- a/x509_workload_identity_integration_test.go
+++ b/x509_workload_identity_integration_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/auth"
 	"github.com/openai/openai-go/v3/azure"
-	"github.com/openai/openai-go/v3/bedrock"
 	"github.com/openai/openai-go/v3/option"
 )
 
@@ -280,7 +279,7 @@ func TestX509WorkloadIdentityDoesNotMutateCallerOwnedRequest(t *testing.T) {
 	}
 }
 
-func TestX509WorkloadIdentityRejectsAzureAndBedrockBeforeExchange(t *testing.T) {
+func TestX509WorkloadIdentityRejectsAzureBeforeExchange(t *testing.T) {
 	t.Run("Azure endpoint without credentials", func(t *testing.T) {
 		t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
 		config, issuer, api := newX509WorkloadIdentityIntegration(t)
@@ -305,21 +304,6 @@ func TestX509WorkloadIdentityRejectsAzureAndBedrockBeforeExchange(t *testing.T) 
 		)
 		if _, err := client.Models.List(t.Context()); err == nil {
 			t.Fatal("Azure API-key provider accepted an X.509 workload identity")
-		}
-		assertX509WorkloadNoRequests(t, issuer, api)
-	})
-	t.Run("Bedrock SkipAuth", func(t *testing.T) {
-		t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
-		config, issuer, api := newX509WorkloadIdentityIntegration(t)
-		client, err := bedrock.NewClient(t.Context(), bedrock.Config{
-			AWSRegion: "us-east-1",
-			SkipAuth:  true,
-		}, option.WithX509WorkloadIdentity(config), option.WithMaxRetries(0))
-		if err == nil {
-			_, err = client.Models.List(t.Context())
-		}
-		if err == nil {
-			t.Fatal("Bedrock SkipAuth accepted an X.509 workload identity")
 		}
 		assertX509WorkloadNoRequests(t, issuer, api)
 	})

--- a/x509_workload_identity_integration_test.go
+++ b/x509_workload_identity_integration_test.go
@@ -102,7 +102,13 @@ func TestX509WorkloadIdentityRejectsConflictingCredentialsAndClients(t *testing.
 		{name: "native HTTP client override", after: func(auth.X509WorkloadIdentity) []option.RequestOption {
 			return []option.RequestOption{option.WithHTTPClient(&http.Client{})}
 		}},
+		{name: "earlier native HTTP client override", before: func(auth.X509WorkloadIdentity) []option.RequestOption {
+			return []option.RequestOption{option.WithHTTPClient(&http.Client{})}
+		}},
 		{name: "opaque HTTP client override", after: func(auth.X509WorkloadIdentity) []option.RequestOption {
+			return []option.RequestOption{option.WithHTTPClient(x509WorkloadRejectedDoer{})}
+		}},
+		{name: "earlier opaque HTTP client override", before: func(auth.X509WorkloadIdentity) []option.RequestOption {
 			return []option.RequestOption{option.WithHTTPClient(x509WorkloadRejectedDoer{})}
 		}},
 		{name: "other workload identity", after: func(config auth.X509WorkloadIdentity) []option.RequestOption {
@@ -151,6 +157,7 @@ func TestX509WorkloadIdentityRejectsLateMiddlewareMutationBeforeExchange(t *test
 		{name: "credential trailer", mutate: func(request *http.Request) {
 			request.Trailer = http.Header{"Authorization": []string{"Bearer attacker-token"}}
 		}},
+		{name: "nil header map", mutate: func(request *http.Request) { request.Header = nil }},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
@@ -173,6 +180,109 @@ func TestX509WorkloadIdentityRejectsLateMiddlewareMutationBeforeExchange(t *test
 			assertX509WorkloadNoRequests(t, issuer, api)
 		})
 	}
+}
+
+func TestX509WorkloadIdentityPreservesStandaloneHTTPClientProvenance(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		service   func(auth.X509WorkloadIdentity) openai.ModelService
+		method    func(auth.X509WorkloadIdentity) []option.RequestOption
+		wantCalls bool
+	}{
+		{
+			name: "standalone implicit native default",
+			service: func(config auth.X509WorkloadIdentity) openai.ModelService {
+				return openai.NewModelService(option.WithX509WorkloadIdentity(config))
+			},
+			wantCalls: true,
+		},
+		{
+			name: "standalone same-layer custom client",
+			service: func(config auth.X509WorkloadIdentity) openai.ModelService {
+				return openai.NewModelService(option.WithHTTPClient(&http.Client{}), option.WithX509WorkloadIdentity(config))
+			},
+		},
+		{
+			name: "standalone inherited custom client",
+			service: func(auth.X509WorkloadIdentity) openai.ModelService {
+				return openai.NewModelService(option.WithHTTPClient(&http.Client{}))
+			},
+			method: func(config auth.X509WorkloadIdentity) []option.RequestOption {
+				return []option.RequestOption{option.WithX509WorkloadIdentity(config)}
+			},
+		},
+		{
+			name: "standalone later custom client",
+			service: func(config auth.X509WorkloadIdentity) openai.ModelService {
+				return openai.NewModelService(option.WithX509WorkloadIdentity(config), option.WithHTTPClient(&http.Client{}))
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			config, issuer, api := newX509WorkloadIdentityIntegration(t)
+			service := test.service(config)
+			var opts []option.RequestOption
+			if test.method != nil {
+				opts = test.method(config)
+			}
+			_, err := service.List(t.Context(), opts...)
+			if test.wantCalls {
+				if err != nil {
+					t.Fatalf("standalone model service with its implicit native default: %v", err)
+				}
+				if len(issuer.requests()) != 1 || len(api.requests()) != 1 {
+					t.Errorf("standalone model service issuer/API calls = %d/%d", len(issuer.requests()), len(api.requests()))
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("standalone X.509 service accepted an explicit custom HTTP client")
+			}
+			assertX509WorkloadNoRequests(t, issuer, api)
+		})
+	}
+}
+
+func TestX509WorkloadIdentityUsesOnlyTheLastAuthenticationOption(t *testing.T) {
+	t.Run("invalid earlier identity is never initialized", func(t *testing.T) {
+		t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+		config, issuer, api := newX509WorkloadIdentityIntegration(t)
+		invalid := config
+		invalid.IdentityProviderID = ""
+		client := openai.NewClient(option.WithX509WorkloadIdentity(invalid), option.WithX509WorkloadIdentity(config))
+		if _, err := client.Models.List(t.Context()); err != nil {
+			t.Fatalf("later valid X.509 option did not replace an invalid earlier identity: %v", err)
+		}
+		if len(issuer.requests()) != 1 || len(api.requests()) != 1 {
+			t.Errorf("winning X.509 option issuer/API calls = %d/%d", len(issuer.requests()), len(api.requests()))
+		}
+	})
+	t.Run("later client identity owns exchange and dispatch", func(t *testing.T) {
+		t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+		first, firstIssuer, firstAPI := newX509WorkloadIdentityIntegration(t)
+		second, secondIssuer, secondAPI := newX509WorkloadIdentityIntegration(t)
+		client := openai.NewClient(option.WithX509WorkloadIdentity(first), option.WithX509WorkloadIdentity(second))
+		if _, err := client.Models.List(t.Context()); err != nil {
+			t.Fatalf("later X.509 transport did not replace an earlier generation: %v", err)
+		}
+		assertX509WorkloadNoRequests(t, firstIssuer, firstAPI)
+		if len(secondIssuer.requests()) != 1 || len(secondAPI.requests()) != 1 {
+			t.Errorf("winning X.509 transport issuer/API calls = %d/%d", len(secondIssuer.requests()), len(secondAPI.requests()))
+		}
+	})
+	t.Run("method identity replaces inherited identity", func(t *testing.T) {
+		t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+		first, firstIssuer, firstAPI := newX509WorkloadIdentityIntegration(t)
+		second, secondIssuer, secondAPI := newX509WorkloadIdentityIntegration(t)
+		client := openai.NewClient(option.WithX509WorkloadIdentity(first))
+		if _, err := client.Models.List(t.Context(), option.WithX509WorkloadIdentity(second)); err != nil {
+			t.Fatalf("method-level X.509 transport did not replace its inherited generation: %v", err)
+		}
+		assertX509WorkloadNoRequests(t, firstIssuer, firstAPI)
+		if len(secondIssuer.requests()) != 1 || len(secondAPI.requests()) != 1 {
+			t.Errorf("winning method X.509 transport issuer/API calls = %d/%d", len(secondIssuer.requests()), len(secondAPI.requests()))
+		}
+	})
 }
 
 func TestX509WorkloadIdentityRejectsMethodLevelOverridesBeforeExchange(t *testing.T) {

--- a/x509_workload_identity_integration_test.go
+++ b/x509_workload_identity_integration_test.go
@@ -253,6 +253,74 @@ func TestX509WorkloadIdentityPreservesStandaloneHTTPClientProvenance(t *testing.
 	}
 }
 
+func TestX509WorkloadIdentityComposesCopiedClientOptionsSafely(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		baseOptions   []option.RequestOption
+		workloadFirst bool
+		wantCalls     bool
+	}{
+		{name: "workload before copied SDK defaults", workloadFirst: true, wantCalls: true},
+		{name: "workload after copied SDK defaults", wantCalls: true},
+		{
+			name:          "copied explicit native client after workload",
+			baseOptions:   []option.RequestOption{option.WithHTTPClient(&http.Client{})},
+			workloadFirst: true,
+		},
+		{
+			name:          "copied explicit opaque client after workload",
+			baseOptions:   []option.RequestOption{option.WithHTTPClient(x509WorkloadRejectedDoer{})},
+			workloadFirst: true,
+		},
+		{
+			name:        "copied explicit native client before workload",
+			baseOptions: []option.RequestOption{option.WithHTTPClient(&http.Client{})},
+		},
+		{
+			name:        "copied explicit opaque client before workload",
+			baseOptions: []option.RequestOption{option.WithHTTPClient(x509WorkloadRejectedDoer{})},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("OPENAI_API_KEY", "")
+			t.Setenv("OPENAI_ADMIN_KEY", "")
+			t.Setenv("OPENAI_CUSTOM_HEADERS", "")
+			t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+			config, issuer, api := newX509WorkloadIdentityIntegration(t)
+			base := openai.NewClient(test.baseOptions...)
+			var opts []option.RequestOption
+			if test.workloadFirst {
+				opts = append(opts, option.WithX509WorkloadIdentity(config))
+			}
+			opts = append(opts, base.Options...)
+			if !test.workloadFirst {
+				opts = append(opts, option.WithX509WorkloadIdentity(config))
+			}
+			client := openai.NewClient(opts...)
+			_, err := client.Models.List(t.Context())
+			if !test.wantCalls {
+				if err == nil {
+					t.Fatal("copied client options accepted an explicit custom HTTP client")
+				}
+				assertX509WorkloadNoRequests(t, issuer, api)
+				return
+			}
+			if err != nil {
+				t.Fatalf("copied SDK-owned HTTP client defaults: %v", err)
+			}
+			issuerRequests := issuer.requests()
+			apiRequests := api.requests()
+			if len(issuerRequests) != 1 || len(apiRequests) != 1 {
+				t.Fatalf("composed client issuer/API calls = %d/%d, want 1/1", len(issuerRequests), len(apiRequests))
+			}
+			if issuerRequests[0].peerCommonName != "integrated-workload" ||
+				apiRequests[0].peerCommonName != "integrated-workload" {
+				t.Error("composed client did not present its attested workload certificate")
+			}
+		})
+	}
+}
+
 func TestX509WorkloadIdentityUsesOnlyTheLastAuthenticationOption(t *testing.T) {
 	t.Run("same option reused in one layer", func(t *testing.T) {
 		t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")

--- a/x509_workload_identity_integration_test.go
+++ b/x509_workload_identity_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"os"
 	"sync/atomic"
 	"testing"
 
@@ -280,12 +281,33 @@ func TestX509WorkloadIdentityComposesCopiedClientOptionsSafely(t *testing.T) {
 			name:        "copied explicit opaque client before workload",
 			baseOptions: []option.RequestOption{option.WithHTTPClient(x509WorkloadRejectedDoer{})},
 		},
+		{
+			name:          "copied explicit production endpoint after workload",
+			baseOptions:   []option.RequestOption{option.WithBaseURL("https://api.openai.com/v1/")},
+			workloadFirst: true,
+		},
+		{
+			name:          "copied explicit regional endpoint after workload",
+			baseOptions:   []option.RequestOption{option.WithBaseURL("https://eu.api.openai.com/v1/")},
+			workloadFirst: true,
+		},
+		{
+			name:        "copied explicit production endpoint before workload",
+			baseOptions: []option.RequestOption{option.WithBaseURL("https://api.openai.com/v1/")},
+		},
+		{
+			name:        "copied explicit regional endpoint before workload",
+			baseOptions: []option.RequestOption{option.WithBaseURL("https://eu.api.openai.com/v1/")},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Setenv("OPENAI_API_KEY", "")
 			t.Setenv("OPENAI_ADMIN_KEY", "")
 			t.Setenv("OPENAI_CUSTOM_HEADERS", "")
-			t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+			t.Setenv("OPENAI_BASE_URL", "synthetic-placeholder")
+			if err := os.Unsetenv("OPENAI_BASE_URL"); err != nil {
+				t.Fatalf("remove configured endpoint before copying SDK defaults: %v", err)
+			}
 			config, issuer, api := newX509WorkloadIdentityIntegration(t)
 			base := openai.NewClient(test.baseOptions...)
 			var opts []option.RequestOption
@@ -300,7 +322,7 @@ func TestX509WorkloadIdentityComposesCopiedClientOptionsSafely(t *testing.T) {
 			_, err := client.Models.List(t.Context())
 			if !test.wantCalls {
 				if err == nil {
-					t.Fatal("copied client options accepted an explicit custom HTTP client")
+					t.Fatal("copied client options accepted an explicit custom HTTP client or unsafe endpoint")
 				}
 				assertX509WorkloadNoRequests(t, issuer, api)
 				return

--- a/x509_workload_identity_response_test.go
+++ b/x509_workload_identity_response_test.go
@@ -1,0 +1,76 @@
+package openai_test
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"sync/atomic"
+	"testing"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+)
+
+func TestX509WorkloadIdentityRedactsReturnedResponseRequests(t *testing.T) {
+	for _, status := range []int{http.StatusOK, http.StatusUnauthorized} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+			config, issuer, api := newX509WorkloadIdentityIntegration(t)
+			originalHandler := api.server.Config.Handler
+			var wireRequests, observedResponses atomic.Int32
+			api.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+				wireRequests.Add(1)
+				if got := request.Header.Get("Authorization"); got != "Bearer "+x509ConformanceToken {
+					t.Errorf("mutually authenticated API wire authorization = %q", got)
+				}
+				if status == http.StatusUnauthorized {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(status)
+					_, _ = io.WriteString(w, `{"error":{"message":"synthetic unauthorized","type":"invalid_request_error"}}`)
+					return
+				}
+				originalHandler.ServeHTTP(w, request)
+			})
+
+			var returned *http.Response
+			client := openai.NewClient(
+				option.WithX509WorkloadIdentity(config),
+				option.WithMaxRetries(0),
+				option.WithMiddleware(func(request *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+					response, err := next(request)
+					if response == nil || response.Request == nil {
+						t.Error("outer middleware did not receive its response request metadata")
+					} else if got := response.Request.Header.Get("Authorization"); got != "" {
+						t.Errorf("outer middleware observed a workload bearer in response metadata: %q", got)
+					}
+					observedResponses.Add(1)
+					return response, err
+				}),
+			)
+			_, err := client.Models.List(t.Context(), option.WithResponseInto(&returned))
+			if status == http.StatusOK && err != nil {
+				t.Fatalf("successful mutually authenticated API request: %v", err)
+			}
+			if status == http.StatusUnauthorized {
+				var apiError *openai.Error
+				if !errors.As(err, &apiError) || apiError.StatusCode != status {
+					t.Fatalf("unauthorized mutually authenticated API request = %v", err)
+				}
+				if apiError.Response == nil || apiError.Response.Request == nil ||
+					apiError.Response.Request.Header.Get("Authorization") != "" {
+					t.Error("typed API error retained workload credentials in its response metadata")
+				}
+			}
+			if returned == nil || returned.Request == nil || returned.Request.URL.Host != x509ConformanceAPIHost {
+				t.Fatal("WithResponseInto did not preserve the response request and destination")
+			}
+			if got := returned.Request.Header.Get("Authorization"); got != "" {
+				t.Errorf("WithResponseInto retained a workload bearer in response metadata: %q", got)
+			}
+			if wireRequests.Load() != 1 || observedResponses.Load() != 1 || len(issuer.requests()) != 1 {
+				t.Errorf("API/middleware/issuer calls = %d/%d/%d, want 1/1/1",
+					wireRequests.Load(), observedResponses.Load(), len(issuer.requests()))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fourth of five stacked Go X.509 workload identity federation changes, based on #856 after #855 and #854.

- Add the explicit X.509 workload identity configuration and `option.WithX509WorkloadIdentity` public-client integration without touching generated SDK source or Azure/Bedrock implementations.
- Bind every issuer and API request to the exact attested transport, clear inherited credentials, preserve and strictly validate configured/environment endpoints, and reject provider, credential, HTTP-client, headerless-operation, or admin-only conflicts before exchange.
- Install a final signer at the transport boundary, isolate signed requests from caller middleware, and mark deterministic authentication/policy errors as non-retryable.
- Cover real certificate-based issuer/API exchanges, malicious middleware, endpoint poisoning, provider conflicts, authentication layering, and generated public entry points.

## Review and security

- Two independent agents reviewed the complete committed range; all findings were addressed and both reviewers repeated the exact-commit review.
- Exact-commit Codex Security scan `c809c251-9ed1-4bf8-8d17-824c7b5f8ae4` reviewed all eight changed files, including the isolated Bedrock provider regression, and reported no findings.

## Verification

- Full repository `go test ./...`.
- Race-tested `auth`, `option`, Azure, Bedrock, request configuration, and root public-client integration.
- Full repository and multi-module lint, focused repeated adversarial tests, `go vet`, and `git diff --check`.
