### PR TITLE
feat(auth): complete X.509 token lifecycle and setup guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1206,6 +1206,75 @@ client := openai.NewClient(
 )
 ```
 
+### X.509 Workload Identity
+
+An enrolled workload certificate can also be exchanged directly for a
+short-lived OpenAI bearer token. Load and own the certificate and private key in
+your application, configure one static certificate on a native transport, and
+attest that transport before creating the client:
+
+```go
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+	"time"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/auth"
+	"github.com/openai/openai-go/v3/option"
+)
+
+certificate, err := tls.LoadX509KeyPair("workload.crt", "workload.key")
+if err != nil {
+	return err
+}
+
+transport, err := auth.NewX509Transport(&http.Transport{
+	TLSClientConfig: &tls.Config{
+		MinVersion:   tls.VersionTLS12,
+		Certificates: []tls.Certificate{certificate},
+	},
+})
+if err != nil {
+	return err
+}
+defer transport.Close()
+
+client := openai.NewClient(option.WithX509WorkloadIdentity(auth.X509WorkloadIdentity{
+	IdentityProviderID: "idp-123",
+	ServiceAccountID:   "sa-456",
+	RefreshBuffer:      5 * time.Minute, // Optional; five minutes is the default.
+	Transport:          transport,
+}))
+
+if _, err := client.Models.List(context.Background()); err != nil {
+	return err
+}
+```
+
+The application retains ownership of its certificate, private key, trust roots,
+and original transport. The attested capability creates its own isolated
+connection pool, so call `Close` when it is no longer needed. Rotating the
+certificate requires a newly attested transport and client.
+
+Token exchange is pinned to `https://mtls.auth.openai.com/oauth/token`; API
+requests use `https://mtls.api.openai.com/v1/`. Existing `OPENAI_BASE_URL` and
+explicit endpoint settings must match that global API endpoint. Azure, Amazon
+Bedrock, regional endpoints, HTTPS proxies, dynamic certificate selection, HTTP
+trace hooks, and separate custom HTTP clients are not supported. Organization
+and project metadata remain available on API requests but are not sent to the
+token issuer.
+
+Successful bearer tokens are cached per identity and transport generation.
+Concurrent refreshes share the requesting caller's context, and the effective
+refresh buffer is reduced automatically for short-lived tokens. Transient issuer
+failures receive at most three bounded, cancellable attempts; permanent OAuth
+failures are not retried. A rejected API token is refreshed and replayed at most
+once, and only when the request body can be recreated. The resulting access
+token is an ordinary bearer token; it is not cryptographically bound to a
+client certificate.
+
 ## Amazon Bedrock
 
 Use the `bedrock` package to call OpenAI models through Amazon Bedrock's

--- a/README.md
+++ b/README.md
@@ -1270,8 +1270,13 @@ Successful bearer tokens are cached per identity and transport generation.
 Concurrent refreshes share the requesting caller's context, and the effective
 refresh buffer is reduced automatically for short-lived tokens. Transient issuer
 failures receive at most three bounded, cancellable attempts; permanent OAuth
-failures are not retried. A rejected API token is refreshed and replayed at most
-once, and only when the request body can be recreated. The resulting access
+failures are not retried. Issuer retries, ordinary API retries, and unauthorized
+recovery share the client's single request retry budget. A rejected API token is
+refreshed and replayed at most once, and only when the request body can be
+recreated; body-bearing requests with caller middleware are not replayed because
+that middleware may have transformed their bytes. During a temporary proactive
+refresh failure, an unexpired cached token remains usable for a bounded cooldown.
+The resulting access
 token is an ordinary bearer token; it is not cryptographically bound to a
 client certificate.
 

--- a/auth/x509lifecycle_test.go
+++ b/auth/x509lifecycle_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -216,6 +217,125 @@ func TestX509WorkloadIdentityCancelsRetryBackoff(t *testing.T) {
 	}
 	if got := attempts.Load(); got != 1 {
 		t.Errorf("canceled retry backoff made %d issuer attempts", got)
+	}
+}
+
+func TestX509WorkloadIdentityRetriesRedactedTransientNetworkFailure(t *testing.T) {
+	fixture := newX509ExchangeFixture(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, x509ValidExchangeResponse())
+	}))
+	originalDial := fixture.template.DialContext
+	var attempts atomic.Int32
+	fixture.template.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		if attempts.Add(1) == 1 {
+			return nil, errors.New("synthetic-private-first-dial-failure")
+		}
+		return originalDial(ctx, network, address)
+	}
+	transport, err := NewX509Transport(fixture.template)
+	if err != nil {
+		t.Fatalf("attest transient-dial workload transport: %v", err)
+	}
+	t.Cleanup(func() { _ = transport.Close() })
+	identity, err := NewX509WorkloadIdentityAuth(X509WorkloadIdentity{
+		IdentityProviderID: "synthetic-identity-provider",
+		ServiceAccountID:   "synthetic-service-account",
+		Transport:          transport,
+	})
+	if err != nil {
+		t.Fatalf("construct transient-dial workload identity: %v", err)
+	}
+	token, err := identity.GetToken(t.Context(), transport)
+	if err != nil || token != x509ExchangeSyntheticToken || attempts.Load() != 2 {
+		t.Errorf("transient native dial token=%q attempts=%d error=%v", token, attempts.Load(), err)
+	}
+	for _, permanent := range []error{errX509Redirect, context.Canceled, context.DeadlineExceeded} {
+		if retryableX509ExchangeError(&x509TransportError{cause: permanent}) {
+			t.Errorf("non-transient native transport cause was retried: %v", permanent)
+		}
+	}
+}
+
+func TestX509WorkloadIdentityPreservesUnexpiredBearerDuringTransientRefreshFailure(t *testing.T) {
+	var exchanges atomic.Int32
+	var failureStatus atomic.Int32
+	fixture := newX509ExchangeFixture(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		exchanges.Add(1)
+		if status := failureStatus.Load(); status != 0 {
+			w.WriteHeader(int(status))
+			_, _ = io.WriteString(w, `{"error":"invalid_grant"}`)
+			return
+		}
+		_, _ = io.WriteString(w, x509ValidExchangeResponse())
+	}))
+	identity := newX509LifecycleIdentity(t, fixture)
+	initial, err := identity.GetToken(t.Context(), fixture.capability)
+	if err != nil {
+		t.Fatalf("prime proactive-refresh token cache: %v", err)
+	}
+	failureStatus.Store(http.StatusServiceUnavailable)
+	identity.mu.Lock()
+	identity.refreshAfter = time.Now().Add(-time.Second)
+	identity.mu.Unlock()
+	fallback, err := identity.GetToken(t.Context(), fixture.capability)
+	if err != nil || fallback != initial || exchanges.Load() != 4 {
+		t.Fatalf("transient proactive refresh fallback=%q exchanges=%d error=%v", fallback, exchanges.Load(), err)
+	}
+	identity.mu.Lock()
+	cooldown, expiry := identity.refreshAfter, identity.cached.expiresAt
+	identity.mu.Unlock()
+	if !cooldown.After(time.Now()) || cooldown.After(expiry) {
+		t.Errorf("proactive retry cooldown = %v, token expiry = %v", cooldown, expiry)
+	}
+	if cached, cachedErr := identity.GetToken(t.Context(), fixture.capability); cachedErr != nil || cached != initial ||
+		exchanges.Load() != 4 {
+		t.Errorf("cooldown did not protect still-valid bearer: token=%q exchanges=%d error=%v",
+			cached, exchanges.Load(), cachedErr)
+	}
+	identity.mu.Lock()
+	identity.cached.expiresAt = time.Now().Add(-time.Second)
+	identity.refreshAfter = time.Now().Add(-time.Second)
+	identity.mu.Unlock()
+	if token, exchangeErr := identity.GetToken(t.Context(), fixture.capability); token != "" || exchangeErr == nil {
+		t.Errorf("expired bearer was used after refresh failure: token=%q error=%v", token, exchangeErr)
+	}
+}
+
+func TestX509WorkloadIdentityNeverFallsBackAfterPermanentOrInvalidatedFailure(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		status     int
+		invalidate bool
+	}{
+		{name: "permanent invalid grant", status: http.StatusBadRequest},
+		{name: "invalidated bearer", status: http.StatusServiceUnavailable, invalidate: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var failing atomic.Bool
+			fixture := newX509ExchangeFixture(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if failing.Load() {
+					w.WriteHeader(test.status)
+					_, _ = io.WriteString(w, `{"error":"invalid_grant"}`)
+					return
+				}
+				_, _ = io.WriteString(w, x509ValidExchangeResponse())
+			}))
+			identity := newX509LifecycleIdentity(t, fixture)
+			token, err := identity.GetToken(t.Context(), fixture.capability)
+			if err != nil {
+				t.Fatalf("prime X.509 failure cache: %v", err)
+			}
+			identity.mu.Lock()
+			identity.refreshAfter = time.Now().Add(-time.Second)
+			identity.mu.Unlock()
+			if test.invalidate {
+				identity.invalidateToken(token)
+			}
+			failing.Store(true)
+			if cached, exchangeErr := identity.GetToken(t.Context(), fixture.capability); cached != "" || exchangeErr == nil {
+				t.Errorf("unsafe fallback returned bearer=%q error=%v", cached, exchangeErr)
+			}
+		})
 	}
 }
 

--- a/auth/x509lifecycle_test.go
+++ b/auth/x509lifecycle_test.go
@@ -1,0 +1,273 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestX509WorkloadIdentitySharesConcurrentRefreshes(t *testing.T) {
+	var exchanges atomic.Int32
+	release := make(chan struct{})
+	fixture := newX509ExchangeFixture(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		exchanges.Add(1)
+		<-release
+		_, _ = io.WriteString(w, x509ValidExchangeResponse())
+	}))
+	identity := newX509LifecycleIdentity(t, fixture)
+	const callers = 32
+	var ready, finished sync.WaitGroup
+	ready.Add(callers)
+	finished.Add(callers)
+	start := make(chan struct{})
+	results := make(chan error, callers)
+	for range callers {
+		go func() {
+			defer finished.Done()
+			ready.Done()
+			<-start
+			token, err := identity.GetToken(t.Context(), fixture.capability)
+			if err == nil && token != x509ExchangeSyntheticToken {
+				err = errors.New("concurrent refresh returned an unexpected token")
+			}
+			results <- err
+		}()
+	}
+	ready.Wait()
+	close(start)
+	close(release)
+	finished.Wait()
+	close(results)
+	for err := range results {
+		if err != nil {
+			t.Errorf("concurrent token request: %v", err)
+		}
+	}
+	if got := exchanges.Load(); got != 1 {
+		t.Errorf("%d concurrent token callers performed %d exchanges", callers, got)
+	}
+}
+
+func TestX509WorkloadIdentityRecoversAfterCanceledRefreshLeader(t *testing.T) {
+	var exchanges atomic.Int32
+	firstReached := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	defer close(releaseFirst)
+	fixture := newX509ExchangeFixture(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if exchanges.Add(1) == 1 {
+			close(firstReached)
+			<-releaseFirst
+			return
+		}
+		_, _ = io.WriteString(w, x509ValidExchangeResponse())
+	}))
+	identity := newX509LifecycleIdentity(t, fixture)
+	leaderContext, cancelLeader := context.WithCancel(t.Context())
+	defer cancelLeader()
+	leaderResult := make(chan error, 1)
+	go func() {
+		_, err := identity.GetToken(leaderContext, fixture.capability)
+		leaderResult <- err
+	}()
+	select {
+	case <-firstReached:
+	case <-time.After(5 * time.Second):
+		t.Fatal("initial refresh leader never reached the issuer")
+	}
+	followerResult := make(chan error, 1)
+	go func() {
+		token, err := identity.GetToken(t.Context(), fixture.capability)
+		if err == nil && token != x509ExchangeSyntheticToken {
+			err = errors.New("healthy refresh follower received an unexpected token")
+		}
+		followerResult <- err
+	}()
+	cancelLeader()
+	select {
+	case err := <-leaderResult:
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("canceled leader error = %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("canceled refresh leader did not finish")
+	}
+	select {
+	case err := <-followerResult:
+		if err != nil {
+			t.Errorf("healthy follower did not recover after leader cancellation: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("healthy refresh follower was poisoned by the canceled leader")
+	}
+	if got := exchanges.Load(); got != 2 {
+		t.Errorf("canceled leader and healthy follower made %d exchanges, want exactly two", got)
+	}
+}
+
+func TestX509WorkloadIdentityRefreshBufferHandlesShortLifetimes(t *testing.T) {
+	var exchanges atomic.Int32
+	fixture := newX509ExchangeFixture(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		number := exchanges.Add(1)
+		body := strings.Replace(x509ValidExchangeResponse(), x509ExchangeSyntheticToken,
+			"synthetic-short-token-"+strconv.Itoa(int(number)), 1)
+		body = strings.Replace(body, `"expires_in":60`, `"expires_in":1`, 1)
+		_, _ = io.WriteString(w, body)
+	}))
+	identity := newX509LifecycleIdentity(t, fixture)
+	first, err := identity.GetToken(t.Context(), fixture.capability)
+	if err != nil {
+		t.Fatalf("acquire short-lived token: %v", err)
+	}
+	second, err := identity.GetToken(t.Context(), fixture.capability)
+	if err != nil || first != second || exchanges.Load() != 1 {
+		t.Fatalf("short-lived token was not cached: first=%q second=%q exchanges=%d error=%v",
+			first, second, exchanges.Load(), err)
+	}
+	identity.mu.Lock()
+	identity.refreshAfter = time.Now().Add(-time.Millisecond)
+	identity.mu.Unlock()
+	third, err := identity.GetToken(t.Context(), fixture.capability)
+	if err != nil || third == first || exchanges.Load() != 2 {
+		t.Errorf("expired refresh window returned token=%q exchanges=%d error=%v", third, exchanges.Load(), err)
+	}
+}
+
+func TestX509WorkloadIdentityRetriesOnlyBoundedTransientIssuerFailures(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		status       int
+		failures     int32
+		wantAttempts int32
+		wantSuccess  bool
+		truncated    bool
+	}{
+		{name: "rate limited then succeeds", status: 429, failures: 2, wantAttempts: 3, wantSuccess: true},
+		{name: "server error then succeeds", status: 500, failures: 2, wantAttempts: 3, wantSuccess: true},
+		{name: "service unavailable exhausts budget", status: 503, failures: 3, wantAttempts: 3},
+		{name: "body read failure then succeeds", failures: 2, wantAttempts: 3, wantSuccess: true, truncated: true},
+		{name: "permanent OAuth failure", status: 400, failures: 3, wantAttempts: 1},
+		{name: "permanent HTTP status", status: 404, failures: 3, wantAttempts: 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var attempts atomic.Int32
+			fixture := newX509ExchangeFixture(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				attempt := attempts.Add(1)
+				if attempt <= test.failures {
+					if test.truncated {
+						w.Header().Set("Content-Length", "1024")
+						_, _ = io.WriteString(w, "synthetic-truncated-issuer-response")
+						return
+					}
+					w.WriteHeader(test.status)
+					_, _ = io.WriteString(w, `{"error":"invalid_grant"}`)
+					return
+				}
+				_, _ = io.WriteString(w, x509ValidExchangeResponse())
+			}))
+			identity := newX509LifecycleIdentity(t, fixture)
+			token, err := identity.GetToken(t.Context(), fixture.capability)
+			if (err == nil) != test.wantSuccess {
+				t.Errorf("transient retry result token=%q error=%v", token, err)
+			}
+			if got := attempts.Load(); got != test.wantAttempts {
+				t.Errorf("issuer attempts = %d, want %d", got, test.wantAttempts)
+			}
+		})
+	}
+}
+
+func TestX509WorkloadIdentityCancelsRetryBackoff(t *testing.T) {
+	var attempts atomic.Int32
+	reached := make(chan struct{})
+	fixture := newX509ExchangeFixture(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if attempts.Add(1) == 1 {
+			close(reached)
+		}
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	identity := newX509LifecycleIdentity(t, fixture)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	result := make(chan error, 1)
+	go func() {
+		_, err := identity.GetToken(ctx, fixture.capability)
+		result <- err
+	}()
+	select {
+	case <-reached:
+		cancel()
+	case <-time.After(5 * time.Second):
+		t.Fatal("retryable issuer did not receive the first exchange")
+	}
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("canceled retry backoff error = %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("retry backoff did not respect request cancellation")
+	}
+	if got := attempts.Load(); got != 1 {
+		t.Errorf("canceled retry backoff made %d issuer attempts", got)
+	}
+}
+
+func TestX509WorkloadIdentityCacheIsGenerationScoped(t *testing.T) {
+	var exchanges atomic.Int32
+	fixture := newX509ExchangeFixture(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		exchanges.Add(1)
+		_, _ = io.WriteString(w, x509ValidExchangeResponse())
+	}))
+	for range 2 {
+		identity := newX509LifecycleIdentity(t, fixture)
+		if _, err := identity.GetToken(t.Context(), fixture.capability); err != nil {
+			t.Fatalf("independent X.509 identity exchange: %v", err)
+		}
+	}
+	if got := exchanges.Load(); got != 2 {
+		t.Errorf("independent identity generations shared a cache: exchanges=%d", got)
+	}
+}
+
+func TestX509WorkloadIdentityInvalidatesOnlyTheRejectedBearer(t *testing.T) {
+	fixture := newX509ExchangeFixture(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, x509ValidExchangeResponse())
+	}))
+	identity := newX509LifecycleIdentity(t, fixture)
+	token, err := identity.GetToken(t.Context(), fixture.capability)
+	if err != nil {
+		t.Fatalf("prime X.509 bearer cache: %v", err)
+	}
+	identity.invalidateToken("stale-rejected-token")
+	identity.mu.Lock()
+	if identity.cached.value != token {
+		t.Error("a stale concurrent 401 invalidated the newer cached bearer")
+	}
+	identity.mu.Unlock()
+	identity.invalidateToken(token)
+	identity.mu.Lock()
+	if identity.cached.value != "" || !identity.refreshAfter.IsZero() {
+		t.Error("the rejected current bearer was not removed from the cache")
+	}
+	identity.mu.Unlock()
+}
+
+func newX509LifecycleIdentity(t *testing.T, fixture *x509ExchangeFixture) *X509WorkloadIdentityAuth {
+	t.Helper()
+	identity, err := NewX509WorkloadIdentityAuth(X509WorkloadIdentity{
+		IdentityProviderID: "synthetic-identity-provider",
+		ServiceAccountID:   "synthetic-service-account",
+		Transport:          fixture.capability,
+	})
+	if err != nil {
+		t.Fatalf("construct ephemeral X.509 lifecycle identity: %v", err)
+	}
+	return identity
+}

--- a/auth/x509lifecycle_test.go
+++ b/auth/x509lifecycle_test.go
@@ -12,6 +12,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/openai/openai-go/v3/internal/requestconfig"
 )
 
 func TestX509WorkloadIdentitySharesConcurrentRefreshes(t *testing.T) {
@@ -112,6 +114,177 @@ func TestX509WorkloadIdentityRecoversAfterCanceledRefreshLeader(t *testing.T) {
 	}
 }
 
+func TestX509WorkloadIdentityFollowersUseTheirOwnRetryBudgets(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		status        int
+		followerLimit int
+		wantExchanges int32
+		wantSuccess   bool
+	}{
+		{name: "retry-enabled follower recovers", status: http.StatusServiceUnavailable,
+			followerLimit: 2, wantExchanges: 2, wantSuccess: true},
+		{name: "zero-retry follower fails", status: http.StatusServiceUnavailable, wantExchanges: 1},
+		{name: "permanent failure is not retried", status: http.StatusBadRequest,
+			followerLimit: 2, wantExchanges: 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var exchanges atomic.Int32
+			firstReached := make(chan struct{})
+			releaseFirst := make(chan struct{})
+			fixture := newX509ExchangeFixture(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if exchanges.Add(1) == 1 {
+					close(firstReached)
+					<-releaseFirst
+					w.WriteHeader(test.status)
+					_, _ = io.WriteString(w, `{"error":{"code":"invalid_grant"}}`)
+					return
+				}
+				_, _ = io.WriteString(w, x509ValidExchangeResponse())
+			}))
+			identity := newX509LifecycleIdentity(t, fixture)
+			leaderScope := requestconfig.NewRequestRetryScope(0, time.Millisecond, true, nil)
+			leaderContext := requestconfig.WithRequestRetryScope(t.Context(), leaderScope)
+			if !leaderScope.BeginAttempt() {
+				t.Fatal("zero-retry leader initial attempt was rejected")
+			}
+			leaderResult := make(chan error, 1)
+			go func() {
+				_, err := identity.GetToken(leaderContext, fixture.capability)
+				leaderResult <- err
+			}()
+			select {
+			case <-firstReached:
+			case <-time.After(5 * time.Second):
+				t.Fatal("zero-retry refresh leader never reached the issuer")
+			}
+			followerScope := requestconfig.NewRequestRetryScope(test.followerLimit, time.Millisecond, true, nil)
+			followerParent := requestconfig.WithRequestRetryScope(t.Context(), followerScope)
+			if !followerScope.BeginAttempt() {
+				t.Fatal("follower initial attempt was rejected")
+			}
+			waiting := make(chan struct{})
+			followerContext := &x509ObservedDoneContext{Context: followerParent, observed: waiting}
+			followerResult := make(chan error, 1)
+			go func() {
+				token, err := identity.GetToken(followerContext, fixture.capability)
+				if err == nil && token != x509ExchangeSyntheticToken {
+					err = errors.New("retry-enabled follower received an unexpected bearer")
+				}
+				followerResult <- err
+			}()
+			select {
+			case <-waiting:
+				close(releaseFirst)
+			case <-time.After(5 * time.Second):
+				t.Fatal("refresh follower never waited for its shared leader")
+			}
+			select {
+			case err := <-leaderResult:
+				if err == nil {
+					t.Error("zero-retry refresh leader unexpectedly recovered")
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("zero-retry refresh leader did not finish")
+			}
+			select {
+			case err := <-followerResult:
+				if (err == nil) != test.wantSuccess {
+					t.Errorf("shared-failure follower error = %v, want success %t", err, test.wantSuccess)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("refresh follower did not finish after its shared failure")
+			}
+			if got := exchanges.Load(); got != test.wantExchanges {
+				t.Errorf("leader/follower issuer attempts = %d, want %d", got, test.wantExchanges)
+			}
+		})
+	}
+}
+
+type x509ObservedDoneContext struct {
+	context.Context
+	observed chan struct{}
+	once     sync.Once
+}
+
+func (ctx *x509ObservedDoneContext) Done() <-chan struct{} {
+	ctx.once.Do(func() { close(ctx.observed) })
+	return ctx.Context.Done()
+}
+
+func TestX509WorkloadIdentityNeverCachesExpiredExchange(t *testing.T) {
+	reached := make(chan struct{})
+	release := make(chan struct{})
+	written := make(chan struct{})
+	fixture := newX509ExchangeFixture(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(reached)
+		<-release
+		body := strings.Replace(x509ValidExchangeResponse(), `"expires_in":60`, `"expires_in":1`, 1)
+		_, _ = io.WriteString(w, body)
+		if flush, ok := w.(http.Flusher); ok {
+			flush.Flush()
+		}
+		close(written)
+	}))
+	identity := newX509LifecycleIdentity(t, fixture)
+	started := time.Now()
+	result := make(chan error, 1)
+	go func() {
+		token, err := identity.GetToken(t.Context(), fixture.capability)
+		if token != "" {
+			err = errors.New("expired exchange returned a bearer")
+		}
+		result <- err
+	}()
+	select {
+	case <-reached:
+	case <-time.After(5 * time.Second):
+		t.Fatal("short-lived exchange never reached the issuer")
+	}
+	identity.mu.Lock()
+	close(release)
+	select {
+	case <-written:
+	case <-time.After(5 * time.Second):
+		identity.mu.Unlock()
+		t.Fatal("short-lived issuer did not finish its response")
+	}
+	timer := time.NewTimer(time.Until(started.Add(1200 * time.Millisecond)))
+	<-timer.C
+	identity.mu.Unlock()
+	select {
+	case err := <-result:
+		if err == nil || !strings.Contains(err.Error(), "expired") {
+			t.Errorf("exchange expiring before cache insertion returned error = %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("expired exchange did not finish")
+	}
+	identity.mu.Lock()
+	if identity.cached.value != "" || !identity.refreshAfter.IsZero() {
+		t.Error("already-expired exchange was inserted into the workload token cache")
+	}
+	identity.mu.Unlock()
+}
+
+func TestX509WorkloadIdentityRejectsExpiredCachedTokenDespiteFutureRefresh(t *testing.T) {
+	var exchanges atomic.Int32
+	fixture := newX509ExchangeFixture(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		exchanges.Add(1)
+		_, _ = io.WriteString(w, x509ValidExchangeResponse())
+	}))
+	identity := newX509LifecycleIdentity(t, fixture)
+	identity.mu.Lock()
+	identity.cached = x509ExchangedToken{value: "expired-synthetic-bearer", expiresAt: time.Now().Add(-time.Second)}
+	identity.refreshAfter = time.Now().Add(time.Hour)
+	identity.mu.Unlock()
+	token, err := identity.GetToken(t.Context(), fixture.capability)
+	if err != nil || token != x509ExchangeSyntheticToken || exchanges.Load() != 1 {
+		t.Errorf("expired cached bearer result = %q, exchanges = %d, error = %v", token, exchanges.Load(), err)
+	}
+}
+
 func TestX509WorkloadIdentityRefreshBufferHandlesShortLifetimes(t *testing.T) {
 	var exchanges atomic.Int32
 	fixture := newX509ExchangeFixture(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -149,6 +322,8 @@ func TestX509WorkloadIdentityRetriesOnlyBoundedTransientIssuerFailures(t *testin
 		wantSuccess  bool
 		truncated    bool
 	}{
+		{name: "request timeout then succeeds", status: 408, failures: 2, wantAttempts: 3, wantSuccess: true},
+		{name: "conflict then succeeds", status: 409, failures: 2, wantAttempts: 3, wantSuccess: true},
 		{name: "rate limited then succeeds", status: 429, failures: 2, wantAttempts: 3, wantSuccess: true},
 		{name: "server error then succeeds", status: 500, failures: 2, wantAttempts: 3, wantSuccess: true},
 		{name: "service unavailable exhausts budget", status: 503, failures: 3, wantAttempts: 3},
@@ -184,14 +359,50 @@ func TestX509WorkloadIdentityRetriesOnlyBoundedTransientIssuerFailures(t *testin
 	}
 }
 
+func TestX509WorkloadIdentitySelectsBoundedIssuerRetryDelays(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		err     error
+		attempt int
+		scope   *requestconfig.RequestRetryScope
+		want    time.Duration
+	}{
+		{name: "ordinary exponential delay", err: &x509ExchangeHTTPError{statusCode: 503},
+			attempt: 1, want: 2 * x509InitialRetryDelay},
+		{name: "issuer-directed delay", err: &x509ExchangeHTTPError{
+			statusCode: 429, retryAfter: 70 * time.Millisecond, hasRetryAfter: true},
+			want: 70 * time.Millisecond},
+		{name: "explicit zero is immediate", err: &x509ExchangeHTTPError{
+			statusCode: 429, retryAfter: 0, hasRetryAfter: true}},
+		{name: "issuer hint obeys caller maximum", err: &x509ExchangeHTTPError{
+			statusCode: 503, retryAfter: time.Second, hasRetryAfter: true},
+			scope: requestconfig.NewRequestRetryScope(2, 7*time.Millisecond, true, nil), want: 7 * time.Millisecond},
+		{name: "ordinary delay obeys caller maximum", err: &x509ExchangeReadError{},
+			scope: requestconfig.NewRequestRetryScope(2, time.Millisecond, true, nil), want: time.Millisecond},
+		{name: "standalone delay remains bounded", err: &x509ExchangeHTTPError{
+			statusCode: 429, retryAfter: time.Hour, hasRetryAfter: true}, want: x509MaximumRetryAfter},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := x509ExchangeRetryDelay(test.err, test.attempt, test.scope); got != test.want {
+				t.Errorf("issuer retry delay = %s, want %s", got, test.want)
+			}
+		})
+	}
+}
+
 func TestX509WorkloadIdentityCancelsRetryBackoff(t *testing.T) {
 	var attempts atomic.Int32
 	reached := make(chan struct{})
 	fixture := newX509ExchangeFixture(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		if attempts.Add(1) == 1 {
+		attempt := attempts.Add(1)
+		w.Header().Set("Retry-After", "8")
+		w.WriteHeader(http.StatusTooManyRequests)
+		if flush, ok := w.(http.Flusher); ok {
+			flush.Flush()
+		}
+		if attempt == 1 {
 			close(reached)
 		}
-		w.WriteHeader(http.StatusTooManyRequests)
 	}))
 	identity := newX509LifecycleIdentity(t, fixture)
 	ctx, cancel := context.WithCancel(t.Context())

--- a/auth/x509lifecycle_test.go
+++ b/auth/x509lifecycle_test.go
@@ -2,6 +2,8 @@ package auth
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"io"
 	"net"
@@ -317,6 +319,7 @@ func TestX509WorkloadIdentityRetriesOnlyBoundedTransientIssuerFailures(t *testin
 	for _, test := range []struct {
 		name         string
 		status       int
+		oauthCode    string
 		failures     int32
 		wantAttempts int32
 		wantSuccess  bool
@@ -328,6 +331,10 @@ func TestX509WorkloadIdentityRetriesOnlyBoundedTransientIssuerFailures(t *testin
 		{name: "server error then succeeds", status: 500, failures: 2, wantAttempts: 3, wantSuccess: true},
 		{name: "service unavailable exhausts budget", status: 503, failures: 3, wantAttempts: 3},
 		{name: "body read failure then succeeds", failures: 2, wantAttempts: 3, wantSuccess: true, truncated: true},
+		{name: "temporarily unavailable OAuth error then succeeds", status: 400,
+			oauthCode: "temporarily_unavailable", failures: 2, wantAttempts: 3, wantSuccess: true},
+		{name: "server error OAuth error then succeeds", status: 401,
+			oauthCode: "server_error", failures: 2, wantAttempts: 3, wantSuccess: true},
 		{name: "permanent OAuth failure", status: 400, failures: 3, wantAttempts: 1},
 		{name: "permanent HTTP status", status: 404, failures: 3, wantAttempts: 1},
 	} {
@@ -342,7 +349,11 @@ func TestX509WorkloadIdentityRetriesOnlyBoundedTransientIssuerFailures(t *testin
 						return
 					}
 					w.WriteHeader(test.status)
-					_, _ = io.WriteString(w, `{"error":"invalid_grant"}`)
+					code := test.oauthCode
+					if code == "" {
+						code = "invalid_grant"
+					}
+					_, _ = io.WriteString(w, `{"error":"`+code+`"}`)
 					return
 				}
 				_, _ = io.WriteString(w, x509ValidExchangeResponse())
@@ -464,6 +475,107 @@ func TestX509WorkloadIdentityRetriesRedactedTransientNetworkFailure(t *testing.T
 		if retryableX509ExchangeError(&x509TransportError{cause: permanent}) {
 			t.Errorf("non-transient native transport cause was retried: %v", permanent)
 		}
+	}
+}
+
+func TestX509WorkloadIdentityDoesNotRetryPermanentTLSVerificationFailures(t *testing.T) {
+	const privateVerificationError = "Authorization: Bearer synthetic-private-verification-token"
+	for _, test := range []struct {
+		name              string
+		configure         func(*tls.Config, *atomic.Int32)
+		wantVerifications int32
+		cached            bool
+	}{
+		{
+			name: "caller connection verification",
+			configure: func(config *tls.Config, verifications *atomic.Int32) {
+				config.VerifyConnection = func(tls.ConnectionState) error {
+					verifications.Add(1)
+					return errors.New(privateVerificationError)
+				}
+			},
+			wantVerifications: 1,
+		},
+		{
+			name: "caller peer certificate verification",
+			configure: func(config *tls.Config, verifications *atomic.Int32) {
+				config.VerifyPeerCertificate = func([][]byte, [][]*x509.Certificate) error {
+					verifications.Add(1)
+					return errors.New(privateVerificationError)
+				}
+			},
+			wantVerifications: 1,
+		},
+		{
+			name: "native untrusted issuer certificate",
+			configure: func(config *tls.Config, _ *atomic.Int32) {
+				config.RootCAs = x509.NewCertPool()
+			},
+		},
+		{
+			name: "permanent verification failure does not reuse cached token",
+			configure: func(config *tls.Config, verifications *atomic.Int32) {
+				config.VerifyConnection = func(tls.ConnectionState) error {
+					verifications.Add(1)
+					return errors.New(privateVerificationError)
+				}
+			},
+			wantVerifications: 1,
+			cached:            true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var exchanges, attempts, verifications atomic.Int32
+			fixture := newX509ExchangeFixture(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				exchanges.Add(1)
+				_, _ = io.WriteString(w, x509ValidExchangeResponse())
+			}))
+			test.configure(fixture.template.TLSClientConfig, &verifications)
+			originalDial := fixture.template.DialContext
+			fixture.template.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+				attempts.Add(1)
+				return originalDial(ctx, network, address)
+			}
+			transport, err := NewX509Transport(fixture.template)
+			if err != nil {
+				t.Fatalf("attest TLS-verification workload transport: %v", err)
+			}
+			t.Cleanup(func() { _ = transport.Close() })
+			identity, err := NewX509WorkloadIdentityAuth(X509WorkloadIdentity{
+				IdentityProviderID: "synthetic-identity-provider",
+				ServiceAccountID:   "synthetic-service-account",
+				Transport:          transport,
+			})
+			if err != nil {
+				t.Fatalf("construct TLS-verification workload identity: %v", err)
+			}
+			if test.cached {
+				identity.cached = x509ExchangedToken{
+					value:     x509ExchangeSyntheticToken,
+					expiresAt: time.Now().Add(time.Minute),
+				}
+				identity.refreshAfter = time.Now().Add(-time.Second)
+			}
+			token, exchangeErr := identity.GetToken(t.Context(), transport)
+			if exchangeErr == nil || token != "" {
+				t.Errorf("permanent TLS-verification failure returned token=%q error=%v", token, exchangeErr)
+			}
+			for cause := exchangeErr; cause != nil; cause = errors.Unwrap(cause) {
+				if strings.Contains(cause.Error(), privateVerificationError) ||
+					strings.Contains(cause.Error(), "Authorization") {
+					t.Errorf("TLS verification error disclosed caller-private credentials: %v", cause)
+				}
+			}
+			if got := attempts.Load(); got != 1 {
+				t.Errorf("permanent TLS-verification failure attempted %d issuer handshakes, want 1", got)
+			}
+			if got := verifications.Load(); got != test.wantVerifications {
+				t.Errorf("TLS verification callback executed %d times, want %d", got, test.wantVerifications)
+			}
+			if got := exchanges.Load(); got != 0 {
+				t.Errorf("failed TLS verification reached the issuer handler %d times", got)
+			}
+		})
 	}
 }
 

--- a/auth/x509lifecycle_test.go
+++ b/auth/x509lifecycle_test.go
@@ -467,6 +467,76 @@ func TestX509WorkloadIdentityRetriesRedactedTransientNetworkFailure(t *testing.T
 	}
 }
 
+func TestX509WorkloadIdentityInvalidationWakesObsoleteProactiveRetry(t *testing.T) {
+	var exchanges atomic.Int32
+	waiting := make(chan struct{})
+	fixture := newX509ExchangeFixture(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		switch exchanges.Add(1) {
+		case 1:
+			_, _ = io.WriteString(w, x509ValidExchangeResponse())
+		case 2:
+			w.Header().Set("Retry-After", "8")
+			w.WriteHeader(http.StatusTooManyRequests)
+			if flush, ok := w.(http.Flusher); ok {
+				flush.Flush()
+			}
+			close(waiting)
+		default:
+			_, _ = io.WriteString(w, strings.Replace(x509ValidExchangeResponse(),
+				x509ExchangeSyntheticToken, "synthetic-refreshed-bearer", 1))
+		}
+	}))
+	identity := newX509LifecycleIdentity(t, fixture)
+	rejected, err := identity.GetToken(t.Context(), fixture.capability)
+	if err != nil {
+		t.Fatalf("prime proactive refresh bearer: %v", err)
+	}
+	identity.mu.Lock()
+	identity.refreshAfter = time.Now().Add(-time.Second)
+	identity.mu.Unlock()
+	ctx, cancel := context.WithTimeout(t.Context(), 750*time.Millisecond)
+	defer cancel()
+	result := make(chan error, 1)
+	go func() {
+		token, refreshErr := identity.GetToken(ctx, fixture.capability)
+		if refreshErr == nil && token != "synthetic-refreshed-bearer" {
+			refreshErr = errors.New("woken proactive refresh returned its obsolete bearer")
+		}
+		result <- refreshErr
+	}()
+	select {
+	case <-waiting:
+	case <-ctx.Done():
+		t.Fatal("obsolete proactive refresh never entered issuer-directed backoff")
+	}
+	identity.invalidateToken("synthetic-other-generation")
+	identity.mu.Lock()
+	current := identity.inFlight
+	if current == nil || current.generation != rejected {
+		identity.mu.Unlock()
+		t.Fatal("proactive refresh lost its originating cached bearer generation")
+	}
+	select {
+	case <-current.wake:
+		identity.mu.Unlock()
+		t.Fatal("stale-generation invalidation woke an unrelated proactive refresh")
+	default:
+	}
+	identity.mu.Unlock()
+	identity.invalidateToken(rejected)
+	select {
+	case refreshErr := <-result:
+		if refreshErr != nil {
+			t.Errorf("generation-specific invalidation did not wake issuer-directed backoff: %v", refreshErr)
+		}
+	case <-ctx.Done():
+		t.Fatal("rejected cached bearer remained blocked behind obsolete eight-second issuer backoff")
+	}
+	if got := exchanges.Load(); got != 3 {
+		t.Errorf("prime/obsolete/woken issuer attempts = %d, want 3", got)
+	}
+}
+
 func TestX509WorkloadIdentityPreservesUnexpiredBearerDuringTransientRefreshFailure(t *testing.T) {
 	var exchanges atomic.Int32
 	var failureStatus atomic.Int32

--- a/auth/x509middleware.go
+++ b/auth/x509middleware.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/openai/openai-go/v3/internal/requestconfig"
@@ -15,6 +16,9 @@ func X509WorkloadIdentityMiddleware(
 	request *http.Request,
 	next func(*http.Request) (*http.Response, error),
 ) (*http.Response, error) {
+	if request == nil || request.Header == nil {
+		return nil, errors.New("X.509 workload identity requires a non-nil request and header map")
+	}
 	token, err := identity.GetToken(request.Context(), httpClient)
 	if err != nil {
 		return nil, err
@@ -27,7 +31,7 @@ func X509WorkloadIdentityMiddleware(
 	}
 	identity.invalidateToken(token)
 	scope := requestconfig.RequestRetryScopeFromContext(request.Context())
-	if request.Body != nil && (request.GetBody == nil || (scope != nil && !scope.AllowBodyReplay())) {
+	if request.Body != nil && (request.GetBody == nil || scope == nil || !scope.AllowBodyReplay()) {
 		return response, nil
 	}
 	if scope != nil && !scope.TryReplay() {

--- a/auth/x509middleware.go
+++ b/auth/x509middleware.go
@@ -38,7 +38,9 @@ func X509WorkloadIdentityMiddleware(
 	if scope != nil && !scope.TryReplay() {
 		return response, nil
 	}
-	_ = response.Body.Close()
+	if response.Body != nil {
+		_ = response.Body.Close()
+	}
 	replay := request.Clone(request.Context())
 	if hadBody {
 		replay.Body, err = request.GetBody()

--- a/auth/x509middleware.go
+++ b/auth/x509middleware.go
@@ -31,7 +31,7 @@ func X509WorkloadIdentityMiddleware(
 			return nil, errors.New("X.509 workload identity cannot replace existing Authorization credentials")
 		}
 	}
-	hadBody := request.Body != nil
+	hadBody := request.Body != nil && request.Body != http.NoBody
 	token, err := identity.GetToken(request.Context(), httpClient)
 	if err != nil {
 		return nil, err

--- a/auth/x509middleware.go
+++ b/auth/x509middleware.go
@@ -19,6 +19,7 @@ func X509WorkloadIdentityMiddleware(
 	if request == nil || request.Header == nil {
 		return nil, errors.New("X.509 workload identity requires a non-nil request and header map")
 	}
+	hadBody := request.Body != nil
 	token, err := identity.GetToken(request.Context(), httpClient)
 	if err != nil {
 		return nil, err
@@ -31,7 +32,7 @@ func X509WorkloadIdentityMiddleware(
 	}
 	identity.invalidateToken(token)
 	scope := requestconfig.RequestRetryScopeFromContext(request.Context())
-	if request.Body != nil && (request.GetBody == nil || scope == nil || !scope.AllowBodyReplay()) {
+	if hadBody && (request.GetBody == nil || scope == nil || !scope.AllowBodyReplay()) {
 		return response, nil
 	}
 	if scope != nil && !scope.TryReplay() {
@@ -39,7 +40,7 @@ func X509WorkloadIdentityMiddleware(
 	}
 	_ = response.Body.Close()
 	replay := request.Clone(request.Context())
-	if request.GetBody != nil {
+	if hadBody {
 		replay.Body, err = request.GetBody()
 		if err != nil {
 			return nil, err

--- a/auth/x509middleware.go
+++ b/auth/x509middleware.go
@@ -2,6 +2,8 @@ package auth
 
 import (
 	"net/http"
+
+	"github.com/openai/openai-go/v3/internal/requestconfig"
 )
 
 // X509WorkloadIdentityMiddleware authenticates a request using its attested
@@ -23,11 +25,15 @@ func X509WorkloadIdentityMiddleware(
 	if err != nil || response == nil || response.StatusCode != http.StatusUnauthorized {
 		return response, err
 	}
-	if request.Body != nil && request.GetBody == nil {
+	identity.invalidateToken(token)
+	scope := requestconfig.RequestRetryScopeFromContext(request.Context())
+	if request.Body != nil && (request.GetBody == nil || (scope != nil && !scope.AllowBodyReplay())) {
+		return response, nil
+	}
+	if scope != nil && !scope.TryReplay() {
 		return response, nil
 	}
 	_ = response.Body.Close()
-	identity.invalidateToken(token)
 	replay := request.Clone(request.Context())
 	if request.GetBody != nil {
 		replay.Body, err = request.GetBody()
@@ -43,5 +49,9 @@ func X509WorkloadIdentityMiddleware(
 		return nil, err
 	}
 	replay.Header.Set("Authorization", "Bearer "+token)
-	return next(replay)
+	response, err = next(replay)
+	if err == nil && response != nil && response.StatusCode == http.StatusUnauthorized {
+		identity.invalidateToken(token)
+	}
+	return response, err
 }

--- a/auth/x509middleware.go
+++ b/auth/x509middleware.go
@@ -39,6 +39,7 @@ func X509WorkloadIdentityMiddleware(
 	authenticated := request.Clone(request.Context())
 	authenticated.Header.Set("Authorization", "Bearer "+token)
 	response, err := next(authenticated)
+	response = x509UnsignedResponse(response)
 	if err != nil || response == nil || response.StatusCode != http.StatusUnauthorized {
 		return response, err
 	}
@@ -67,10 +68,31 @@ func X509WorkloadIdentityMiddleware(
 	}
 	replay.Header.Set("Authorization", "Bearer "+token)
 	response, err = next(replay)
+	response = x509UnsignedResponse(response)
 	if err == nil && response != nil && response.StatusCode == http.StatusUnauthorized {
 		identity.invalidateToken(token)
 	}
 	return response, err
+}
+
+func x509UnsignedResponse(response *http.Response) *http.Response {
+	if response == nil || response.Request == nil || response.Request.Header == nil {
+		return response
+	}
+	for name := range response.Request.Header {
+		if !strings.EqualFold(strings.ReplaceAll(name, "_", "-"), "authorization") {
+			continue
+		}
+		clone := *response
+		clone.Request = response.Request.Clone(response.Request.Context())
+		for credential := range clone.Request.Header {
+			if strings.EqualFold(strings.ReplaceAll(credential, "_", "-"), "authorization") {
+				delete(clone.Request.Header, credential)
+			}
+		}
+		return &clone
+	}
+	return response
 }
 
 func x509UnauthorizedRetryResponse(response *http.Response, retry bool) *http.Response {
@@ -81,6 +103,7 @@ func x509UnauthorizedRetryResponse(response *http.Response, retry bool) *http.Re
 	}
 	if retry {
 		clone.Header.Set("x-should-retry", "true")
+		clone.Header.Set("Retry-After-Ms", "0")
 	} else {
 		clone.Header.Set("x-should-retry", "false")
 	}

--- a/auth/x509middleware.go
+++ b/auth/x509middleware.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/openai/openai-go/v3/internal/requestconfig"
 )
@@ -16,8 +17,19 @@ func X509WorkloadIdentityMiddleware(
 	request *http.Request,
 	next func(*http.Request) (*http.Response, error),
 ) (*http.Response, error) {
-	if request == nil || request.Header == nil {
+	if request == nil || request.Header == nil || next == nil {
 		return nil, errors.New("X.509 workload identity requires a non-nil request and header map")
+	}
+	if err := validateX509Request(request); err != nil {
+		return nil, err
+	}
+	if request.URL.Host != x509APIHost {
+		return nil, errors.New("X.509 workload identity requires the global OpenAI mTLS API origin")
+	}
+	for name := range request.Header {
+		if strings.EqualFold(strings.ReplaceAll(name, "_", "-"), "authorization") {
+			return nil, errors.New("X.509 workload identity cannot replace existing Authorization credentials")
+		}
 	}
 	hadBody := request.Body != nil
 	token, err := identity.GetToken(request.Context(), httpClient)
@@ -32,27 +44,25 @@ func X509WorkloadIdentityMiddleware(
 	}
 	identity.invalidateToken(token)
 	scope := requestconfig.RequestRetryScopeFromContext(request.Context())
-	if hadBody && (request.GetBody == nil || scope == nil || !scope.AllowBodyReplay()) {
+	if scope != nil {
+		replayable := !hadBody || (request.GetBody != nil && scope.AllowBodyReplay())
+		if replayable && scope.TryOuterReplay() {
+			return x509UnauthorizedRetryResponse(response, true), nil
+		}
+		if response.Header.Get("x-should-retry") == "true" {
+			return x509UnauthorizedRetryResponse(response, false), nil
+		}
 		return response, nil
 	}
-	if scope != nil && !scope.TryReplay() {
+	if hadBody {
 		return response, nil
 	}
 	if response.Body != nil {
 		_ = response.Body.Close()
 	}
 	replay := request.Clone(request.Context())
-	if hadBody {
-		replay.Body, err = request.GetBody()
-		if err != nil {
-			return nil, err
-		}
-	}
 	token, err = identity.GetToken(request.Context(), httpClient)
 	if err != nil {
-		if replay.Body != nil {
-			_ = replay.Body.Close()
-		}
 		return nil, err
 	}
 	replay.Header.Set("Authorization", "Bearer "+token)
@@ -61,4 +71,18 @@ func X509WorkloadIdentityMiddleware(
 		identity.invalidateToken(token)
 	}
 	return response, err
+}
+
+func x509UnauthorizedRetryResponse(response *http.Response, retry bool) *http.Response {
+	clone := *response
+	clone.Header = response.Header.Clone()
+	if clone.Header == nil {
+		clone.Header = make(http.Header)
+	}
+	if retry {
+		clone.Header.Set("x-should-retry", "true")
+	} else {
+		clone.Header.Set("x-should-retry", "false")
+	}
+	return &clone
 }

--- a/auth/x509middleware.go
+++ b/auth/x509middleware.go
@@ -1,0 +1,47 @@
+package auth
+
+import (
+	"net/http"
+)
+
+// X509WorkloadIdentityMiddleware authenticates a request using its attested
+// workload identity. A rejected bearer is conditionally invalidated and the
+// request is replayed at most once when its body can be recreated safely.
+func X509WorkloadIdentityMiddleware(
+	identity *X509WorkloadIdentityAuth,
+	httpClient HTTPDoer,
+	request *http.Request,
+	next func(*http.Request) (*http.Response, error),
+) (*http.Response, error) {
+	token, err := identity.GetToken(request.Context(), httpClient)
+	if err != nil {
+		return nil, err
+	}
+	authenticated := request.Clone(request.Context())
+	authenticated.Header.Set("Authorization", "Bearer "+token)
+	response, err := next(authenticated)
+	if err != nil || response == nil || response.StatusCode != http.StatusUnauthorized {
+		return response, err
+	}
+	if request.Body != nil && request.GetBody == nil {
+		return response, nil
+	}
+	_ = response.Body.Close()
+	identity.invalidateToken(token)
+	replay := request.Clone(request.Context())
+	if request.GetBody != nil {
+		replay.Body, err = request.GetBody()
+		if err != nil {
+			return nil, err
+		}
+	}
+	token, err = identity.GetToken(request.Context(), httpClient)
+	if err != nil {
+		if replay.Body != nil {
+			_ = replay.Body.Close()
+		}
+		return nil, err
+	}
+	replay.Header.Set("Authorization", "Bearer "+token)
+	return next(replay)
+}

--- a/auth/x509middleware_test.go
+++ b/auth/x509middleware_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -249,6 +250,126 @@ func TestX509WorkloadIdentityMiddlewareReplaysUnauthorizedResponsesWithoutBodies
 			}
 			if got := restored.Load(); got != 0 {
 				t.Errorf("bodyless middleware request invoked its retained GetBody factory %d times", got)
+			}
+		})
+	}
+}
+
+func TestX509WorkloadIdentityMiddlewareNeverReturnsSignedResponseRequests(t *testing.T) {
+	for _, test := range []struct {
+		name           string
+		status         int
+		dispatchError  bool
+		scoped         bool
+		nilRequest     bool
+		nilHeader      bool
+		unauthorized   bool
+		wantDispatches int32
+	}{
+		{name: "successful response", status: http.StatusOK, wantDispatches: 1},
+		{name: "API error response", status: http.StatusForbidden, wantDispatches: 1},
+		{name: "response and transport error", status: http.StatusOK, dispatchError: true, wantDispatches: 1},
+		{name: "response without request", status: http.StatusOK, nilRequest: true, wantDispatches: 1},
+		{name: "response request without headers", status: http.StatusOK, nilHeader: true, wantDispatches: 1},
+		{name: "scoped unauthorized response", status: http.StatusUnauthorized, scoped: true, wantDispatches: 1},
+		{name: "unscoped unauthorized replay", status: http.StatusOK, unauthorized: true, wantDispatches: 2},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var exchanges, dispatches atomic.Int32
+			fixture := newX509ExchangeFixture(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				token := fmt.Sprintf("synthetic-private-response-token-%d", exchanges.Add(1))
+				_, _ = io.WriteString(w, strings.Replace(x509ValidExchangeResponse(), x509ExchangeSyntheticToken, token, 1))
+			}))
+			identity := newX509LifecycleIdentity(t, fixture)
+			request, err := http.NewRequestWithContext(t.Context(), http.MethodGet,
+				"https://"+x509APIHost+"/v1/models", nil)
+			if err != nil {
+				t.Fatalf("construct unsigned middleware request: %v", err)
+			}
+			request.Header.Set("X-Synthetic-Metadata", "preserved")
+			if test.scoped {
+				scope := requestconfig.NewRequestRetryScope(1, 0, true, nil)
+				if !scope.BeginAttempt() {
+					t.Fatal("begin request-scoped authentication attempt")
+				}
+				request = request.WithContext(requestconfig.WithRequestRetryScope(request.Context(), scope))
+			}
+
+			var wireResponses []*http.Response
+			var returnedError = errors.New("synthetic dispatch failure")
+			response, middlewareErr := X509WorkloadIdentityMiddleware(identity, fixture.capability, request,
+				func(authenticated *http.Request) (*http.Response, error) {
+					attempt := dispatches.Add(1)
+					if got := authenticated.Header.Get("Authorization"); got != fmt.Sprintf("Bearer synthetic-private-response-token-%d", attempt) {
+						t.Errorf("authenticated wire attempt %d bearer = %q", attempt, got)
+					}
+					status := test.status
+					if test.unauthorized && attempt == 1 {
+						status = http.StatusUnauthorized
+					}
+					wire := &http.Response{
+						StatusCode: status,
+						Header:     http.Header{"X-Synthetic-Response": {"preserved"}},
+						Body:       io.NopCloser(strings.NewReader("synthetic-response-body")),
+						Request:    authenticated,
+					}
+					if test.nilRequest {
+						wire.Request = nil
+					} else if test.nilHeader {
+						wire.Request = authenticated.Clone(authenticated.Context())
+						wire.Request.Header = nil
+					} else {
+						wire.Request.Header["aUtHoRiZaTiOn"] = []string{"Bearer synthetic-private-alias"}
+					}
+					wireResponses = append(wireResponses, wire)
+					if test.dispatchError {
+						return wire, returnedError
+					}
+					return wire, nil
+				})
+			if response == nil {
+				t.Fatalf("signed middleware response unexpectedly nil: %v", middlewareErr)
+			}
+			if closeErr := response.Body.Close(); closeErr != nil {
+				t.Errorf("close returned middleware response: %v", closeErr)
+			}
+			if test.dispatchError != errors.Is(middlewareErr, returnedError) {
+				t.Errorf("middleware dispatch error = %v", middlewareErr)
+			}
+			if response.StatusCode != test.status || response.Header.Get("X-Synthetic-Response") != "preserved" {
+				t.Errorf("returned response lost its status or headers: %v", response)
+			}
+			if test.nilRequest {
+				if response.Request != nil {
+					t.Error("response unexpectedly acquired a request")
+				}
+			} else if test.nilHeader {
+				if response.Request == nil || response.Request.Header != nil {
+					t.Error("response request unexpectedly acquired a header map")
+				}
+			} else {
+				if response.Request == nil || response.Request.Header.Get("X-Synthetic-Metadata") != "preserved" {
+					t.Fatal("response lost its unsigned request metadata")
+				}
+				for name := range response.Request.Header {
+					if strings.EqualFold(strings.ReplaceAll(name, "_", "-"), "authorization") {
+						t.Errorf("returned response exposed signed %q request credentials", name)
+					}
+				}
+				for _, wire := range wireResponses {
+					if wire.Request == nil || wire.Request.Header.Get("Authorization") == "" {
+						t.Error("sanitizing the returned response modified its original signed wire request")
+					}
+				}
+			}
+			if test.scoped && response.Header.Get("x-should-retry") != "true" {
+				t.Error("scoped unauthorized response lost its outer-retry signal")
+			}
+			if got := dispatches.Load(); got != test.wantDispatches {
+				t.Errorf("authenticated dispatches = %d, want %d", got, test.wantDispatches)
+			}
+			if request.Header.Get("Authorization") != "" {
+				t.Error("authentication modified the original unsigned caller request")
 			}
 		})
 	}

--- a/auth/x509middleware_test.go
+++ b/auth/x509middleware_test.go
@@ -18,26 +18,68 @@ func TestX509WorkloadIdentityMiddlewareRejectsMalformedRequestsBeforeExchange(t 
 		_, _ = io.WriteString(w, x509ValidExchangeResponse())
 	}))
 	identity := newX509LifecycleIdentity(t, fixture)
-	request, err := http.NewRequestWithContext(t.Context(), http.MethodGet,
-		"https://"+x509APIHost+"/v1/models", nil)
-	if err != nil {
-		t.Fatalf("construct malformed middleware request: %v", err)
-	}
-	request.Header = nil
-	for _, invalid := range []*http.Request{nil, request} {
-		response, middlewareErr := X509WorkloadIdentityMiddleware(identity, fixture.capability, invalid,
-			func(*http.Request) (*http.Response, error) {
-				t.Error("malformed request reached the authenticated middleware dispatch")
-				return nil, nil
-			})
-		if response != nil && response.Body != nil {
-			if closeErr := response.Body.Close(); closeErr != nil {
-				t.Errorf("close unexpected malformed middleware response: %v", closeErr)
+	for _, test := range []struct {
+		name   string
+		mutate func(*http.Request) *http.Request
+	}{
+		{name: "nil request", mutate: func(*http.Request) *http.Request { return nil }},
+		{name: "nil headers", mutate: func(request *http.Request) *http.Request {
+			request.Header = nil
+			return request
+		}},
+		{name: "attacker origin", mutate: func(request *http.Request) *http.Request {
+			request.URL.Host = "attacker.example.test"
+			return request
+		}},
+		{name: "approved issuer is not API origin", mutate: func(request *http.Request) *http.Request {
+			request.URL.Host = x509AuthenticationHost
+			return request
+		}},
+		{name: "path traversal", mutate: func(request *http.Request) *http.Request {
+			request.URL.Path = "/v1/../attacker"
+			return request
+		}},
+		{name: "existing valid bearer", mutate: func(request *http.Request) *http.Request {
+			request.Header.Set("Authorization", "Bearer synthetic-existing-token")
+			return request
+		}},
+		{name: "credential alias", mutate: func(request *http.Request) *http.Request {
+			request.Header.Set("X_API_KEY", "synthetic-existing-key")
+			return request
+		}},
+		{name: "unsupported CONNECT method", mutate: func(request *http.Request) *http.Request {
+			request.Method = http.MethodConnect
+			return request
+		}},
+		{name: "custom HTTP framing", mutate: func(request *http.Request) *http.Request {
+			request.Header.Set("Connection", "upgrade")
+			return request
+		}},
+		{name: "custom transfer encoding", mutate: func(request *http.Request) *http.Request {
+			request.TransferEncoding = []string{"chunked"}
+			return request
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			request, err := http.NewRequestWithContext(t.Context(), http.MethodGet,
+				"https://"+x509APIHost+"/v1/models", nil)
+			if err != nil {
+				t.Fatalf("construct malformed middleware request: %v", err)
 			}
-		}
-		if response != nil || middlewareErr == nil {
-			t.Errorf("malformed direct middleware request = response:%v error:%v", response, middlewareErr)
-		}
+			response, middlewareErr := X509WorkloadIdentityMiddleware(identity, fixture.capability, test.mutate(request),
+				func(*http.Request) (*http.Response, error) {
+					t.Error("malformed request reached the authenticated middleware dispatch")
+					return nil, nil
+				})
+			if response != nil && response.Body != nil {
+				if closeErr := response.Body.Close(); closeErr != nil {
+					t.Errorf("close unexpected malformed middleware response: %v", closeErr)
+				}
+			}
+			if response != nil || middlewareErr == nil {
+				t.Errorf("malformed direct middleware request = response:%v error:%v", response, middlewareErr)
+			}
+		})
 	}
 	if got := exchanges.Load(); got != 0 {
 		t.Errorf("malformed direct middleware requests minted %d tokens", got)
@@ -172,10 +214,19 @@ func TestX509WorkloadIdentityMiddlewareReplaysUnauthorizedResponsesWithoutBodies
 					t.Errorf("close unexpected synthetic response body: %v", closeErr)
 				}
 			}
-			if err != nil || response == nil || response.StatusCode != http.StatusOK || response.Body != nil {
+			wantStatus := http.StatusOK
+			wantAttempts := int32(2)
+			if scoped {
+				wantStatus = http.StatusUnauthorized
+				wantAttempts = 1
+				if response == nil || response.Header.Get("x-should-retry") != "true" {
+					t.Error("scoped unauthorized response did not request a complete outer SDK retry")
+				}
+			}
+			if err != nil || response == nil || response.StatusCode != wantStatus || response.Body != nil {
 				t.Fatalf("bodyless unauthorized response replay = response:%v error:%v", response, err)
 			}
-			if exchanges.Load() != 2 || dispatched.Load() != 2 {
+			if exchanges.Load() != wantAttempts || dispatched.Load() != wantAttempts {
 				t.Errorf("bodyless unauthorized response issuer/dispatch attempts = %d/%d", exchanges.Load(), dispatched.Load())
 			}
 			if got := request.Header.Get("Authorization"); got != "" {

--- a/auth/x509middleware_test.go
+++ b/auth/x509middleware_test.go
@@ -87,7 +87,7 @@ func TestX509WorkloadIdentityMiddlewareDoesNotReplayUnscopedTransformedBody(t *t
 }
 
 func TestX509WorkloadIdentityMiddlewareCanReplayUnscopedBodylessRequests(t *testing.T) {
-	var exchanges, dispatched atomic.Int32
+	var exchanges, dispatched, restored atomic.Int32
 	fixture := newX509ExchangeFixture(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		token := fmt.Sprintf("synthetic-direct-token-%d", exchanges.Add(1))
 		_, _ = io.WriteString(w, strings.Replace(x509ValidExchangeResponse(), x509ExchangeSyntheticToken, token, 1))
@@ -98,8 +98,15 @@ func TestX509WorkloadIdentityMiddlewareCanReplayUnscopedBodylessRequests(t *test
 	if err != nil {
 		t.Fatalf("construct bodyless direct middleware request: %v", err)
 	}
+	request.GetBody = func() (io.ReadCloser, error) {
+		restored.Add(1)
+		return io.NopCloser(strings.NewReader("synthetic-removed-private-body")), nil
+	}
 	response, err := X509WorkloadIdentityMiddleware(identity, fixture.capability, request,
-		func(*http.Request) (*http.Response, error) {
+		func(authenticated *http.Request) (*http.Response, error) {
+			if authenticated.Body != nil {
+				t.Error("bodyless direct middleware replay restored a removed request body")
+			}
 			status := http.StatusOK
 			if dispatched.Add(1) == 1 {
 				status = http.StatusUnauthorized
@@ -114,5 +121,8 @@ func TestX509WorkloadIdentityMiddlewareCanReplayUnscopedBodylessRequests(t *test
 	}
 	if exchanges.Load() != 2 || dispatched.Load() != 2 {
 		t.Errorf("unscoped bodyless middleware issuer/dispatch attempts = %d/%d", exchanges.Load(), dispatched.Load())
+	}
+	if got := restored.Load(); got != 0 {
+		t.Errorf("bodyless middleware replay invoked its retained GetBody factory %d times", got)
 	}
 }

--- a/auth/x509middleware_test.go
+++ b/auth/x509middleware_test.go
@@ -172,13 +172,18 @@ func TestX509WorkloadIdentityMiddlewareCanReplayUnscopedBodylessRequests(t *test
 }
 
 func TestX509WorkloadIdentityMiddlewareReplaysUnauthorizedResponsesWithoutBodies(t *testing.T) {
-	for _, scoped := range []bool{false, true} {
-		name := "direct middleware"
-		if scoped {
-			name = "request-scoped middleware"
-		}
-		t.Run(name, func(t *testing.T) {
-			var exchanges, dispatched atomic.Int32
+	for _, test := range []struct {
+		name   string
+		scoped bool
+		noBody bool
+	}{
+		{name: "direct middleware"},
+		{name: "request-scoped middleware", scoped: true},
+		{name: "direct middleware with http.NoBody", noBody: true},
+		{name: "request-scoped middleware with http.NoBody", scoped: true, noBody: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var exchanges, dispatched, restored atomic.Int32
 			fixture := newX509ExchangeFixture(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				token := fmt.Sprintf("synthetic-bodyless-response-token-%d", exchanges.Add(1))
 				_, _ = io.WriteString(w, strings.Replace(x509ValidExchangeResponse(), x509ExchangeSyntheticToken, token, 1))
@@ -189,7 +194,14 @@ func TestX509WorkloadIdentityMiddlewareReplaysUnauthorizedResponsesWithoutBodies
 			if err != nil {
 				t.Fatalf("construct request for bodyless unauthorized response: %v", err)
 			}
-			if scoped {
+			if test.noBody {
+				request.Body = http.NoBody
+				request.GetBody = func() (io.ReadCloser, error) {
+					restored.Add(1)
+					return io.NopCloser(strings.NewReader("synthetic-removed-private-body")), nil
+				}
+			}
+			if test.scoped {
 				scope := requestconfig.NewRequestRetryScope(1, 0, false, nil)
 				if !scope.BeginAttempt() {
 					t.Fatal("begin initial scoped middleware attempt")
@@ -198,6 +210,9 @@ func TestX509WorkloadIdentityMiddlewareReplaysUnauthorizedResponsesWithoutBodies
 			}
 			response, err := X509WorkloadIdentityMiddleware(identity, fixture.capability, request,
 				func(authenticated *http.Request) (*http.Response, error) {
+					if test.noBody && authenticated.Body != http.NoBody {
+						t.Error("http.NoBody direct middleware request restored a removed payload")
+					}
 					attempt := dispatched.Add(1)
 					want := fmt.Sprintf("Bearer synthetic-bodyless-response-token-%d", attempt)
 					if got := authenticated.Header.Get("Authorization"); got != want {
@@ -216,7 +231,7 @@ func TestX509WorkloadIdentityMiddlewareReplaysUnauthorizedResponsesWithoutBodies
 			}
 			wantStatus := http.StatusOK
 			wantAttempts := int32(2)
-			if scoped {
+			if test.scoped {
 				wantStatus = http.StatusUnauthorized
 				wantAttempts = 1
 				if response == nil || response.Header.Get("x-should-retry") != "true" {
@@ -231,6 +246,9 @@ func TestX509WorkloadIdentityMiddlewareReplaysUnauthorizedResponsesWithoutBodies
 			}
 			if got := request.Header.Get("Authorization"); got != "" {
 				t.Errorf("direct middleware mutated caller-owned request Authorization: %q", got)
+			}
+			if got := restored.Load(); got != 0 {
+				t.Errorf("bodyless middleware request invoked its retained GetBody factory %d times", got)
 			}
 		})
 	}

--- a/auth/x509middleware_test.go
+++ b/auth/x509middleware_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+
+	"github.com/openai/openai-go/v3/internal/requestconfig"
 )
 
 func TestX509WorkloadIdentityMiddlewareRejectsMalformedRequestsBeforeExchange(t *testing.T) {
@@ -124,5 +126,61 @@ func TestX509WorkloadIdentityMiddlewareCanReplayUnscopedBodylessRequests(t *test
 	}
 	if got := restored.Load(); got != 0 {
 		t.Errorf("bodyless middleware replay invoked its retained GetBody factory %d times", got)
+	}
+}
+
+func TestX509WorkloadIdentityMiddlewareReplaysUnauthorizedResponsesWithoutBodies(t *testing.T) {
+	for _, scoped := range []bool{false, true} {
+		name := "direct middleware"
+		if scoped {
+			name = "request-scoped middleware"
+		}
+		t.Run(name, func(t *testing.T) {
+			var exchanges, dispatched atomic.Int32
+			fixture := newX509ExchangeFixture(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				token := fmt.Sprintf("synthetic-bodyless-response-token-%d", exchanges.Add(1))
+				_, _ = io.WriteString(w, strings.Replace(x509ValidExchangeResponse(), x509ExchangeSyntheticToken, token, 1))
+			}))
+			identity := newX509LifecycleIdentity(t, fixture)
+			request, err := http.NewRequestWithContext(t.Context(), http.MethodGet,
+				"https://"+x509APIHost+"/v1/models", nil)
+			if err != nil {
+				t.Fatalf("construct request for bodyless unauthorized response: %v", err)
+			}
+			if scoped {
+				scope := requestconfig.NewRequestRetryScope(1, 0, false, nil)
+				if !scope.BeginAttempt() {
+					t.Fatal("begin initial scoped middleware attempt")
+				}
+				request = request.WithContext(requestconfig.WithRequestRetryScope(request.Context(), scope))
+			}
+			response, err := X509WorkloadIdentityMiddleware(identity, fixture.capability, request,
+				func(authenticated *http.Request) (*http.Response, error) {
+					attempt := dispatched.Add(1)
+					want := fmt.Sprintf("Bearer synthetic-bodyless-response-token-%d", attempt)
+					if got := authenticated.Header.Get("Authorization"); got != want {
+						t.Errorf("authenticated bodyless response attempt %d bearer = %q, want %q", attempt, got, want)
+					}
+					status := http.StatusOK
+					if attempt == 1 {
+						status = http.StatusUnauthorized
+					}
+					return &http.Response{StatusCode: status}, nil
+				})
+			if response != nil && response.Body != nil {
+				if closeErr := response.Body.Close(); closeErr != nil {
+					t.Errorf("close unexpected synthetic response body: %v", closeErr)
+				}
+			}
+			if err != nil || response == nil || response.StatusCode != http.StatusOK || response.Body != nil {
+				t.Fatalf("bodyless unauthorized response replay = response:%v error:%v", response, err)
+			}
+			if exchanges.Load() != 2 || dispatched.Load() != 2 {
+				t.Errorf("bodyless unauthorized response issuer/dispatch attempts = %d/%d", exchanges.Load(), dispatched.Load())
+			}
+			if got := request.Header.Get("Authorization"); got != "" {
+				t.Errorf("direct middleware mutated caller-owned request Authorization: %q", got)
+			}
+		})
 	}
 }

--- a/auth/x509middleware_test.go
+++ b/auth/x509middleware_test.go
@@ -1,0 +1,118 @@
+package auth
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestX509WorkloadIdentityMiddlewareRejectsMalformedRequestsBeforeExchange(t *testing.T) {
+	var exchanges atomic.Int32
+	fixture := newX509ExchangeFixture(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		exchanges.Add(1)
+		_, _ = io.WriteString(w, x509ValidExchangeResponse())
+	}))
+	identity := newX509LifecycleIdentity(t, fixture)
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodGet,
+		"https://"+x509APIHost+"/v1/models", nil)
+	if err != nil {
+		t.Fatalf("construct malformed middleware request: %v", err)
+	}
+	request.Header = nil
+	for _, invalid := range []*http.Request{nil, request} {
+		response, middlewareErr := X509WorkloadIdentityMiddleware(identity, fixture.capability, invalid,
+			func(*http.Request) (*http.Response, error) {
+				t.Error("malformed request reached the authenticated middleware dispatch")
+				return nil, nil
+			})
+		if response != nil && response.Body != nil {
+			if closeErr := response.Body.Close(); closeErr != nil {
+				t.Errorf("close unexpected malformed middleware response: %v", closeErr)
+			}
+		}
+		if response != nil || middlewareErr == nil {
+			t.Errorf("malformed direct middleware request = response:%v error:%v", response, middlewareErr)
+		}
+	}
+	if got := exchanges.Load(); got != 0 {
+		t.Errorf("malformed direct middleware requests minted %d tokens", got)
+	}
+}
+
+func TestX509WorkloadIdentityMiddlewareDoesNotReplayUnscopedTransformedBody(t *testing.T) {
+	var exchanges, dispatched atomic.Int32
+	fixture := newX509ExchangeFixture(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		exchanges.Add(1)
+		_, _ = io.WriteString(w, x509ValidExchangeResponse())
+	}))
+	identity := newX509LifecycleIdentity(t, fixture)
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodPost,
+		"https://"+x509APIHost+"/v1/models", strings.NewReader("original-serialized-body"))
+	if err != nil {
+		t.Fatalf("construct replayable middleware request: %v", err)
+	}
+	if request.GetBody == nil {
+		t.Fatal("negative-control middleware request lacks its original replay factory")
+	}
+	request.Body = io.NopCloser(strings.NewReader("caller-transformed-body"))
+	response, err := X509WorkloadIdentityMiddleware(identity, fixture.capability, request,
+		func(authenticated *http.Request) (*http.Response, error) {
+			dispatched.Add(1)
+			body, readErr := io.ReadAll(authenticated.Body)
+			if readErr != nil || string(body) != "caller-transformed-body" {
+				t.Errorf("unscoped middleware wire body = %q, error = %v", body, readErr)
+			}
+			return &http.Response{
+				StatusCode: http.StatusUnauthorized,
+				Body:       io.NopCloser(strings.NewReader("synthetic unauthorized response")),
+			}, nil
+		})
+	if err != nil || response == nil || response.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("unscoped transformed request = response:%v error:%v", response, err)
+	}
+	if closeErr := response.Body.Close(); closeErr != nil {
+		t.Fatalf("close preserved unauthorized response: %v", closeErr)
+	}
+	if exchanges.Load() != 1 || dispatched.Load() != 1 {
+		t.Errorf("unscoped transformed request issuer/dispatch attempts = %d/%d", exchanges.Load(), dispatched.Load())
+	}
+	identity.mu.Lock()
+	if identity.cached.value != "" {
+		t.Error("unscoped unauthorized request did not invalidate its rejected bearer")
+	}
+	identity.mu.Unlock()
+}
+
+func TestX509WorkloadIdentityMiddlewareCanReplayUnscopedBodylessRequests(t *testing.T) {
+	var exchanges, dispatched atomic.Int32
+	fixture := newX509ExchangeFixture(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		token := fmt.Sprintf("synthetic-direct-token-%d", exchanges.Add(1))
+		_, _ = io.WriteString(w, strings.Replace(x509ValidExchangeResponse(), x509ExchangeSyntheticToken, token, 1))
+	}))
+	identity := newX509LifecycleIdentity(t, fixture)
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodGet,
+		"https://"+x509APIHost+"/v1/models", nil)
+	if err != nil {
+		t.Fatalf("construct bodyless direct middleware request: %v", err)
+	}
+	response, err := X509WorkloadIdentityMiddleware(identity, fixture.capability, request,
+		func(*http.Request) (*http.Response, error) {
+			status := http.StatusOK
+			if dispatched.Add(1) == 1 {
+				status = http.StatusUnauthorized
+			}
+			return &http.Response{StatusCode: status, Body: io.NopCloser(strings.NewReader("synthetic"))}, nil
+		})
+	if err != nil || response == nil || response.StatusCode != http.StatusOK {
+		t.Fatalf("unscoped bodyless middleware replay = response:%v error:%v", response, err)
+	}
+	if closeErr := response.Body.Close(); closeErr != nil {
+		t.Fatalf("close direct bodyless response: %v", closeErr)
+	}
+	if exchanges.Load() != 2 || dispatched.Load() != 2 {
+		t.Errorf("unscoped bodyless middleware issuer/dispatch attempts = %d/%d", exchanges.Load(), dispatched.Load())
+	}
+}

--- a/auth/x509workloadidentity.go
+++ b/auth/x509workloadidentity.go
@@ -4,7 +4,14 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync"
 	"time"
+)
+
+const (
+	x509DefaultRefreshBuffer = 5 * time.Minute
+	x509MaximumAttempts      = 3
+	x509InitialRetryDelay    = 25 * time.Millisecond
 )
 
 // X509WorkloadIdentity configures an OpenAI workload authenticated with a
@@ -19,7 +26,16 @@ type X509WorkloadIdentity struct {
 // X509WorkloadIdentityAuth exchanges a static, attested X.509 workload identity
 // for an ordinary OpenAI bearer token.
 type X509WorkloadIdentityAuth struct {
-	config X509WorkloadIdentity
+	config       X509WorkloadIdentity
+	mu           sync.Mutex
+	cached       x509ExchangedToken
+	refreshAfter time.Time
+	inFlight     *x509TokenRefresh
+}
+
+type x509TokenRefresh struct {
+	done chan struct{}
+	err  error
 }
 
 // NewX509WorkloadIdentityAuth validates and binds a workload identity to one
@@ -46,13 +62,100 @@ func (identity *X509WorkloadIdentityAuth) GetToken(ctx context.Context, doer HTT
 	if identity == nil {
 		return "", errors.New("X.509 workload identity authentication is invalid")
 	}
+	if ctx == nil {
+		return "", errors.New("X.509 workload identity requires a non-nil context")
+	}
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
 	transport, ok := doer.(*X509Transport)
 	if !ok || transport != identity.config.Transport {
 		return "", errors.New("X.509 workload identity requires its exact attested transport")
 	}
-	token, err := x509Exchange(ctx, transport, identity.config.IdentityProviderID, identity.config.ServiceAccountID)
-	if err != nil {
+	if err := transport.validateAttestation(); err != nil {
 		return "", err
 	}
-	return token.value, nil
+	for {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		identity.mu.Lock()
+		if identity.cached.value != "" && time.Now().Before(identity.refreshAfter) {
+			token := identity.cached.value
+			identity.mu.Unlock()
+			return token, nil
+		}
+		if current := identity.inFlight; current != nil {
+			identity.mu.Unlock()
+			select {
+			case <-ctx.Done():
+				return "", ctx.Err()
+			case <-current.done:
+				if current.err == nil || errors.Is(current.err, context.Canceled) ||
+					errors.Is(current.err, context.DeadlineExceeded) {
+					continue
+				}
+				return "", current.err
+			}
+		}
+		refresh := &x509TokenRefresh{done: make(chan struct{})}
+		identity.inFlight = refresh
+		identity.mu.Unlock()
+
+		token, err := identity.exchangeWithRetry(ctx, transport)
+		identity.mu.Lock()
+		if err == nil {
+			identity.cached = token
+			buffer := identity.config.RefreshBuffer
+			if buffer == 0 {
+				buffer = x509DefaultRefreshBuffer
+			}
+			buffer = min(buffer, time.Until(token.expiresAt)/2)
+			identity.refreshAfter = token.expiresAt.Add(-buffer)
+		}
+		refresh.err = err
+		identity.inFlight = nil
+		close(refresh.done)
+		identity.mu.Unlock()
+		if err != nil {
+			return "", err
+		}
+		return token.value, nil
+	}
+}
+
+func (identity *X509WorkloadIdentityAuth) exchangeWithRetry(ctx context.Context, transport *X509Transport) (x509ExchangedToken, error) {
+	for attempt := 0; ; attempt++ {
+		token, err := x509Exchange(ctx, transport, identity.config.IdentityProviderID, identity.config.ServiceAccountID)
+		if err == nil || !retryableX509ExchangeError(err) || attempt+1 >= x509MaximumAttempts {
+			return token, err
+		}
+		timer := time.NewTimer(x509InitialRetryDelay << attempt)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return x509ExchangedToken{}, ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func retryableX509ExchangeError(err error) bool {
+	var status *x509ExchangeHTTPError
+	if errors.As(err, &status) {
+		return status.retryable()
+	}
+	var read *x509ExchangeReadError
+	return errors.As(err, &read) && read.retryable()
+}
+
+func (identity *X509WorkloadIdentityAuth) invalidateToken(value string) {
+	identity.mu.Lock()
+	defer identity.mu.Unlock()
+	if identity.cached.value == value {
+		identity.cached = x509ExchangedToken{}
+		identity.refreshAfter = time.Time{}
+	}
 }

--- a/auth/x509workloadidentity.go
+++ b/auth/x509workloadidentity.go
@@ -206,6 +206,10 @@ func x509ExchangeRetryDelay(err error, attempt int, scope *requestconfig.Request
 }
 
 func retryableX509ExchangeError(err error) bool {
+	var oauth *OAuthError
+	if errors.As(err, &oauth) {
+		return oauth.ErrorCode == "temporarily_unavailable" || oauth.ErrorCode == "server_error"
+	}
 	var status *x509ExchangeHTTPError
 	if errors.As(err, &status) {
 		return status.retryable()

--- a/auth/x509workloadidentity.go
+++ b/auth/x509workloadidentity.go
@@ -6,12 +6,15 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/openai/openai-go/v3/internal/requestconfig"
 )
 
 const (
 	x509DefaultRefreshBuffer = 5 * time.Minute
 	x509MaximumAttempts      = 3
 	x509InitialRetryDelay    = 25 * time.Millisecond
+	x509MaximumRetryCooldown = 5 * time.Second
 )
 
 // X509WorkloadIdentity configures an OpenAI workload authenticated with a
@@ -104,7 +107,15 @@ func (identity *X509WorkloadIdentityAuth) GetToken(ctx context.Context, doer HTT
 
 		token, err := identity.exchangeWithRetry(ctx, transport)
 		identity.mu.Lock()
-		if err == nil {
+		fallback := false
+		if err != nil && retryableX509ExchangeError(err) && identity.cached.value != "" &&
+			time.Now().Before(identity.cached.expiresAt) {
+			cooldown := min(x509MaximumRetryCooldown, time.Until(identity.cached.expiresAt)/2)
+			identity.refreshAfter = time.Now().Add(cooldown)
+			token, err = identity.cached, nil
+			fallback = true
+		}
+		if err == nil && !fallback {
 			identity.cached = token
 			buffer := identity.config.RefreshBuffer
 			if buffer == 0 {
@@ -130,6 +141,9 @@ func (identity *X509WorkloadIdentityAuth) exchangeWithRetry(ctx context.Context,
 		if err == nil || !retryableX509ExchangeError(err) || attempt+1 >= x509MaximumAttempts {
 			return token, err
 		}
+		if scope := requestconfig.RequestRetryScopeFromContext(ctx); scope != nil && !scope.TryRetry() {
+			return token, err
+		}
 		timer := time.NewTimer(x509InitialRetryDelay << attempt)
 		select {
 		case <-ctx.Done():
@@ -148,7 +162,11 @@ func retryableX509ExchangeError(err error) bool {
 		return status.retryable()
 	}
 	var read *x509ExchangeReadError
-	return errors.As(err, &read) && read.retryable()
+	if errors.As(err, &read) {
+		return read.retryable()
+	}
+	var transport *x509TransportError
+	return errors.As(err, &transport) && transport.cause == nil
 }
 
 func (identity *X509WorkloadIdentityAuth) invalidateToken(value string) {

--- a/auth/x509workloadidentity.go
+++ b/auth/x509workloadidentity.go
@@ -83,7 +83,8 @@ func (identity *X509WorkloadIdentityAuth) GetToken(ctx context.Context, doer HTT
 			return "", err
 		}
 		identity.mu.Lock()
-		if identity.cached.value != "" && time.Now().Before(identity.refreshAfter) {
+		now := time.Now()
+		if identity.cached.value != "" && now.Before(identity.refreshAfter) && now.Before(identity.cached.expiresAt) {
 			token := identity.cached.value
 			identity.mu.Unlock()
 			return token, nil
@@ -97,6 +98,11 @@ func (identity *X509WorkloadIdentityAuth) GetToken(ctx context.Context, doer HTT
 				if current.err == nil || errors.Is(current.err, context.Canceled) ||
 					errors.Is(current.err, context.DeadlineExceeded) {
 					continue
+				}
+				if retryableX509ExchangeError(current.err) {
+					if scope := requestconfig.RequestRetryScopeFromContext(ctx); scope != nil && scope.TryRetry() {
+						continue
+					}
 				}
 				return "", current.err
 			}
@@ -116,13 +122,25 @@ func (identity *X509WorkloadIdentityAuth) GetToken(ctx context.Context, doer HTT
 			fallback = true
 		}
 		if err == nil && !fallback {
-			identity.cached = token
-			buffer := identity.config.RefreshBuffer
-			if buffer == 0 {
-				buffer = x509DefaultRefreshBuffer
+			remaining := time.Until(token.expiresAt)
+			if remaining <= 0 {
+				err = errors.New("X.509 token exchange returned an already expired token")
+			} else {
+				identity.cached = token
+				buffer := identity.config.RefreshBuffer
+				if buffer == 0 {
+					buffer = x509DefaultRefreshBuffer
+				}
+				buffer = min(buffer, remaining/2)
+				identity.refreshAfter = token.expiresAt.Add(-buffer)
 			}
-			buffer = min(buffer, time.Until(token.expiresAt)/2)
-			identity.refreshAfter = token.expiresAt.Add(-buffer)
+		}
+		if err == nil && !time.Now().Before(token.expiresAt) {
+			err = errors.New("X.509 token exchange returned an already expired token")
+			if identity.cached.value == token.value {
+				identity.cached = x509ExchangedToken{}
+				identity.refreshAfter = time.Time{}
+			}
 		}
 		refresh.err = err
 		identity.inFlight = nil
@@ -141,10 +159,11 @@ func (identity *X509WorkloadIdentityAuth) exchangeWithRetry(ctx context.Context,
 		if err == nil || !retryableX509ExchangeError(err) || attempt+1 >= x509MaximumAttempts {
 			return token, err
 		}
-		if scope := requestconfig.RequestRetryScopeFromContext(ctx); scope != nil && !scope.TryRetry() {
+		scope := requestconfig.RequestRetryScopeFromContext(ctx)
+		if scope != nil && !scope.TryRetry() {
 			return token, err
 		}
-		timer := time.NewTimer(x509InitialRetryDelay << attempt)
+		timer := time.NewTimer(x509ExchangeRetryDelay(err, attempt, scope))
 		select {
 		case <-ctx.Done():
 			if !timer.Stop() {
@@ -154,6 +173,19 @@ func (identity *X509WorkloadIdentityAuth) exchangeWithRetry(ctx context.Context,
 		case <-timer.C:
 		}
 	}
+}
+
+func x509ExchangeRetryDelay(err error, attempt int, scope *requestconfig.RequestRetryScope) time.Duration {
+	delay := x509InitialRetryDelay << attempt
+	var status *x509ExchangeHTTPError
+	if errors.As(err, &status) && status.hasRetryAfter {
+		delay = status.retryAfter
+	}
+	maximum := x509MaximumRetryAfter
+	if scope != nil {
+		maximum = scope.MaxRetryDelay()
+	}
+	return min(delay, maximum)
 }
 
 func retryableX509ExchangeError(err error) bool {

--- a/auth/x509workloadidentity.go
+++ b/auth/x509workloadidentity.go
@@ -37,8 +37,10 @@ type X509WorkloadIdentityAuth struct {
 }
 
 type x509TokenRefresh struct {
-	done chan struct{}
-	err  error
+	done       chan struct{}
+	wake       chan struct{}
+	generation string
+	err        error
 }
 
 // NewX509WorkloadIdentityAuth validates and binds a workload identity to one
@@ -107,11 +109,15 @@ func (identity *X509WorkloadIdentityAuth) GetToken(ctx context.Context, doer HTT
 				return "", current.err
 			}
 		}
-		refresh := &x509TokenRefresh{done: make(chan struct{})}
+		refresh := &x509TokenRefresh{
+			done:       make(chan struct{}),
+			wake:       make(chan struct{}),
+			generation: identity.cached.value,
+		}
 		identity.inFlight = refresh
 		identity.mu.Unlock()
 
-		token, err := identity.exchangeWithRetry(ctx, transport)
+		token, err := identity.exchangeWithRetry(ctx, transport, refresh)
 		identity.mu.Lock()
 		fallback := false
 		if err != nil && retryableX509ExchangeError(err) && identity.cached.value != "" &&
@@ -153,7 +159,10 @@ func (identity *X509WorkloadIdentityAuth) GetToken(ctx context.Context, doer HTT
 	}
 }
 
-func (identity *X509WorkloadIdentityAuth) exchangeWithRetry(ctx context.Context, transport *X509Transport) (x509ExchangedToken, error) {
+func (identity *X509WorkloadIdentityAuth) exchangeWithRetry(
+	ctx context.Context, transport *X509Transport, refresh *x509TokenRefresh,
+) (x509ExchangedToken, error) {
+	wake := refresh.wake
 	for attempt := 0; ; attempt++ {
 		token, err := x509Exchange(ctx, transport, identity.config.IdentityProviderID, identity.config.ServiceAccountID)
 		if err == nil || !retryableX509ExchangeError(err) || attempt+1 >= x509MaximumAttempts {
@@ -171,6 +180,14 @@ func (identity *X509WorkloadIdentityAuth) exchangeWithRetry(ctx context.Context,
 			}
 			return x509ExchangedToken{}, ctx.Err()
 		case <-timer.C:
+		case <-wake:
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			wake = nil
 		}
 	}
 }
@@ -207,5 +224,8 @@ func (identity *X509WorkloadIdentityAuth) invalidateToken(value string) {
 	if identity.cached.value == value {
 		identity.cached = x509ExchangedToken{}
 		identity.refreshAfter = time.Time{}
+		if current := identity.inFlight; current != nil && current.generation == value {
+			close(current.wake)
+		}
 	}
 }

--- a/auth/x509workloadidentity_test.go
+++ b/auth/x509workloadidentity_test.go
@@ -66,8 +66,8 @@ func TestX509WorkloadIdentityAuthExchangesOnlyOnItsAttestedTransport(t *testing.
 			t.Fatalf("exchange on attested transport token=%q error=%v", token, tokenErr)
 		}
 	}
-	if got := exchanges.Load(); got != 2 {
-		t.Errorf("pre-cache integration made %d exchanges, want one per GetToken call", got)
+	if got := exchanges.Load(); got != 1 {
+		t.Errorf("cached workload identity made %d exchanges, want one per transport generation", got)
 	}
 	for _, doer := range []HTTPDoer{nil, http.DefaultClient} {
 		if token, tokenErr := identity.GetToken(t.Context(), doer); token != "" || tokenErr == nil {
@@ -92,7 +92,7 @@ func TestX509WorkloadIdentityAuthExchangesOnlyOnItsAttestedTransport(t *testing.
 		tokenErr == nil || !strings.Contains(tokenErr.Error(), "invalid") {
 		t.Errorf("nil X.509 identity returned token=%q error=%v", token, tokenErr)
 	}
-	if got := exchanges.Load(); got != 2 {
+	if got := exchanges.Load(); got != 1 {
 		t.Errorf("rejected transports/cancellation caused unexpected exchanges: %d", got)
 	}
 }

--- a/internal/requestconfig/option_layers.go
+++ b/internal/requestconfig/option_layers.go
@@ -18,6 +18,7 @@ type authenticationState struct {
 	currentLayer             *optionLayerIdentity
 	providerInCurrentLayer   *ProviderAuthOption
 	selectedProvider         *ProviderAuthOption
+	retryScopeFactory        *requestRetryScopeFactory
 	httpClientExplicit       bool
 	apiKeyLayer              *optionLayerIdentity
 	adminAPIKeyLayer         *optionLayerIdentity
@@ -256,6 +257,9 @@ func (state authenticationState) cloneAsInherited(cfg *RequestConfig) authentica
 	state.adminAPIKeyLayer = nil
 	state.authorizationHeaderLayer = nil
 	state.apiKeyHeaderLayer = nil
+	if state.retryScopeFactory != nil {
+		state.retryScopeFactory.install(cfg)
+	}
 
 	hasAuthorizationOverride := state.headerOverride || state.authorizationExplicit ||
 		len(cfg.Request.Header.Values("Authorization")) != 0

--- a/internal/requestconfig/retry_scope.go
+++ b/internal/requestconfig/retry_scope.go
@@ -8,6 +8,12 @@ import (
 
 type requestRetryScopeContextKey struct{}
 
+type requestRetryScopeFactory struct {
+	maximum         int
+	maximumDelay    time.Duration
+	allowBodyReplay bool
+}
+
 // RequestRetryScope shares one retry budget across provider authentication,
 // ordinary SDK request attempts, and a single unauthorized-response replay.
 // This is internal API and may change without notice.
@@ -34,6 +40,27 @@ func NewRequestRetryScope(maximum int, maximumDelay time.Duration, allowBodyRepl
 		allowBodyReplay: allowBodyReplay,
 		onInternalRetry: onInternalRetry,
 	}
+}
+
+// InstallRequestRetryScope attaches a fresh logical-request budget to cfg and
+// ensures configuration clones receive independent budgets and callbacks.
+func (cfg *RequestConfig) InstallRequestRetryScope(allowBodyReplay bool) *RequestRetryScope {
+	factory := &requestRetryScopeFactory{
+		maximum:         cfg.MaxRetries,
+		maximumDelay:    cfg.MaxRetryDelay,
+		allowBodyReplay: allowBodyReplay,
+	}
+	cfg.authentication.retryScopeFactory = factory
+	return factory.install(cfg)
+}
+
+func (factory *requestRetryScopeFactory) install(cfg *RequestConfig) *RequestRetryScope {
+	cfg.MaxRetries = factory.maximum
+	scope := NewRequestRetryScope(factory.maximum, factory.maximumDelay, factory.allowBodyReplay, func(consumed int) {
+		cfg.MaxRetries = factory.maximum - consumed
+	})
+	cfg.Request = cfg.Request.WithContext(WithRequestRetryScope(cfg.Request.Context(), scope))
+	return scope
 }
 
 // WithRequestRetryScope associates a scope with an existing request context.

--- a/internal/requestconfig/retry_scope.go
+++ b/internal/requestconfig/retry_scope.go
@@ -2,6 +2,8 @@ package requestconfig
 
 import (
 	"context"
+	"errors"
+	"net/http"
 	"sync"
 	"time"
 )
@@ -54,6 +56,22 @@ func (cfg *RequestConfig) InstallRequestRetryScope(allowBodyReplay bool) *Reques
 	return factory.install(cfg)
 }
 
+// InstallRequestAttemptMiddleware counts complete SDK attempts before caller
+// middleware can short-circuit authentication. Configuration clones inherit
+// this middleware and resolve their own independently installed scope.
+func (cfg *RequestConfig) InstallRequestAttemptMiddleware() {
+	cfg.Middlewares = append([]middleware{func(request *http.Request, next middlewareNext) (*http.Response, error) {
+		if request == nil {
+			return nil, WithNoRetryError(errors.New("X.509 workload identity requires a non-nil request"))
+		}
+		scope := RequestRetryScopeFromContext(request.Context())
+		if scope == nil || !scope.BeginAttempt() {
+			return nil, WithNoRetryError(errors.New("X.509 workload identity retry budget exhausted"))
+		}
+		return next(request)
+	}}, cfg.Middlewares...)
+}
+
 func (factory *requestRetryScopeFactory) install(cfg *RequestConfig) *RequestRetryScope {
 	cfg.MaxRetries = factory.maximum
 	scope := NewRequestRetryScope(factory.maximum, factory.maximumDelay, factory.allowBodyReplay, func(consumed int) {
@@ -95,12 +113,12 @@ func (scope *RequestRetryScope) TryRetry() bool {
 	return scope.tryInternalRetry()
 }
 
-// TryReplay consumes one retry for the only allowed unauthorized-response
-// replay associated with this logical request.
-func (scope *RequestRetryScope) TryReplay() bool {
+// TryOuterReplay reserves the sole unauthorized recovery without consuming a
+// retry. The SDK's next complete attempt accounts for the retry instead.
+func (scope *RequestRetryScope) TryOuterReplay() bool {
 	scope.mu.Lock()
 	defer scope.mu.Unlock()
-	if scope.replayUsed || !scope.tryInternalRetry() {
+	if scope.replayUsed || scope.outerRetries+scope.internalRetries >= scope.maximum {
 		return false
 	}
 	scope.replayUsed = true

--- a/internal/requestconfig/retry_scope.go
+++ b/internal/requestconfig/retry_scope.go
@@ -3,6 +3,7 @@ package requestconfig
 import (
 	"context"
 	"sync"
+	"time"
 )
 
 type requestRetryScopeContextKey struct{}
@@ -13,6 +14,7 @@ type requestRetryScopeContextKey struct{}
 type RequestRetryScope struct {
 	mu              sync.Mutex
 	maximum         int
+	maximumDelay    time.Duration
 	outerRetries    int
 	internalRetries int
 	attempts        int
@@ -22,9 +24,13 @@ type RequestRetryScope struct {
 }
 
 // NewRequestRetryScope creates the retry scope for one logical SDK request.
-func NewRequestRetryScope(maximum int, allowBodyReplay bool, onInternalRetry func(int)) *RequestRetryScope {
+func NewRequestRetryScope(maximum int, maximumDelay time.Duration, allowBodyReplay bool, onInternalRetry func(int)) *RequestRetryScope {
+	if maximumDelay <= 0 {
+		maximumDelay = DefaultMaxServerDelay
+	}
 	return &RequestRetryScope{
 		maximum:         max(0, maximum),
+		maximumDelay:    maximumDelay,
 		allowBodyReplay: allowBodyReplay,
 		onInternalRetry: onInternalRetry,
 	}
@@ -78,6 +84,12 @@ func (scope *RequestRetryScope) TryReplay() bool {
 // body after it became replayable.
 func (scope *RequestRetryScope) AllowBodyReplay() bool {
 	return scope.allowBodyReplay
+}
+
+// MaxRetryDelay bounds issuer-directed and SDK-selected retry waits for this
+// logical request.
+func (scope *RequestRetryScope) MaxRetryDelay() time.Duration {
+	return scope.maximumDelay
 }
 
 func (scope *RequestRetryScope) tryInternalRetry() bool {

--- a/internal/requestconfig/retry_scope.go
+++ b/internal/requestconfig/retry_scope.go
@@ -1,0 +1,92 @@
+package requestconfig
+
+import (
+	"context"
+	"sync"
+)
+
+type requestRetryScopeContextKey struct{}
+
+// RequestRetryScope shares one retry budget across provider authentication,
+// ordinary SDK request attempts, and a single unauthorized-response replay.
+// This is internal API and may change without notice.
+type RequestRetryScope struct {
+	mu              sync.Mutex
+	maximum         int
+	outerRetries    int
+	internalRetries int
+	attempts        int
+	replayUsed      bool
+	allowBodyReplay bool
+	onInternalRetry func(int)
+}
+
+// NewRequestRetryScope creates the retry scope for one logical SDK request.
+func NewRequestRetryScope(maximum int, allowBodyReplay bool, onInternalRetry func(int)) *RequestRetryScope {
+	return &RequestRetryScope{
+		maximum:         max(0, maximum),
+		allowBodyReplay: allowBodyReplay,
+		onInternalRetry: onInternalRetry,
+	}
+}
+
+// WithRequestRetryScope associates a scope with an existing request context.
+func WithRequestRetryScope(ctx context.Context, scope *RequestRetryScope) context.Context {
+	return context.WithValue(ctx, requestRetryScopeContextKey{}, scope)
+}
+
+// RequestRetryScopeFromContext returns the logical request's retry scope.
+func RequestRetryScopeFromContext(ctx context.Context) *RequestRetryScope {
+	scope, _ := ctx.Value(requestRetryScopeContextKey{}).(*RequestRetryScope)
+	return scope
+}
+
+// BeginAttempt records the first dispatch or one ordinary SDK retry attempt.
+func (scope *RequestRetryScope) BeginAttempt() bool {
+	scope.mu.Lock()
+	defer scope.mu.Unlock()
+	if scope.attempts != 0 {
+		if scope.outerRetries+scope.internalRetries >= scope.maximum {
+			return false
+		}
+		scope.outerRetries++
+	}
+	scope.attempts++
+	return true
+}
+
+// TryRetry consumes one retry for an internal provider-authentication attempt.
+func (scope *RequestRetryScope) TryRetry() bool {
+	scope.mu.Lock()
+	defer scope.mu.Unlock()
+	return scope.tryInternalRetry()
+}
+
+// TryReplay consumes one retry for the only allowed unauthorized-response
+// replay associated with this logical request.
+func (scope *RequestRetryScope) TryReplay() bool {
+	scope.mu.Lock()
+	defer scope.mu.Unlock()
+	if scope.replayUsed || !scope.tryInternalRetry() {
+		return false
+	}
+	scope.replayUsed = true
+	return true
+}
+
+// AllowBodyReplay reports whether caller middleware could have transformed the
+// body after it became replayable.
+func (scope *RequestRetryScope) AllowBodyReplay() bool {
+	return scope.allowBodyReplay
+}
+
+func (scope *RequestRetryScope) tryInternalRetry() bool {
+	if scope.outerRetries+scope.internalRetries >= scope.maximum {
+		return false
+	}
+	scope.internalRetries++
+	if scope.onInternalRetry != nil {
+		scope.onInternalRetry(scope.internalRetries)
+	}
+	return true
+}

--- a/internal/requestconfig/retry_scope_test.go
+++ b/internal/requestconfig/retry_scope_test.go
@@ -1,6 +1,8 @@
 package requestconfig
 
 import (
+	"net/http"
+	"sync"
 	"testing"
 	"time"
 )
@@ -53,5 +55,52 @@ func TestRequestRetryScopePreservesConfiguredMaximumDelay(t *testing.T) {
 	scope := NewRequestRetryScope(2, 7*time.Millisecond, true, nil)
 	if got := scope.MaxRetryDelay(); got != 7*time.Millisecond {
 		t.Errorf("request maximum retry delay = %s, want 7ms", got)
+	}
+}
+
+func TestRequestRetryScopeClonesHaveIndependentBudgetsAndCallbacks(t *testing.T) {
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://example.com", nil)
+	if err != nil {
+		t.Fatalf("construct retry-scope clone request: %v", err)
+	}
+	parent := RequestConfig{Request: request, MaxRetries: 2, MaxRetryDelay: 7 * time.Millisecond}
+	parentScope := parent.InstallRequestRetryScope(true)
+	if !parentScope.BeginAttempt() || !parentScope.TryRetry() || parent.MaxRetries != 1 {
+		t.Fatal("parent retry scope did not consume its own logical budget")
+	}
+	clone := parent.Clone(t.Context())
+	if clone == nil || clone.MaxRetries != 2 {
+		t.Fatalf("cloned logical request maximum = %v, want reset original maximum 2", clone)
+	}
+	cloneScope := RequestRetryScopeFromContext(clone.Request.Context())
+	if cloneScope == nil || cloneScope == parentScope || cloneScope.MaxRetryDelay() != 7*time.Millisecond {
+		t.Fatal("request clone reused its parent's scope or lost its configured maximum delay")
+	}
+	if !cloneScope.BeginAttempt() || !cloneScope.TryRetry() || clone.MaxRetries != 1 {
+		t.Fatal("cloned logical request did not consume its own independent retry")
+	}
+	if parent.MaxRetries != 1 {
+		t.Errorf("cloned retry mutated ancestor MaxRetries = %d", parent.MaxRetries)
+	}
+	var finished sync.WaitGroup
+	const concurrentClones = 12
+	finished.Add(concurrentClones)
+	for range concurrentClones {
+		go func() {
+			defer finished.Done()
+			current := parent.Clone(t.Context())
+			if current == nil {
+				t.Error("concurrent request clone returned nil")
+				return
+			}
+			scope := RequestRetryScopeFromContext(current.Request.Context())
+			if scope == nil || !scope.BeginAttempt() || !scope.TryRetry() || current.MaxRetries != 1 {
+				t.Error("concurrent request clone lost its isolated retry budget")
+			}
+		}()
+	}
+	finished.Wait()
+	if parent.MaxRetries != 1 {
+		t.Errorf("concurrent request clones mutated ancestor MaxRetries = %d", parent.MaxRetries)
 	}
 }

--- a/internal/requestconfig/retry_scope_test.go
+++ b/internal/requestconfig/retry_scope_test.go
@@ -1,0 +1,44 @@
+package requestconfig
+
+import "testing"
+
+func TestRequestRetryScopeSharesLogicalAttemptBudget(t *testing.T) {
+	var consumed []int
+	scope := NewRequestRetryScope(2, true, func(value int) { consumed = append(consumed, value) })
+	for range 2 {
+		if !scope.BeginAttempt() {
+			t.Fatal("initial request and first outer retry were not admitted")
+		}
+	}
+	if !scope.TryReplay() {
+		t.Fatal("remaining retry budget did not admit the first 401 replay")
+	}
+	if scope.TryReplay() || scope.TryRetry() || scope.BeginAttempt() {
+		t.Error("combined retry scope admitted an attempt beyond its logical budget")
+	}
+	if len(consumed) != 1 || consumed[0] != 1 {
+		t.Errorf("internal retry callbacks = %v, want [1]", consumed)
+	}
+}
+
+func TestRequestRetryScopePreservesContextAndReplayPolicy(t *testing.T) {
+	scope := NewRequestRetryScope(2, false, nil)
+	ctx := WithRequestRetryScope(t.Context(), scope)
+	if RequestRetryScopeFromContext(ctx) != scope || scope.AllowBodyReplay() {
+		t.Error("request context lost its retry scope or transformed-body replay policy")
+	}
+	if RequestRetryScopeFromContext(t.Context()) != nil {
+		t.Error("ordinary contexts unexpectedly acquired an X.509 retry scope")
+	}
+	if !scope.BeginAttempt() {
+		t.Fatal("initial issuer attempt was rejected")
+	}
+	for range 2 {
+		if !scope.TryRetry() {
+			t.Fatal("issuer retry budget was rejected prematurely")
+		}
+	}
+	if scope.TryRetry() {
+		t.Error("issuer retries did not stop at the logical request budget")
+	}
+}

--- a/internal/requestconfig/retry_scope_test.go
+++ b/internal/requestconfig/retry_scope_test.go
@@ -1,10 +1,13 @@
 package requestconfig
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestRequestRetryScopeSharesLogicalAttemptBudget(t *testing.T) {
 	var consumed []int
-	scope := NewRequestRetryScope(2, true, func(value int) { consumed = append(consumed, value) })
+	scope := NewRequestRetryScope(2, time.Second, true, func(value int) { consumed = append(consumed, value) })
 	for range 2 {
 		if !scope.BeginAttempt() {
 			t.Fatal("initial request and first outer retry were not admitted")
@@ -22,13 +25,16 @@ func TestRequestRetryScopeSharesLogicalAttemptBudget(t *testing.T) {
 }
 
 func TestRequestRetryScopePreservesContextAndReplayPolicy(t *testing.T) {
-	scope := NewRequestRetryScope(2, false, nil)
+	scope := NewRequestRetryScope(2, 0, false, nil)
 	ctx := WithRequestRetryScope(t.Context(), scope)
 	if RequestRetryScopeFromContext(ctx) != scope || scope.AllowBodyReplay() {
 		t.Error("request context lost its retry scope or transformed-body replay policy")
 	}
 	if RequestRetryScopeFromContext(t.Context()) != nil {
 		t.Error("ordinary contexts unexpectedly acquired an X.509 retry scope")
+	}
+	if scope.MaxRetryDelay() != DefaultMaxServerDelay {
+		t.Errorf("default maximum retry delay = %s, want %s", scope.MaxRetryDelay(), DefaultMaxServerDelay)
 	}
 	if !scope.BeginAttempt() {
 		t.Fatal("initial issuer attempt was rejected")
@@ -40,5 +46,12 @@ func TestRequestRetryScopePreservesContextAndReplayPolicy(t *testing.T) {
 	}
 	if scope.TryRetry() {
 		t.Error("issuer retries did not stop at the logical request budget")
+	}
+}
+
+func TestRequestRetryScopePreservesConfiguredMaximumDelay(t *testing.T) {
+	scope := NewRequestRetryScope(2, 7*time.Millisecond, true, nil)
+	if got := scope.MaxRetryDelay(); got != 7*time.Millisecond {
+		t.Errorf("request maximum retry delay = %s, want 7ms", got)
 	}
 }

--- a/internal/requestconfig/retry_scope_test.go
+++ b/internal/requestconfig/retry_scope_test.go
@@ -15,14 +15,14 @@ func TestRequestRetryScopeSharesLogicalAttemptBudget(t *testing.T) {
 			t.Fatal("initial request and first outer retry were not admitted")
 		}
 	}
-	if !scope.TryReplay() {
+	if !scope.TryOuterReplay() {
 		t.Fatal("remaining retry budget did not admit the first 401 replay")
 	}
-	if scope.TryReplay() || scope.TryRetry() || scope.BeginAttempt() {
+	if scope.TryOuterReplay() || !scope.BeginAttempt() || scope.TryRetry() || scope.BeginAttempt() {
 		t.Error("combined retry scope admitted an attempt beyond its logical budget")
 	}
-	if len(consumed) != 1 || consumed[0] != 1 {
-		t.Errorf("internal retry callbacks = %v, want [1]", consumed)
+	if len(consumed) != 0 {
+		t.Errorf("outer retry incorrectly consumed internal retry callbacks: %v", consumed)
 	}
 }
 
@@ -48,6 +48,82 @@ func TestRequestRetryScopePreservesContextAndReplayPolicy(t *testing.T) {
 	}
 	if scope.TryRetry() {
 		t.Error("issuer retries did not stop at the logical request budget")
+	}
+}
+
+func TestRequestRetryScopeReservesOnlyOneCompleteUnauthorizedAttempt(t *testing.T) {
+	var consumed []int
+	scope := NewRequestRetryScope(2, time.Second, true, func(value int) { consumed = append(consumed, value) })
+	if !scope.BeginAttempt() || !scope.TryOuterReplay() {
+		t.Fatal("initial attempt did not reserve its unauthorized outer retry")
+	}
+	if scope.TryOuterReplay() {
+		t.Error("one logical request reserved multiple unauthorized recoveries")
+	}
+	if len(consumed) != 0 {
+		t.Errorf("outer recovery incorrectly consumed an internal retry: %v", consumed)
+	}
+	if !scope.BeginAttempt() || !scope.TryRetry() {
+		t.Error("reserved outer attempt did not preserve the remaining issuer retry")
+	}
+	if scope.BeginAttempt() || scope.TryRetry() {
+		t.Error("outer recovery exceeded its shared logical retry budget")
+	}
+	if len(consumed) != 1 || consumed[0] != 1 {
+		t.Errorf("mixed outer/internal retry callbacks = %v, want [1]", consumed)
+	}
+	zero := NewRequestRetryScope(0, time.Second, true, nil)
+	if !zero.BeginAttempt() || zero.TryOuterReplay() {
+		t.Error("zero-retry scope incorrectly reserved an unauthorized recovery")
+	}
+}
+
+func TestRequestAttemptMiddlewarePreservesIndependentCloneScopes(t *testing.T) {
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://example.com", nil)
+	if err != nil {
+		t.Fatalf("construct counted request: %v", err)
+	}
+	parent := RequestConfig{Request: request, MaxRetries: 1}
+	parentScope := parent.InstallRequestRetryScope(true)
+	parent.InstallRequestAttemptMiddleware()
+	if len(parent.Middlewares) != 1 {
+		t.Fatalf("parent installed %d attempt counters, want exactly one", len(parent.Middlewares))
+	}
+	var calls int
+	next := func(*http.Request) (*http.Response, error) {
+		calls++
+		return &http.Response{StatusCode: http.StatusOK}, nil
+	}
+	attempt := func(cfg *RequestConfig) error {
+		response, attemptErr := cfg.Middlewares[0](cfg.Request, next)
+		if response != nil && response.Body != nil {
+			if closeErr := response.Body.Close(); closeErr != nil {
+				t.Errorf("close synthetic counted-attempt response: %v", closeErr)
+			}
+		}
+		return attemptErr
+	}
+	for range 2 {
+		if attemptErr := attempt(&parent); attemptErr != nil {
+			t.Fatalf("counted parent attempt failed: %v", attemptErr)
+		}
+	}
+	if attemptErr := attempt(&parent); attemptErr == nil {
+		t.Error("attempt counter accepted a caller-middleware short circuit beyond its budget")
+	}
+	clone := parent.Clone(t.Context())
+	if clone == nil || len(clone.Middlewares) != 1 {
+		t.Fatalf("cloned request duplicated its outer attempt counter: %v", clone)
+	}
+	cloneScope := RequestRetryScopeFromContext(clone.Request.Context())
+	if cloneScope == nil || cloneScope == parentScope {
+		t.Fatal("cloned outer attempt counter reused its parent's scope")
+	}
+	if attemptErr := attempt(clone); attemptErr != nil {
+		t.Fatalf("cloned attempt counter did not resolve its fresh context scope: %v", attemptErr)
+	}
+	if calls != 3 {
+		t.Errorf("parent and clone dispatched %d admitted attempts, want 3", calls)
 	}
 }
 

--- a/option/x509workloadidentity.go
+++ b/option/x509workloadidentity.go
@@ -68,12 +68,21 @@ func WithX509WorkloadIdentity(config auth.X509WorkloadIdentity) RequestOption {
 				return initializationError
 			}
 			final.CustomHTTPDoer = config.Transport
+			originalRetries := final.MaxRetries
+			allowBodyReplay := len(final.Middlewares) == 0
+			scope := requestconfig.NewRequestRetryScope(originalRetries, allowBodyReplay, func(consumed int) {
+				final.MaxRetries = originalRetries - consumed
+			})
 			return WithMiddleware(func(request *http.Request, next MiddlewareNext) (*http.Response, error) {
 				if !validX509WorkloadAPIRequest(request) || unsafeX509CredentialHeaders(request.Header) {
 					return nil, requestconfig.WithNoRetryError(
 						errors.New("X.509 workload identity rejected an unsafe final API request"),
 					)
 				}
+				if !scope.BeginAttempt() {
+					return nil, requestconfig.WithNoRetryError(errors.New("X.509 workload identity retry budget exhausted"))
+				}
+				request = request.WithContext(requestconfig.WithRequestRetryScope(request.Context(), scope))
 				authenticationFailed := true
 				response, err := auth.X509WorkloadIdentityMiddleware(identity, config.Transport, request,
 					func(authenticated *http.Request) (*http.Response, error) {

--- a/option/x509workloadidentity.go
+++ b/option/x509workloadidentity.go
@@ -70,15 +70,17 @@ func WithX509WorkloadIdentity(config auth.X509WorkloadIdentity) RequestOption {
 			final.CustomHTTPDoer = config.Transport
 			allowBodyReplay := len(final.Middlewares) == 0
 			final.InstallRequestRetryScope(allowBodyReplay)
+			final.InstallRequestAttemptMiddleware()
 			return WithMiddleware(func(request *http.Request, next MiddlewareNext) (*http.Response, error) {
 				if !validX509WorkloadAPIRequest(request) || unsafeX509CredentialHeaders(request.Header) {
 					return nil, requestconfig.WithNoRetryError(
 						errors.New("X.509 workload identity rejected an unsafe final API request"),
 					)
 				}
-				scope := requestconfig.RequestRetryScopeFromContext(request.Context())
-				if scope == nil || !scope.BeginAttempt() {
-					return nil, requestconfig.WithNoRetryError(errors.New("X.509 workload identity retry budget exhausted"))
+				if requestconfig.RequestRetryScopeFromContext(request.Context()) == nil {
+					return nil, requestconfig.WithNoRetryError(
+						errors.New("X.509 workload identity requires its request-owned retry scope"),
+					)
 				}
 				authenticationFailed := true
 				response, err := auth.X509WorkloadIdentityMiddleware(identity, config.Transport, request,

--- a/option/x509workloadidentity.go
+++ b/option/x509workloadidentity.go
@@ -70,7 +70,7 @@ func WithX509WorkloadIdentity(config auth.X509WorkloadIdentity) RequestOption {
 			final.CustomHTTPDoer = config.Transport
 			originalRetries := final.MaxRetries
 			allowBodyReplay := len(final.Middlewares) == 0
-			scope := requestconfig.NewRequestRetryScope(originalRetries, allowBodyReplay, func(consumed int) {
+			scope := requestconfig.NewRequestRetryScope(originalRetries, final.MaxRetryDelay, allowBodyReplay, func(consumed int) {
 				final.MaxRetries = originalRetries - consumed
 			})
 			return WithMiddleware(func(request *http.Request, next MiddlewareNext) (*http.Response, error) {

--- a/option/x509workloadidentity.go
+++ b/option/x509workloadidentity.go
@@ -74,14 +74,18 @@ func WithX509WorkloadIdentity(config auth.X509WorkloadIdentity) RequestOption {
 						errors.New("X.509 workload identity rejected an unsafe final API request"),
 					)
 				}
-				token, err := identity.GetToken(request.Context(), config.Transport)
-				if err != nil {
+				authenticationFailed := true
+				response, err := auth.X509WorkloadIdentityMiddleware(identity, config.Transport, request,
+					func(authenticated *http.Request) (*http.Response, error) {
+						response, dispatchErr := next(authenticated)
+						authenticationFailed = dispatchErr == nil && response != nil &&
+							response.StatusCode == http.StatusUnauthorized
+						return response, dispatchErr
+					})
+				if err != nil && authenticationFailed {
 					return nil, requestconfig.WithNoRetryError(err)
 				}
-				authenticated := request.Clone(request.Context())
-				authenticated.Header.Set("Authorization", "Bearer "+token)
-				response, dispatchErr := next(authenticated)
-				return redactX509Response(response), dispatchErr
+				return redactX509Response(response), err
 			}).Apply(final)
 		}).Apply(cfg)
 	})

--- a/option/x509workloadidentity.go
+++ b/option/x509workloadidentity.go
@@ -68,21 +68,18 @@ func WithX509WorkloadIdentity(config auth.X509WorkloadIdentity) RequestOption {
 				return initializationError
 			}
 			final.CustomHTTPDoer = config.Transport
-			originalRetries := final.MaxRetries
 			allowBodyReplay := len(final.Middlewares) == 0
-			scope := requestconfig.NewRequestRetryScope(originalRetries, final.MaxRetryDelay, allowBodyReplay, func(consumed int) {
-				final.MaxRetries = originalRetries - consumed
-			})
+			final.InstallRequestRetryScope(allowBodyReplay)
 			return WithMiddleware(func(request *http.Request, next MiddlewareNext) (*http.Response, error) {
 				if !validX509WorkloadAPIRequest(request) || unsafeX509CredentialHeaders(request.Header) {
 					return nil, requestconfig.WithNoRetryError(
 						errors.New("X.509 workload identity rejected an unsafe final API request"),
 					)
 				}
-				if !scope.BeginAttempt() {
+				scope := requestconfig.RequestRetryScopeFromContext(request.Context())
+				if scope == nil || !scope.BeginAttempt() {
 					return nil, requestconfig.WithNoRetryError(errors.New("X.509 workload identity retry budget exhausted"))
 				}
-				request = request.WithContext(requestconfig.WithRequestRetryScope(request.Context(), scope))
 				authenticationFailed := true
 				response, err := auth.X509WorkloadIdentityMiddleware(identity, config.Transport, request,
 					func(authenticated *http.Request) (*http.Response, error) {

--- a/x509_workload_identity_integration_test.go
+++ b/x509_workload_identity_integration_test.go
@@ -521,7 +521,7 @@ func TestX509WorkloadIdentityUsesOnlyTheLastAuthenticationOption(t *testing.T) {
 				t.Errorf("concurrent reused X.509 option request: %v", err)
 			}
 		}
-		if len(issuer.requests()) != requests || len(api.requests()) != requests {
+		if len(issuer.requests()) != 1 || len(api.requests()) != requests {
 			t.Errorf("concurrently reused X.509 option issuer/API calls = %d/%d",
 				len(issuer.requests()), len(api.requests()))
 		}

--- a/x509_workload_identity_integration_test.go
+++ b/x509_workload_identity_integration_test.go
@@ -31,8 +31,8 @@ func TestX509WorkloadIdentityAuthenticatesPublicClientOverMutualTLS(t *testing.T
 	}
 	issuerRequests := issuer.requests()
 	apiRequests := api.requests()
-	if len(issuerRequests) != 2 || len(apiRequests) != 2 {
-		t.Fatalf("pre-cache client made issuer/API requests = %d/%d, want 2/2", len(issuerRequests), len(apiRequests))
+	if len(issuerRequests) != 1 || len(apiRequests) != 2 {
+		t.Fatalf("cached client made issuer/API requests = %d/%d, want 1/2", len(issuerRequests), len(apiRequests))
 	}
 	for _, request := range issuerRequests {
 		if request.authorization != "" || request.host != x509ConformanceIssuerHost ||

--- a/x509_workload_identity_lifecycle_test.go
+++ b/x509_workload_identity_lifecycle_test.go
@@ -53,6 +53,62 @@ func TestX509WorkloadIdentityBoundsIssuerRetriesAcrossSDKRetries(t *testing.T) {
 	}
 }
 
+func TestX509WorkloadIdentityHonorsBoundedIssuerRetryAfter(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		status  int
+		header  string
+		value   string
+		maximum time.Duration
+		minimum time.Duration
+		ceiling time.Duration
+	}{
+		{name: "request timeout", status: http.StatusRequestTimeout,
+			header: "Retry-After-Ms", value: "40", maximum: 200 * time.Millisecond, minimum: 30 * time.Millisecond},
+		{name: "conflict", status: http.StatusConflict,
+			header: "Retry-After-Ms", value: "40", maximum: 200 * time.Millisecond, minimum: 30 * time.Millisecond},
+		{name: "rate limited", status: http.StatusTooManyRequests,
+			header: "Retry-After", value: "0.04", maximum: 200 * time.Millisecond, minimum: 30 * time.Millisecond},
+		{name: "service unavailable", status: http.StatusServiceUnavailable,
+			header: "Retry-After-Ms", value: "40", maximum: 200 * time.Millisecond, minimum: 30 * time.Millisecond},
+		{name: "caller delay clamps issuer hint", status: http.StatusTooManyRequests,
+			header: "Retry-After", value: "8", maximum: 5 * time.Millisecond, ceiling: 250 * time.Millisecond},
+		{name: "explicit zero is immediate", status: http.StatusServiceUnavailable,
+			header: "Retry-After-Ms", value: "0", maximum: time.Second, ceiling: 250 * time.Millisecond},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+			config, issuer, api := newX509WorkloadIdentityIntegration(t)
+			var exchanges atomic.Int32
+			attempted := make(chan time.Time, 2)
+			issuer.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				attempted <- time.Now()
+				if exchanges.Add(1) == 1 {
+					w.Header().Set(test.header, test.value)
+					w.WriteHeader(test.status)
+					return
+				}
+				_, _ = io.WriteString(w, x509IntegrationTokenResponse("synthetic-retry-after-bearer"))
+			})
+			client := openai.NewClient(option.WithX509WorkloadIdentity(config), option.WithMaxRetryDelay(test.maximum))
+			if _, err := client.Models.List(t.Context()); err != nil {
+				t.Fatalf("issuer-directed retry failed: %v", err)
+			}
+			first, second := <-attempted, <-attempted
+			delay := second.Sub(first)
+			if delay < test.minimum {
+				t.Errorf("issuer-directed retry waited %s, want at least %s", delay, test.minimum)
+			}
+			if test.ceiling > 0 && delay > test.ceiling {
+				t.Errorf("bounded issuer-directed retry waited %s, want no more than %s", delay, test.ceiling)
+			}
+			if exchanges.Load() != 2 || len(api.requests()) != 1 {
+				t.Errorf("issuer-directed retry issuer/API attempts = %d/%d", exchanges.Load(), len(api.requests()))
+			}
+		})
+	}
+}
+
 func TestX509WorkloadIdentitySharesRetryBudgetAcrossMixedIssuerAPIAndUnauthorized(t *testing.T) {
 	for _, test := range []struct {
 		name        string

--- a/x509_workload_identity_lifecycle_test.go
+++ b/x509_workload_identity_lifecycle_test.go
@@ -185,6 +185,49 @@ func TestX509WorkloadIdentityUnauthorizedRecoveryReentersSDKAttempt(t *testing.T
 	}
 }
 
+func TestX509WorkloadIdentityUnauthorizedRecoverySkipsOrdinaryRetryBackoff(t *testing.T) {
+	t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+	config, issuer, api := newX509WorkloadIdentityIntegration(t)
+	var exchanges, dispatches, middlewareAttempts atomic.Int32
+	issuer.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, x509IntegrationTokenResponse(
+			fmt.Sprintf("synthetic-immediate-recovery-%d", exchanges.Add(1)),
+		))
+	})
+	api.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if dispatches.Add(1) == 1 {
+			time.Sleep(35 * time.Millisecond)
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = io.WriteString(w, `{"error":{"message":"synthetic rejected bearer"}}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"data":[]}`)
+	})
+	client := openai.NewClient(
+		option.WithX509WorkloadIdentity(config),
+		option.WithMaxRetries(1),
+		option.WithRequestTimeout(100*time.Millisecond),
+		option.WithMiddleware(func(request *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+			middlewareAttempts.Add(1)
+			return next(request)
+		}),
+	)
+	parent, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	started := time.Now()
+	if _, err := client.Models.List(parent); err != nil {
+		t.Fatalf("unauthorized recovery used ordinary retry backoff under a short attempt timeout: %v", err)
+	}
+	if elapsed := time.Since(started); elapsed >= 300*time.Millisecond {
+		t.Errorf("unauthorized recovery waited %s for ordinary server backoff", elapsed)
+	}
+	if exchanges.Load() != 2 || dispatches.Load() != 2 || middlewareAttempts.Load() != 2 {
+		t.Errorf("immediate recovery issuer/API/middleware attempts = %d/%d/%d, want 2/2/2",
+			exchanges.Load(), dispatches.Load(), middlewareAttempts.Load())
+	}
+}
+
 func TestX509WorkloadIdentityRetriesOnlyTransientOAuthErrorCodes(t *testing.T) {
 	for _, test := range []struct {
 		name        string

--- a/x509_workload_identity_lifecycle_test.go
+++ b/x509_workload_identity_lifecycle_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -153,6 +154,105 @@ func TestX509WorkloadIdentitySharesRetryBudgetAcrossMixedIssuerAPIAndUnauthorize
 					exchanges.Load(), requests.Load(), test.wantIssuer, test.wantAPI)
 			}
 		})
+	}
+}
+
+func TestX509WorkloadIdentityPaginationUsesIndependentLogicalRetryScopes(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		maximum   int
+		failPage  int
+		wantCalls int32
+	}{
+		{name: "zero-retry budget still fetches four pages", maximum: 0, wantCalls: 4},
+		{name: "default budget fetches four pages", maximum: 2, wantCalls: 4},
+		{name: "later page has a fresh retry budget", maximum: 1, failPage: 3, wantCalls: 5},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+			config, issuer, api := newX509WorkloadIdentityIntegration(t)
+			var requests atomic.Int32
+			var failed atomic.Bool
+			api.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+				requests.Add(1)
+				previous := request.URL.Query().Get("after")
+				page := 1
+				if previous != "" {
+					parsed, err := strconv.Atoi(previous)
+					if err != nil {
+						w.WriteHeader(http.StatusBadRequest)
+						return
+					}
+					page = parsed + 1
+				}
+				w.Header().Set("Content-Type", "application/json")
+				if page == test.failPage && failed.CompareAndSwap(false, true) {
+					w.WriteHeader(http.StatusInternalServerError)
+					_, _ = io.WriteString(w, `{"error":{"message":"synthetic transient page failure"}}`)
+					return
+				}
+				_, _ = fmt.Fprintf(w, `{"data":[{"id":%q}],"has_more":%t}`, strconv.Itoa(page), page < 4)
+			})
+			client := openai.NewClient(option.WithX509WorkloadIdentity(config),
+				option.WithMaxRetries(test.maximum), option.WithMaxRetryDelay(time.Millisecond))
+			pages := client.Batches.ListAutoPaging(t.Context(), openai.BatchListParams{})
+			var received int
+			for pages.Next() {
+				received++
+				if id := pages.Current().ID; id != strconv.Itoa(received) {
+					t.Errorf("auto-paging item %d has ID %q", received, id)
+				}
+			}
+			if err := pages.Err(); err != nil || received != 4 {
+				t.Fatalf("independently scoped auto-paging returned %d pages, error = %v", received, err)
+			}
+			if requests.Load() != test.wantCalls || len(issuer.requests()) != 1 {
+				t.Errorf("auto-paging issuer/API calls = %d/%d, want 1/%d",
+					len(issuer.requests()), requests.Load(), test.wantCalls)
+			}
+		})
+	}
+}
+
+func TestX509WorkloadIdentityConcurrentPageClonesHaveIndependentBudgets(t *testing.T) {
+	t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+	config, issuer, api := newX509WorkloadIdentityIntegration(t)
+	var subsequent atomic.Int32
+	api.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if request.URL.Query().Get("after") == "" {
+			_, _ = io.WriteString(w, `{"data":[{"id":"1"}],"has_more":true}`)
+			return
+		}
+		if subsequent.Add(1) <= 2 {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = io.WriteString(w, `{"error":{"message":"synthetic concurrent page failure"}}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"data":[{"id":"2"}],"has_more":false}`)
+	})
+	client := openai.NewClient(option.WithX509WorkloadIdentity(config), option.WithMaxRetryDelay(time.Millisecond))
+	page, err := client.Batches.List(t.Context(), openai.BatchListParams{})
+	if err != nil {
+		t.Fatalf("load first concurrently cloned page: %v", err)
+	}
+	results := make(chan error, 2)
+	for range 2 {
+		go func() {
+			next, nextErr := page.GetNextPage()
+			if nextErr == nil && (next == nil || len(next.Data) != 1 || next.Data[0].ID != "2") {
+				nextErr = errors.New("concurrent page clone returned an unexpected item")
+			}
+			results <- nextErr
+		}()
+	}
+	for range 2 {
+		if nextErr := <-results; nextErr != nil {
+			t.Errorf("concurrent independently scoped page clone: %v", nextErr)
+		}
+	}
+	if len(issuer.requests()) != 1 {
+		t.Errorf("concurrent page clones minted %d workload tokens", len(issuer.requests()))
 	}
 }
 
@@ -324,6 +424,43 @@ func TestX509WorkloadIdentityDoesNotReplayMiddlewareTransformedBodies(t *testing
 	}
 	if exchanges.Load() != 2 || requests.Load() != 2 {
 		t.Errorf("post-invalidation issuer/API calls = %d/%d, want 2/2", exchanges.Load(), requests.Load())
+	}
+}
+
+func TestX509WorkloadIdentityDoesNotRestoreMiddlewareRemovedBody(t *testing.T) {
+	t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+	config, issuer, api := newX509WorkloadIdentityIntegration(t)
+	var requests atomic.Int32
+	api.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		body, err := io.ReadAll(request.Body)
+		if err != nil || len(body) != 0 {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if requests.Add(1) == 1 {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = io.WriteString(w, `{"error":{"message":"synthetic removed-body rejection"}}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"data":[]}`)
+	})
+	client := openai.NewClient(
+		option.WithX509WorkloadIdentity(config),
+		option.WithMiddleware(func(request *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+			if request.Body != nil {
+				request.Body = nil
+				request.ContentLength = 0
+			}
+			return next(request)
+		}),
+	)
+	if err := client.Execute(t.Context(), http.MethodPost, "models",
+		map[string]string{"secret": "synthetic-removed-payload"}, nil); err != nil {
+		t.Fatalf("bodyless unauthorized replay restored its removed payload: %v", err)
+	}
+	if requests.Load() != 2 || len(issuer.requests()) != 2 {
+		t.Errorf("removed-body issuer/API attempts = %d/%d, want 2/2", len(issuer.requests()), requests.Load())
 	}
 }
 

--- a/x509_workload_identity_lifecycle_test.go
+++ b/x509_workload_identity_lifecycle_test.go
@@ -1,6 +1,7 @@
 package openai_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -49,6 +50,176 @@ func TestX509WorkloadIdentityBoundsIssuerRetriesAcrossSDKRetries(t *testing.T) {
 			}
 			if got := int32(len(api.requests())); got != test.wantAPI {
 				t.Errorf("API attempts = %d, want %d", got, test.wantAPI)
+			}
+		})
+	}
+}
+
+func TestX509WorkloadIdentityCountsShortCircuitedCallerMiddlewareAttempts(t *testing.T) {
+	t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+	config, issuer, api := newX509WorkloadIdentityIntegration(t)
+	var middlewareAttempts, exchanges, dispatched atomic.Int32
+	issuer.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if exchanges.Add(1) == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		_, _ = io.WriteString(w, x509IntegrationTokenResponse("synthetic-shared-attempt-token"))
+	})
+	api.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		dispatched.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":[]}`)
+	})
+	client := openai.NewClient(
+		option.WithX509WorkloadIdentity(config),
+		option.WithMaxRetries(2),
+		option.WithMaxRetryDelay(time.Millisecond),
+		option.WithMiddleware(func(request *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+			if middlewareAttempts.Add(1) == 1 {
+				return &http.Response{
+					StatusCode: http.StatusInternalServerError,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"synthetic caller failure"}}`)),
+				}, nil
+			}
+			return next(request)
+		}),
+	)
+	if _, err := client.Models.List(t.Context()); err != nil {
+		t.Fatalf("shared caller-middleware and issuer retry budget did not recover: %v", err)
+	}
+	if middlewareAttempts.Load() != 2 || exchanges.Load() != 2 || dispatched.Load() != 1 {
+		t.Errorf("caller/issuer/API attempts = %d/%d/%d, want 2/2/1 within one shared budget",
+			middlewareAttempts.Load(), exchanges.Load(), dispatched.Load())
+	}
+}
+
+func TestX509WorkloadIdentityRejectsCallerMiddlewareRemovingRetryScope(t *testing.T) {
+	t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+	config, issuer, api := newX509WorkloadIdentityIntegration(t)
+	client := openai.NewClient(
+		option.WithX509WorkloadIdentity(config),
+		option.WithMiddleware(func(request *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+			return next(request.WithContext(context.Background()))
+		}),
+	)
+	if _, err := client.Models.List(t.Context()); err == nil {
+		t.Fatal("caller middleware removed the request-owned retry scope")
+	}
+	assertX509WorkloadNoRequests(t, issuer, api)
+}
+
+func TestX509WorkloadIdentityUnauthorizedRecoveryReentersSDKAttempt(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		maximum     int
+		wantCalls   int32
+		wantSuccess bool
+	}{
+		{name: "fresh middleware and attempt timeout", maximum: 1, wantCalls: 2, wantSuccess: true},
+		{name: "zero retries prevents unauthorized recovery", maximum: 0, wantCalls: 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+			config, issuer, api := newX509WorkloadIdentityIntegration(t)
+			var middlewareAttempts, exchanges, dispatched atomic.Int32
+			var mu sync.Mutex
+			var deadlines []time.Time
+			issuer.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = io.WriteString(w, x509IntegrationTokenResponse(
+					fmt.Sprintf("synthetic-outer-recovery-%d", exchanges.Add(1)),
+				))
+			})
+			api.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if dispatched.Add(1) == 1 {
+					time.Sleep(10 * time.Millisecond)
+					w.WriteHeader(http.StatusUnauthorized)
+					_, _ = io.WriteString(w, `{"error":{"message":"synthetic rejected bearer"}}`)
+					return
+				}
+				_, _ = io.WriteString(w, `{"data":[]}`)
+			})
+			client := openai.NewClient(
+				option.WithX509WorkloadIdentity(config),
+				option.WithMaxRetries(test.maximum),
+				option.WithMaxRetryDelay(time.Millisecond),
+				option.WithRequestTimeout(time.Second),
+				option.WithMiddleware(func(request *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+					middlewareAttempts.Add(1)
+					if deadline, ok := request.Context().Deadline(); ok {
+						mu.Lock()
+						deadlines = append(deadlines, deadline)
+						mu.Unlock()
+					}
+					return next(request)
+				}),
+			)
+			_, err := client.Models.List(t.Context())
+			if (err == nil) != test.wantSuccess {
+				t.Errorf("outer unauthorized recovery error = %v, want success %v", err, test.wantSuccess)
+			}
+			if middlewareAttempts.Load() != test.wantCalls || exchanges.Load() != test.wantCalls ||
+				dispatched.Load() != test.wantCalls {
+				t.Errorf("caller/issuer/API attempts = %d/%d/%d, want %d/%d/%d",
+					middlewareAttempts.Load(), exchanges.Load(), dispatched.Load(),
+					test.wantCalls, test.wantCalls, test.wantCalls)
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			if len(deadlines) != int(test.wantCalls) {
+				t.Fatalf("caller middleware observed %d per-attempt deadlines, want %d", len(deadlines), test.wantCalls)
+			}
+			if len(deadlines) == 2 && !deadlines[1].After(deadlines[0].Add(5*time.Millisecond)) {
+				t.Errorf("unauthorized recovery reused its first attempt deadline: %s then %s", deadlines[0], deadlines[1])
+			}
+		})
+	}
+}
+
+func TestX509WorkloadIdentityRetriesOnlyTransientOAuthErrorCodes(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		code        string
+		status      int
+		wantCalls   int32
+		wantSuccess bool
+	}{
+		{name: "temporarily unavailable", code: "temporarily_unavailable", status: 400, wantCalls: 2, wantSuccess: true},
+		{name: "server error", code: "server_error", status: 401, wantCalls: 2, wantSuccess: true},
+		{name: "invalid grant remains permanent", code: "invalid_grant", status: 400, wantCalls: 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+			config, issuer, api := newX509WorkloadIdentityIntegration(t)
+			var exchanges atomic.Int32
+			issuer.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if exchanges.Add(1) == 1 {
+					w.WriteHeader(test.status)
+					_, _ = fmt.Fprintf(w, `{"error":%q,"error_description":"synthetic-private-issuer-detail"}`, test.code)
+					return
+				}
+				_, _ = io.WriteString(w, x509IntegrationTokenResponse("synthetic-recovered-oauth-token"))
+			})
+			client := openai.NewClient(option.WithX509WorkloadIdentity(config),
+				option.WithMaxRetries(1), option.WithMaxRetryDelay(time.Millisecond))
+			_, err := client.Models.List(t.Context())
+			if (err == nil) != test.wantSuccess {
+				t.Errorf("OAuth error %q produced error=%v, want success %v", test.code, err, test.wantSuccess)
+			}
+			if err != nil && strings.Contains(err.Error(), "synthetic-private-issuer-detail") {
+				t.Errorf("OAuth error disclosed sensitive issuer details: %v", err)
+			}
+			if got := exchanges.Load(); got != test.wantCalls {
+				t.Errorf("OAuth error %q caused %d issuer attempts, want %d", test.code, got, test.wantCalls)
+			}
+			wantAPI := 0
+			if test.wantSuccess {
+				wantAPI = 1
+			}
+			if got := len(api.requests()); got != wantAPI {
+				t.Errorf("OAuth error %q dispatched %d API requests, want %d", test.code, got, wantAPI)
 			}
 		})
 	}

--- a/x509_workload_identity_lifecycle_test.go
+++ b/x509_workload_identity_lifecycle_test.go
@@ -1,0 +1,223 @@
+package openai_test
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/auth"
+	"github.com/openai/openai-go/v3/option"
+)
+
+func TestX509WorkloadIdentityBoundsIssuerRetriesAcrossSDKRetries(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		failures    int32
+		wantIssuer  int32
+		wantAPI     int32
+		wantSuccess bool
+	}{
+		{name: "transient issuer recovers", failures: 2, wantIssuer: 3, wantAPI: 1, wantSuccess: true},
+		{name: "transient issuer exhausts", failures: 10, wantIssuer: 3, wantAPI: 0},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+			config, issuer, api := newX509WorkloadIdentityIntegration(t)
+			var exchanges atomic.Int32
+			issuer.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if exchanges.Add(1) <= test.failures {
+					w.WriteHeader(http.StatusServiceUnavailable)
+					return
+				}
+				_, _ = io.WriteString(w, x509IntegrationTokenResponse("synthetic-recovered-token"))
+			})
+			client := openai.NewClient(option.WithX509WorkloadIdentity(config), option.WithMaxRetryDelay(time.Millisecond))
+			_, err := client.Models.List(t.Context())
+			if (err == nil) != test.wantSuccess {
+				t.Errorf("issuer retry result error=%v, want success=%v", err, test.wantSuccess)
+			}
+			if got := exchanges.Load(); got != test.wantIssuer {
+				t.Errorf("issuer attempts = %d, want %d without SDK retry multiplication", got, test.wantIssuer)
+			}
+			if got := int32(len(api.requests())); got != test.wantAPI {
+				t.Errorf("API attempts = %d, want %d", got, test.wantAPI)
+			}
+		})
+	}
+}
+
+func TestX509WorkloadIdentityRefreshesUnauthorizedReplayableRequestsOnce(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		body         any
+		alwaysReject bool
+		wantIssuer   int32
+		wantAPI      int32
+		wantSuccess  bool
+	}{
+		{name: "bodyless request", wantIssuer: 2, wantAPI: 2, wantSuccess: true},
+		{name: "replayable JSON body", body: map[string]string{"input": "synthetic-body"},
+			wantIssuer: 2, wantAPI: 2, wantSuccess: true},
+		{name: "non-replayable body", body: strings.NewReader("synthetic-streaming-body"),
+			wantIssuer: 1, wantAPI: 1},
+		{name: "repeated unauthorized stops", alwaysReject: true, wantIssuer: 2, wantAPI: 2},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+			config, issuer, api := newX509WorkloadIdentityIntegration(t)
+			var exchanges, requests atomic.Int32
+			var mu sync.Mutex
+			var bearers, bodies []string
+			issuer.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				number := exchanges.Add(1)
+				_, _ = io.WriteString(w, x509IntegrationTokenResponse(fmt.Sprintf("synthetic-bearer-%d", number)))
+			})
+			api.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+				body, _ := io.ReadAll(request.Body)
+				mu.Lock()
+				bearers = append(bearers, request.Header.Get("Authorization"))
+				bodies = append(bodies, string(body))
+				mu.Unlock()
+				w.Header().Set("Content-Type", "application/json")
+				if requests.Add(1) == 1 || test.alwaysReject {
+					w.WriteHeader(http.StatusUnauthorized)
+					_, _ = io.WriteString(w, `{"error":{"message":"synthetic rejected bearer"}}`)
+					return
+				}
+				_, _ = io.WriteString(w, `{"data":[]}`)
+			})
+			client := openai.NewClient(option.WithX509WorkloadIdentity(config))
+			var err error
+			if test.body == nil {
+				_, err = client.Models.List(t.Context())
+			} else {
+				err = client.Execute(t.Context(), http.MethodPost, "models", test.body, nil)
+			}
+			if (err == nil) != test.wantSuccess {
+				t.Errorf("401 replay result error=%v, want success=%v", err, test.wantSuccess)
+			}
+			if got := exchanges.Load(); got != test.wantIssuer {
+				t.Errorf("401 replay issuer exchanges = %d, want %d", got, test.wantIssuer)
+			}
+			if got := requests.Load(); got != test.wantAPI {
+				t.Errorf("401 replay API attempts = %d, want %d", got, test.wantAPI)
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			if len(bearers) == 2 && (bearers[0] != "Bearer synthetic-bearer-1" ||
+				bearers[1] != "Bearer synthetic-bearer-2") {
+				t.Errorf("401 replay bearer generations = %v", bearers)
+			}
+			if len(bodies) == 2 && bodies[0] != bodies[1] {
+				t.Errorf("401 replay changed its request body: %q versus %q", bodies[0], bodies[1])
+			}
+		})
+	}
+}
+
+func TestX509WorkloadIdentityDoesNotRetryRefreshFailureAfterUnauthorized(t *testing.T) {
+	t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+	config, issuer, api := newX509WorkloadIdentityIntegration(t)
+	var exchanges, requests atomic.Int32
+	issuer.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if exchanges.Add(1) == 1 {
+			_, _ = io.WriteString(w, x509IntegrationTokenResponse("synthetic-initial-bearer"))
+			return
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, `{"error":"invalid_grant","error_description":"synthetic-private-detail"}`)
+	})
+	api.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+	client := openai.NewClient(option.WithX509WorkloadIdentity(config))
+	_, err := client.Models.List(t.Context())
+	var oauthError *auth.OAuthError
+	if !errors.As(err, &oauthError) || oauthError.StatusCode != http.StatusBadRequest {
+		t.Fatalf("401 refresh failure lost its typed OAuth cause: %v", err)
+	}
+	if exchanges.Load() != 2 || requests.Load() != 1 {
+		t.Errorf("401 refresh issuer/API attempts = %d/%d, want 2/1", exchanges.Load(), requests.Load())
+	}
+}
+
+func TestX509WorkloadIdentityPreservesOrdinaryAPIStatusRetries(t *testing.T) {
+	t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+	config, issuer, api := newX509WorkloadIdentityIntegration(t)
+	var requests atomic.Int32
+	api.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if requests.Add(1) == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = io.WriteString(w, `{"error":{"message":"synthetic transient API failure"}}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"data":[]}`)
+	})
+	client := openai.NewClient(option.WithX509WorkloadIdentity(config), option.WithMaxRetryDelay(time.Millisecond))
+	if _, err := client.Models.List(t.Context()); err != nil {
+		t.Fatalf("ordinary API 500 did not preserve generic request retries: %v", err)
+	}
+	if len(issuer.requests()) != 1 || requests.Load() != 2 {
+		t.Errorf("cached issuer/API retry attempts = %d/%d, want 1/2", len(issuer.requests()), requests.Load())
+	}
+}
+
+func TestX509WorkloadIdentitySharesRefreshAfterConcurrentUnauthorized(t *testing.T) {
+	t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+	config, issuer, api := newX509WorkloadIdentityIntegration(t)
+	var exchanges, oldRequests, newRequests atomic.Int32
+	bothRejected := make(chan struct{})
+	issuer.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		number := exchanges.Add(1)
+		_, _ = io.WriteString(w, x509IntegrationTokenResponse(fmt.Sprintf("synthetic-concurrent-%d", number)))
+	})
+	api.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		if request.Header.Get("Authorization") == "Bearer synthetic-concurrent-1" {
+			if oldRequests.Add(1) == 2 {
+				close(bothRejected)
+			}
+			<-bothRejected
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		newRequests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":[]}`)
+	})
+	client := openai.NewClient(option.WithX509WorkloadIdentity(config))
+	results := make(chan error, 2)
+	for range 2 {
+		go func() {
+			_, err := client.Models.List(t.Context())
+			results <- err
+		}()
+	}
+	for range 2 {
+		select {
+		case err := <-results:
+			if err != nil {
+				t.Errorf("concurrent 401 replay: %v", err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("concurrent unauthorized requests did not complete")
+		}
+	}
+	if exchanges.Load() != 2 || oldRequests.Load() != 2 || newRequests.Load() != 2 {
+		t.Errorf("concurrent stale 401 issuer/old/new requests = %d/%d/%d, want 2/2/2",
+			exchanges.Load(), oldRequests.Load(), newRequests.Load())
+	}
+}
+
+func x509IntegrationTokenResponse(token string) string {
+	return fmt.Sprintf(`{"access_token":%q,"token_type":"Bearer",`+
+		`"issued_token_type":"urn:ietf:params:oauth:token-type:access_token","expires_in":60}`, token)
+}

--- a/x509_workload_identity_lifecycle_test.go
+++ b/x509_workload_identity_lifecycle_test.go
@@ -116,8 +116,11 @@ func TestX509WorkloadIdentityUnauthorizedRecoveryReentersSDKAttempt(t *testing.T
 		maximum     int
 		wantCalls   int32
 		wantSuccess bool
+		noBody      bool
 	}{
 		{name: "fresh middleware and attempt timeout", maximum: 1, wantCalls: 2, wantSuccess: true},
+		{name: "http.NoBody replays through caller middleware", maximum: 1,
+			wantCalls: 2, wantSuccess: true, noBody: true},
 		{name: "zero retries prevents unauthorized recovery", maximum: 0, wantCalls: 1},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -148,6 +151,10 @@ func TestX509WorkloadIdentityUnauthorizedRecoveryReentersSDKAttempt(t *testing.T
 				option.WithRequestTimeout(time.Second),
 				option.WithMiddleware(func(request *http.Request, next option.MiddlewareNext) (*http.Response, error) {
 					middlewareAttempts.Add(1)
+					if test.noBody {
+						request.Body = http.NoBody
+						request.ContentLength = 0
+					}
 					if deadline, ok := request.Context().Deadline(); ok {
 						mu.Lock()
 						deadlines = append(deadlines, deadline)

--- a/x509_workload_identity_lifecycle_test.go
+++ b/x509_workload_identity_lifecycle_test.go
@@ -53,6 +53,53 @@ func TestX509WorkloadIdentityBoundsIssuerRetriesAcrossSDKRetries(t *testing.T) {
 	}
 }
 
+func TestX509WorkloadIdentitySharesRetryBudgetAcrossMixedIssuerAPIAndUnauthorized(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		issuerFails int32
+		statuses    []int
+		wantIssuer  int32
+		wantAPI     int32
+	}{
+		{name: "API 500 then 401 replay then 500", statuses: []int{500, 401, 500}, wantIssuer: 2, wantAPI: 3},
+		{name: "issuer exhausts retries before 401", issuerFails: 2, statuses: []int{401}, wantIssuer: 3, wantAPI: 1},
+		{name: "401 replay then 500 then second 401", statuses: []int{401, 500, 401}, wantIssuer: 2, wantAPI: 3},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+			config, issuer, api := newX509WorkloadIdentityIntegration(t)
+			var exchanges, requests atomic.Int32
+			issuer.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				number := exchanges.Add(1)
+				if number <= test.issuerFails {
+					w.WriteHeader(http.StatusServiceUnavailable)
+					return
+				}
+				_, _ = io.WriteString(w, x509IntegrationTokenResponse(fmt.Sprintf("synthetic-scope-%d", number)))
+			})
+			api.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				number := int(requests.Add(1)) - 1
+				w.Header().Set("Content-Type", "application/json")
+				if number >= len(test.statuses) {
+					w.WriteHeader(http.StatusInternalServerError)
+					_, _ = io.WriteString(w, `{"error":{"message":"unexpected extra attempt"}}`)
+					return
+				}
+				w.WriteHeader(test.statuses[number])
+				_, _ = io.WriteString(w, `{"error":{"message":"synthetic mixed-sequence failure"}}`)
+			})
+			client := openai.NewClient(option.WithX509WorkloadIdentity(config), option.WithMaxRetryDelay(time.Millisecond))
+			if _, err := client.Models.List(t.Context()); err == nil {
+				t.Fatal("mixed issuer/API failure unexpectedly succeeded")
+			}
+			if exchanges.Load() != test.wantIssuer || requests.Load() != test.wantAPI {
+				t.Errorf("mixed issuer/API attempts = %d/%d, want %d/%d within one logical retry budget",
+					exchanges.Load(), requests.Load(), test.wantIssuer, test.wantAPI)
+			}
+		})
+	}
+}
+
 func TestX509WorkloadIdentityRefreshesUnauthorizedReplayableRequestsOnce(t *testing.T) {
 	for _, test := range []struct {
 		name         string
@@ -119,6 +166,108 @@ func TestX509WorkloadIdentityRefreshesUnauthorizedReplayableRequestsOnce(t *test
 				t.Errorf("401 replay changed its request body: %q versus %q", bodies[0], bodies[1])
 			}
 		})
+	}
+}
+
+func TestX509WorkloadIdentityInvalidatesNonreplayableAndRepeatedUnauthorizedBearers(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		body          any
+		firstStatuses int32
+		wantIssuer    int32
+		wantAPI       int32
+	}{
+		{name: "non-replayable first body", body: strings.NewReader("synthetic-streaming-body"),
+			firstStatuses: 1, wantIssuer: 2, wantAPI: 2},
+		{name: "replayed bearer also rejected", firstStatuses: 2, wantIssuer: 3, wantAPI: 3},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+			config, issuer, api := newX509WorkloadIdentityIntegration(t)
+			var exchanges, requests atomic.Int32
+			issuer.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = io.WriteString(w, x509IntegrationTokenResponse(
+					fmt.Sprintf("synthetic-invalidated-%d", exchanges.Add(1)),
+				))
+			})
+			api.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if requests.Add(1) <= test.firstStatuses {
+					w.WriteHeader(http.StatusUnauthorized)
+					_, _ = io.WriteString(w, `{"error":{"message":"synthetic rejected bearer"}}`)
+					return
+				}
+				_, _ = io.WriteString(w, `{"data":[]}`)
+			})
+			client := openai.NewClient(option.WithX509WorkloadIdentity(config))
+			var err error
+			if test.body == nil {
+				_, err = client.Models.List(t.Context())
+			} else {
+				err = client.Execute(t.Context(), http.MethodPost, "models", test.body, nil)
+			}
+			if err == nil {
+				t.Fatal("initial unauthorized request unexpectedly succeeded")
+			}
+			if _, err := client.Models.List(t.Context()); err != nil {
+				t.Fatalf("fresh request reused an invalidated bearer: %v", err)
+			}
+			if exchanges.Load() != test.wantIssuer || requests.Load() != test.wantAPI {
+				t.Errorf("rejected bearer issuer/API requests = %d/%d, want %d/%d",
+					exchanges.Load(), requests.Load(), test.wantIssuer, test.wantAPI)
+			}
+		})
+	}
+}
+
+func TestX509WorkloadIdentityDoesNotReplayMiddlewareTransformedBodies(t *testing.T) {
+	t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+	config, issuer, api := newX509WorkloadIdentityIntegration(t)
+	var exchanges, requests atomic.Int32
+	var observed string
+	var mu sync.Mutex
+	issuer.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, x509IntegrationTokenResponse(fmt.Sprintf("synthetic-transform-%d", exchanges.Add(1))))
+	})
+	api.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		body, _ := io.ReadAll(request.Body)
+		mu.Lock()
+		observed = string(body)
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		if requests.Add(1) == 1 {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = io.WriteString(w, `{"error":{"message":"synthetic transformed bearer rejection"}}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"data":[]}`)
+	})
+	client := openai.NewClient(
+		option.WithX509WorkloadIdentity(config),
+		option.WithMiddleware(func(request *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+			if request.Body != nil {
+				request.Body = io.NopCloser(strings.NewReader("middleware-transformed-body"))
+				request.ContentLength = int64(len("middleware-transformed-body"))
+			}
+			return next(request)
+		}),
+	)
+	if err := client.Execute(t.Context(), http.MethodPost, "models", map[string]string{"input": "original"}, nil); err == nil {
+		t.Fatal("body transformed by caller middleware was replayed after unauthorized")
+	}
+	mu.Lock()
+	if observed != "middleware-transformed-body" {
+		t.Errorf("first wire body = %q, want caller-transformed bytes", observed)
+	}
+	mu.Unlock()
+	if exchanges.Load() != 1 || requests.Load() != 1 {
+		t.Errorf("transformed request issuer/API calls = %d/%d, want 1/1", exchanges.Load(), requests.Load())
+	}
+	if _, err := client.Models.List(t.Context()); err != nil {
+		t.Fatalf("bodyless request did not recover after transformed-body invalidation: %v", err)
+	}
+	if exchanges.Load() != 2 || requests.Load() != 2 {
+		t.Errorf("post-invalidation issuer/API calls = %d/%d, want 2/2", exchanges.Load(), requests.Load())
 	}
 }
 


### PR DESCRIPTION
## Summary

Final change in the five-part X.509 workload identity stack, based on #857 after #856, #855, and #854.

- Add transport-generation-scoped token caching, context-owned single-flight refresh, bounded issuer-only transient retries, cancellation-safe waiter handoff, and lifetime-aware refresh buffering.
- Add compare-and-invalidate handling for API 401 responses with at most one replay and only for bodyless or provably replayable requests; preserve ordinary SDK API retries without multiplying authentication attempts.
- Document direct native mTLS setup, caller-owned certificate and trust material, attested transport lifecycle, global endpoint restrictions, and operational constraints.
- Add deterministic real-mTLS and concurrency/race coverage for cached credentials, transient/permanent OAuth failures, deadlines, stale concurrent 401s, request-body replay, and cleanup.

## Review and security

- Two independent agents exhaustively reviewed every committed lifecycle change; six first-round findings were fixed and both final independent reviews reported no issues.
- Exact-commit Codex Security scan `e0f5204c-276b-4ca2-96d5-b71ba363a579` reviewed all nine executable changed files and reported no findings.

## Verification

- Full repository and security-sensitive package race tests, including repeated concurrent refresh and adversarial 401 replay cases.
- Repository-wide and multi-module lint, examples/consumer builds, dependency tidiness, `go vet`, and committed-diff whitespace checks.
- Custom-code budget remains within the existing repository limit; no ratchet increase or generated SDK-source modifications.
