### PR TITLE
fix: harden X.509 refresh races and empty-body replay

### DIFF
--- a/auth/x509workloadidentity.go
+++ b/auth/x509workloadidentity.go
@@ -17,6 +17,8 @@ const (
 	x509MaximumRetryCooldown = 5 * time.Second
 )
 
+var errX509InvalidatedBearer = errors.New("X.509 token exchange returned an invalidated bearer")
+
 // X509WorkloadIdentity configures an OpenAI workload authenticated with a
 // caller-owned X.509 certificate and an explicitly attested native transport.
 type X509WorkloadIdentity struct {
@@ -29,11 +31,12 @@ type X509WorkloadIdentity struct {
 // X509WorkloadIdentityAuth exchanges a static, attested X.509 workload identity
 // for an ordinary OpenAI bearer token.
 type X509WorkloadIdentityAuth struct {
-	config       X509WorkloadIdentity
-	mu           sync.Mutex
-	cached       x509ExchangedToken
-	refreshAfter time.Time
-	inFlight     *x509TokenRefresh
+	config        X509WorkloadIdentity
+	mu            sync.Mutex
+	cached        x509ExchangedToken
+	rejectedToken string
+	refreshAfter  time.Time
+	inFlight      *x509TokenRefresh
 }
 
 type x509TokenRefresh struct {
@@ -119,6 +122,9 @@ func (identity *X509WorkloadIdentityAuth) GetToken(ctx context.Context, doer HTT
 
 		token, err := identity.exchangeWithRetry(ctx, transport, refresh)
 		identity.mu.Lock()
+		if err == nil && token.value == identity.rejectedToken {
+			err = errX509InvalidatedBearer
+		}
 		fallback := false
 		if err != nil && retryableX509ExchangeError(err) && identity.cached.value != "" &&
 			time.Now().Before(identity.cached.expiresAt) {
@@ -133,6 +139,7 @@ func (identity *X509WorkloadIdentityAuth) GetToken(ctx context.Context, doer HTT
 				err = errors.New("X.509 token exchange returned an already expired token")
 			} else {
 				identity.cached = token
+				identity.rejectedToken = ""
 				buffer := identity.config.RefreshBuffer
 				if buffer == 0 {
 					buffer = x509DefaultRefreshBuffer
@@ -165,12 +172,22 @@ func (identity *X509WorkloadIdentityAuth) exchangeWithRetry(
 	wake := refresh.wake
 	for attempt := 0; ; attempt++ {
 		token, err := x509Exchange(ctx, transport, identity.config.IdentityProviderID, identity.config.ServiceAccountID)
+		if err == nil {
+			identity.mu.Lock()
+			if token.value == identity.rejectedToken {
+				err = errX509InvalidatedBearer
+			}
+			identity.mu.Unlock()
+		}
 		if err == nil || !retryableX509ExchangeError(err) || attempt+1 >= x509MaximumAttempts {
 			return token, err
 		}
 		scope := requestconfig.RequestRetryScopeFromContext(ctx)
 		if scope != nil && !scope.TryRetry() {
 			return token, err
+		}
+		if errors.Is(err, errX509InvalidatedBearer) {
+			continue
 		}
 		timer := time.NewTimer(x509ExchangeRetryDelay(err, attempt, scope))
 		select {
@@ -206,6 +223,9 @@ func x509ExchangeRetryDelay(err error, attempt int, scope *requestconfig.Request
 }
 
 func retryableX509ExchangeError(err error) bool {
+	if errors.Is(err, errX509InvalidatedBearer) {
+		return true
+	}
 	var oauth *OAuthError
 	if errors.As(err, &oauth) {
 		return oauth.ErrorCode == "temporarily_unavailable" || oauth.ErrorCode == "server_error"
@@ -229,6 +249,7 @@ func (identity *X509WorkloadIdentityAuth) invalidateToken(value string) {
 		identity.cached = x509ExchangedToken{}
 		identity.refreshAfter = time.Time{}
 		if current := identity.inFlight; current != nil && current.generation == value {
+			identity.rejectedToken = value
 			close(current.wake)
 		}
 	}

--- a/auth/x509workloadidentity_test.go
+++ b/auth/x509workloadidentity_test.go
@@ -5,10 +5,13 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/openai/openai-go/v3/internal/requestconfig"
 )
 
 func TestNewX509WorkloadIdentityAuthValidatesConfiguration(t *testing.T) {
@@ -94,5 +97,176 @@ func TestX509WorkloadIdentityAuthExchangesOnlyOnItsAttestedTransport(t *testing.
 	}
 	if got := exchanges.Load(); got != 1 {
 		t.Errorf("rejected transports/cancellation caused unexpected exchanges: %d", got)
+	}
+}
+
+func TestX509WorkloadIdentityNeverRepublishesBearerInvalidatedDuringRefresh(t *testing.T) {
+	const replacement = "synthetic-replacement-bearer"
+	var exchanges atomic.Int32
+	refreshStarted := make(chan struct{})
+	releaseRefresh := make(chan struct{})
+	fixture := newX509ExchangeFixture(t, http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		switch exchanges.Add(1) {
+		case 1:
+			_, _ = io.WriteString(w, x509ValidExchangeResponse())
+		case 2:
+			close(refreshStarted)
+			select {
+			case <-releaseRefresh:
+				_, _ = io.WriteString(w, x509ValidExchangeResponse())
+			case <-request.Context().Done():
+			}
+		default:
+			_, _ = io.WriteString(w, strings.Replace(x509ValidExchangeResponse(),
+				x509ExchangeSyntheticToken, replacement, 1))
+		}
+	}))
+	identity := newX509LifecycleIdentity(t, fixture)
+	rejected, err := identity.GetToken(t.Context(), fixture.capability)
+	if err != nil || rejected != x509ExchangeSyntheticToken {
+		t.Fatalf("prime proactively refreshed bearer = %q, error = %v", rejected, err)
+	}
+	identity.mu.Lock()
+	identity.refreshAfter = time.Now().Add(-time.Second)
+	identity.mu.Unlock()
+
+	type result struct {
+		token string
+		err   error
+	}
+	results := make(chan result, 2)
+	refresh := func(ctx context.Context) {
+		token, tokenErr := identity.GetToken(ctx, fixture.capability)
+		results <- result{token: token, err: tokenErr}
+	}
+	go refresh(t.Context())
+	select {
+	case <-refreshStarted:
+	case <-t.Context().Done():
+		t.Fatal("proactive refresh never reached its synchronized issuer response")
+	}
+	follower := &x509ObservedDoneContext{Context: t.Context(), observed: make(chan struct{})}
+	go refresh(follower)
+	select {
+	case <-follower.observed:
+	case <-t.Context().Done():
+		t.Fatal("concurrent refresh follower never waited for the in-flight issuer response")
+	}
+	identity.invalidateToken(rejected)
+	identity.mu.Lock()
+	if identity.cached.value != "" || identity.inFlight == nil || identity.inFlight.generation != rejected {
+		identity.mu.Unlock()
+		t.Fatal("rejected bearer was not invalidated while its proactive refresh remained in flight")
+	}
+	identity.mu.Unlock()
+	close(releaseRefresh)
+
+	for range 2 {
+		select {
+		case got := <-results:
+			if got.token != replacement || got.err != nil {
+				t.Errorf("invalidated proactive refresh did not acquire a distinct bearer: token=%q error=%v",
+					got.token, got.err)
+			}
+		case <-t.Context().Done():
+			t.Fatal("invalidated proactive refresh did not release its concurrent callers")
+		}
+	}
+	identity.mu.Lock()
+	if identity.cached.value != replacement || identity.rejectedToken != "" || identity.inFlight != nil {
+		t.Error("distinct replacement bearer was not safely published and cleared its rejected generation")
+	}
+	identity.mu.Unlock()
+	if got := exchanges.Load(); got != 3 {
+		t.Errorf("prime/invalidated/distinct replacement exchanges = %d, want three", got)
+	}
+	for range 2 {
+		token, tokenErr := identity.GetToken(t.Context(), fixture.capability)
+		if tokenErr != nil || token != replacement {
+			t.Errorf("fresh post-invalidation bearer = %q, error = %v", token, tokenErr)
+		}
+	}
+	if got := exchanges.Load(); got != 3 {
+		t.Errorf("fresh post-invalidation bearer required %d exchanges, want three", got)
+	}
+}
+
+func TestX509WorkloadIdentityBoundsRepeatedInvalidatedBearerResponses(t *testing.T) {
+	for _, maximum := range []int{-1, 0, 1} {
+		name := "unscoped"
+		if maximum >= 0 {
+			name = "scoped retries " + strconv.Itoa(maximum)
+		}
+		t.Run(name, func(t *testing.T) {
+			var exchanges atomic.Int32
+			refreshStarted := make(chan struct{})
+			releaseRefresh := make(chan struct{})
+			fixture := newX509ExchangeFixture(t, http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+				if exchanges.Add(1) == 2 {
+					close(refreshStarted)
+					select {
+					case <-releaseRefresh:
+					case <-request.Context().Done():
+						return
+					}
+				}
+				_, _ = io.WriteString(w, x509ValidExchangeResponse())
+			}))
+			identity := newX509LifecycleIdentity(t, fixture)
+			rejected, err := identity.GetToken(t.Context(), fixture.capability)
+			if err != nil {
+				t.Fatalf("prime repeatedly invalidated workload bearer: %v", err)
+			}
+			identity.mu.Lock()
+			identity.refreshAfter = time.Now().Add(-time.Second)
+			identity.mu.Unlock()
+			ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+			defer cancel()
+			if maximum >= 0 {
+				scope := requestconfig.NewRequestRetryScope(maximum, time.Millisecond, true, nil)
+				if !scope.BeginAttempt() {
+					t.Fatal("begin invalidated workload request attempt")
+				}
+				ctx = requestconfig.WithRequestRetryScope(ctx, scope)
+			}
+			result := make(chan error, 1)
+			go func() {
+				token, exchangeErr := identity.GetToken(ctx, fixture.capability)
+				if token != "" {
+					result <- errors.New("repeated issuer response republished its rejected bearer")
+					return
+				}
+				result <- exchangeErr
+			}()
+			select {
+			case <-refreshStarted:
+			case <-ctx.Done():
+				t.Fatal("repeatedly invalidated refresh never reached its issuer")
+			}
+			identity.invalidateToken(rejected)
+			close(releaseRefresh)
+			select {
+			case exchangeErr := <-result:
+				if !errors.Is(exchangeErr, errX509InvalidatedBearer) ||
+					strings.Contains(exchangeErr.Error(), rejected) {
+					t.Errorf("repeated rejected bearer error = %v, want a safe bounded failure", exchangeErr)
+				}
+			case <-ctx.Done():
+				t.Fatal("repeated rejected bearer exhausted its context instead of bounded retry budget")
+			}
+			want := int32(1 + x509MaximumAttempts)
+			if maximum >= 0 {
+				want = int32(2 + maximum)
+			}
+			if got := exchanges.Load(); got != want {
+				t.Errorf("bounded repeated-bearer issuer exchanges = %d, want %d", got, want)
+			}
+			identity.mu.Lock()
+			if identity.cached.value != "" || identity.rejectedToken != rejected ||
+				!identity.refreshAfter.IsZero() || identity.inFlight != nil {
+				t.Error("repeatedly rejected bearer was republished or lost its invalidation record")
+			}
+			identity.mu.Unlock()
+		})
 	}
 }

--- a/internal/requestconfig/nobody_retry_test.go
+++ b/internal/requestconfig/nobody_retry_test.go
@@ -49,3 +49,29 @@ func TestExecuteDoesNotRecreateHTTPNoBodyFromStaleFactory(t *testing.T) {
 		t.Errorf("empty request attempts = %d, want two", attempts)
 	}
 }
+
+func TestClonePreservesHTTPNoBodyWithoutCallingItsFactory(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		staleFactory bool
+	}{
+		{name: "nil factory"},
+		{name: "stale factory", staleFactory: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := newBodyCloseRequestConfig(t, http.NoBody)
+			cfg.Request.Body = http.NoBody
+			cfg.Request.GetBody = nil
+			if test.staleFactory {
+				cfg.Request.GetBody = func() (io.ReadCloser, error) {
+					t.Fatal("stale GetBody factory recreated a cloned empty request body")
+					return nil, nil
+				}
+			}
+			clone := cfg.Clone(t.Context())
+			if clone == nil || clone.Request.Body != http.NoBody {
+				t.Fatalf("cloned canonical empty body = %#v, want http.NoBody", clone)
+			}
+		})
+	}
+}

--- a/internal/requestconfig/nobody_retry_test.go
+++ b/internal/requestconfig/nobody_retry_test.go
@@ -1,0 +1,51 @@
+package requestconfig
+
+import (
+	"io"
+	"net/http"
+	"testing"
+)
+
+func TestShouldRetryTreatsHTTPNoBodyAsReplayable(t *testing.T) {
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "https://example.test/v1/models", nil)
+	if err != nil {
+		t.Fatalf("construct empty request: %v", err)
+	}
+	request.Body = http.NoBody
+	response := &http.Response{StatusCode: http.StatusInternalServerError, Header: make(http.Header)}
+	if !shouldRetry(request, response, nil) {
+		t.Error("http.NoBody was incorrectly classified as a non-replayable request payload")
+	}
+}
+
+func TestExecuteDoesNotRecreateHTTPNoBodyFromStaleFactory(t *testing.T) {
+	cfg := newBodyCloseRequestConfig(t, http.NoBody)
+	cfg.MaxRetries = 1
+	cfg.Request.GetBody = func() (io.ReadCloser, error) {
+		t.Fatal("stale GetBody factory recreated a request explicitly configured without a body")
+		return nil, nil
+	}
+	attempts := 0
+	cfg.Middlewares = []middleware{func(request *http.Request, _ middlewareNext) (*http.Response, error) {
+		if request.Body != http.NoBody {
+			t.Errorf("empty request attempt did not retain its canonical http.NoBody sentinel: %T", request.Body)
+		}
+		attempts++
+		status := http.StatusNoContent
+		if attempts == 1 {
+			status = http.StatusInternalServerError
+		}
+		return &http.Response{
+			StatusCode: status,
+			Header:     http.Header{"Retry-After-Ms": {"0"}},
+			Body:       http.NoBody,
+			Request:    request,
+		}, nil
+	}}
+	if err := cfg.Execute(); err != nil {
+		t.Fatalf("retry configured empty request: %v", err)
+	}
+	if attempts != 2 {
+		t.Errorf("empty request attempts = %d, want two", attempts)
+	}
+}

--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -802,7 +802,7 @@ func (cfg *RequestConfig) Clone(ctx context.Context) *RequestConfig {
 	}
 	req := cfg.Request.Clone(ctx)
 	var err error
-	if req.Body != nil {
+	if req.Body != nil && req.Body != http.NoBody {
 		req.Body, err = req.GetBody()
 	}
 	if err != nil {

--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -383,7 +383,7 @@ func applyMiddleware(middleware middleware, next middlewareNext) middlewareNext 
 
 func shouldRetry(req *http.Request, res *http.Response, err error) bool {
 	// If there is no way to recover the Body, then we shouldn't retry.
-	if req.Body != nil && req.GetBody == nil {
+	if !requestBodyReplayable(req) {
 		return false
 	}
 
@@ -411,6 +411,10 @@ func shouldRetry(req *http.Request, res *http.Response, err error) bool {
 		res.StatusCode == http.StatusConflict ||
 		res.StatusCode == http.StatusTooManyRequests ||
 		res.StatusCode >= http.StatusInternalServerError
+}
+
+func requestBodyReplayable(request *http.Request) bool {
+	return request.Body == nil || request.Body == http.NoBody || request.GetBody != nil
 }
 
 func parseRetryAfterHeader(resp *http.Response, maxDelay time.Duration) (time.Duration, bool) {
@@ -649,7 +653,7 @@ func (cfg *RequestConfig) Execute() (err error) {
 		}
 
 		req := cfg.Request.Clone(ctx)
-		if req.Body != nil {
+		if req.Body != nil && req.Body != http.NoBody {
 			req.Body = &closeOnceReadCloser{ReadCloser: req.Body}
 		}
 		if shouldSendRetryCount {
@@ -674,7 +678,7 @@ func (cfg *RequestConfig) Execute() (err error) {
 		}
 
 		// Prepare next request and wait for the retry delay
-		if cfg.Request.GetBody != nil {
+		if cfg.Request.Body != nil && cfg.Request.Body != http.NoBody && cfg.Request.GetBody != nil {
 			cfg.Request.Body, err = cfg.Request.GetBody()
 			if err != nil {
 				return err
@@ -682,7 +686,7 @@ func (cfg *RequestConfig) Execute() (err error) {
 		}
 
 		// Can't actually refresh the body, so we don't attempt to retry here
-		if cfg.Request.GetBody == nil && cfg.Request.Body != nil {
+		if !requestBodyReplayable(cfg.Request) {
 			break
 		}
 

--- a/option/requestoption.go
+++ b/option/requestoption.go
@@ -350,27 +350,35 @@ func WithWorkloadIdentity(config auth.WorkloadIdentity) RequestOption {
 		}
 		r.SetAPIKey("")
 
-		r.Middlewares = append(r.Middlewares, func(req *http.Request, next func(*http.Request) (*http.Response, error)) (*http.Response, error) {
-			if !workloadIdentityAuth.Selected(r) {
-				return next(req)
+		middlewareIndex := len(r.Middlewares)
+		return requestconfig.WithRequestFinalizer(func(final *requestconfig.RequestConfig) error {
+			if !workloadIdentityAuth.Selected(final) {
+				return nil
 			}
-			initOnce.Do(func() {
-				wia, initErr = auth.NewWorkloadIdentityAuth(config)
-			})
+			final.Middlewares = append(final.Middlewares, nil)
+			copy(final.Middlewares[middlewareIndex+1:], final.Middlewares[middlewareIndex:])
+			final.Middlewares[middlewareIndex] = func(req *http.Request, next func(*http.Request) (*http.Response, error)) (*http.Response, error) {
+				if !workloadIdentityAuth.Selected(final) {
+					return next(req)
+				}
+				initOnce.Do(func() {
+					wia, initErr = auth.NewWorkloadIdentityAuth(config)
+				})
 
-			if initErr != nil {
-				return nil, initErr
+				if initErr != nil {
+					return nil, initErr
+				}
+
+				var httpDoer auth.HTTPDoer
+				if final.CustomHTTPDoer != nil {
+					httpDoer = final.CustomHTTPDoer
+				} else {
+					httpDoer = final.HTTPClient
+				}
+
+				return auth.WorkloadIdentityMiddleware(wia, httpDoer, req, next)
 			}
-
-			var httpDoer auth.HTTPDoer
-			if r.CustomHTTPDoer != nil {
-				httpDoer = r.CustomHTTPDoer
-			} else {
-				httpDoer = r.HTTPClient
-			}
-
-			return auth.WorkloadIdentityMiddleware(wia, httpDoer, req, next)
-		})
-		return nil
+			return nil
+		}).Apply(r)
 	})
 }

--- a/x509_workload_identity_nobody_pagination_test.go
+++ b/x509_workload_identity_nobody_pagination_test.go
@@ -1,0 +1,45 @@
+package openai_test
+
+import (
+	"io"
+	"net/http"
+	"sync/atomic"
+	"testing"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+)
+
+func TestX509WorkloadIdentityAutoPaginationPreservesHTTPNoBody(t *testing.T) {
+	t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+	config, issuer, api := newX509WorkloadIdentityIntegration(t)
+	var requests atomic.Int32
+	api.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		if request.ContentLength != 0 {
+			t.Errorf("empty paginated request content length = %d, want zero", request.ContentLength)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if requests.Add(1) == 1 {
+			_, _ = io.WriteString(w, `{"data":[{"id":"synthetic-first"}],"has_more":true}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"data":[{"id":"synthetic-second"}],"has_more":false}`)
+	})
+	client := openai.NewClient(option.WithX509WorkloadIdentity(config), option.WithMaxRetries(0))
+	pages := client.Batches.ListAutoPaging(
+		t.Context(),
+		openai.BatchListParams{},
+		option.WithRequestBody("application/json", http.NoBody),
+	)
+	var items int
+	for pages.Next() {
+		items++
+	}
+	if err := pages.Err(); err != nil || items != 2 {
+		t.Fatalf("empty-body auto-pagination returned items=%d, error=%v", items, err)
+	}
+	if requests.Load() != 2 || len(issuer.requests()) != 1 {
+		t.Errorf("empty-body auto-pagination API/issuer calls = %d/%d, want 2/1",
+			requests.Load(), len(issuer.requests()))
+	}
+}

--- a/x509_workload_identity_nobody_test.go
+++ b/x509_workload_identity_nobody_test.go
@@ -1,0 +1,59 @@
+package openai_test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"sync/atomic"
+	"testing"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+)
+
+func TestX509WorkloadIdentityReplaysConfiguredHTTPNoBody(t *testing.T) {
+	t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+	config, issuer, api := newX509WorkloadIdentityIntegration(t)
+	var attempts, observations, exchanges atomic.Int32
+	issuer.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, x509IntegrationTokenResponse(
+			fmt.Sprintf("synthetic-configured-empty-%d", exchanges.Add(1)),
+		))
+	})
+	api.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		if request.ContentLength != 0 {
+			t.Errorf("configured empty request content length = %d, want zero", request.ContentLength)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		attempt := attempts.Add(1)
+		if got := request.Header.Get("Authorization"); got != fmt.Sprintf("Bearer synthetic-configured-empty-%d", attempt) {
+			t.Errorf("configured empty request attempt %d authorization = %q", attempt, got)
+		}
+		if attempt == 1 {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = io.WriteString(w, `{"error":{"message":"synthetic rejected bearer"}}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"data":[]}`)
+	})
+	client := openai.NewClient(
+		option.WithX509WorkloadIdentity(config),
+		option.WithMaxRetries(1),
+		option.WithMiddleware(func(request *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+			if request.Body != http.NoBody {
+				t.Errorf("configured empty request lost the canonical http.NoBody sentinel: %T", request.Body)
+			}
+			observations.Add(1)
+			return next(request)
+		}),
+	)
+	var result map[string]any
+	if err := client.Execute(t.Context(), http.MethodPost, "models", nil, &result,
+		option.WithRequestBody("application/json", http.NoBody)); err != nil {
+		t.Fatalf("configured http.NoBody request was not replayed after authentication failure: %v", err)
+	}
+	if attempts.Load() != 2 || observations.Load() != 2 || exchanges.Load() != 2 {
+		t.Errorf("configured empty request API/middleware/issuer attempts = %d/%d/%d, want 2/2/2",
+			attempts.Load(), observations.Load(), exchanges.Load())
+	}
+}

--- a/x509_workload_identity_provider_replay_test.go
+++ b/x509_workload_identity_provider_replay_test.go
@@ -1,0 +1,170 @@
+package openai_test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/auth"
+	"github.com/openai/openai-go/v3/option"
+)
+
+func TestX509WorkloadIdentityIgnoresInactiveProviderMiddlewareForBodyReplay(t *testing.T) {
+	for _, test := range []struct {
+		name             string
+		callerMiddleware bool
+		callerFirst      bool
+		repeatedProvider bool
+		wantAttempts     int32
+	}{
+		{name: "inactive inherited provider is safe to replay", wantAttempts: 2},
+		{name: "multiple inactive inherited providers are safe to replay", repeatedProvider: true, wantAttempts: 2},
+		{name: "caller middleware after inherited provider remains unsafe", callerMiddleware: true, wantAttempts: 1},
+		{name: "caller middleware before inherited provider remains unsafe", callerMiddleware: true, callerFirst: true, wantAttempts: 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+			config, issuer, api := newX509WorkloadIdentityIntegration(t)
+			var exchanges, requests atomic.Int32
+			var bodiesMu sync.Mutex
+			var bodies []string
+			issuer.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = io.WriteString(w, x509IntegrationTokenResponse(
+					fmt.Sprintf("synthetic-provider-replay-%d", exchanges.Add(1)),
+				))
+			})
+			api.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+				body, err := io.ReadAll(request.Body)
+				if err != nil {
+					t.Errorf("read mutually authenticated API request: %v", err)
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				bodiesMu.Lock()
+				bodies = append(bodies, string(body))
+				bodiesMu.Unlock()
+				w.Header().Set("Content-Type", "application/json")
+				if requests.Add(1) == 1 {
+					w.WriteHeader(http.StatusUnauthorized)
+					_, _ = io.WriteString(w, `{"error":{"message":"synthetic rejected bearer"}}`)
+					return
+				}
+				_, _ = io.WriteString(w, `{}`)
+			})
+
+			ordinary := option.WithWorkloadIdentity(auth.WorkloadIdentity{
+				IdentityProviderID: "synthetic-inactive-provider",
+				ServiceAccountID:   "synthetic-inactive-service-account",
+				Provider:           originTestSubjectTokenProvider{},
+			})
+			options := []option.RequestOption{ordinary, option.WithMaxRetries(1)}
+			if test.repeatedProvider {
+				options = append(options, ordinary)
+			}
+			if test.callerMiddleware {
+				caller := option.WithMiddleware(func(request *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+					if err := request.Body.Close(); err != nil {
+						return nil, err
+					}
+					const transformed = "synthetic-middleware-transformed-body"
+					request.Body = io.NopCloser(strings.NewReader(transformed))
+					request.ContentLength = int64(len(transformed))
+					return next(request)
+				})
+				if test.callerFirst {
+					options = append([]option.RequestOption{caller}, options...)
+				} else {
+					options = append(options, caller)
+				}
+			}
+			client := openai.NewClient(options...)
+			err := client.Execute(
+				t.Context(),
+				http.MethodPost,
+				"models",
+				map[string]string{"input": "synthetic-original-body"},
+				nil,
+				option.WithX509WorkloadIdentity(config),
+			)
+			if gotSuccess, wantSuccess := err == nil, test.wantAttempts == 2; gotSuccess != wantSuccess {
+				t.Errorf("inherited-provider unauthorized recovery error = %v, want success %v", err, wantSuccess)
+			}
+			if got := exchanges.Load(); got != test.wantAttempts {
+				t.Errorf("issuer exchanges = %d, want %d", got, test.wantAttempts)
+			}
+			if got := requests.Load(); got != test.wantAttempts {
+				t.Errorf("mutually authenticated API attempts = %d, want %d", got, test.wantAttempts)
+			}
+			bodiesMu.Lock()
+			defer bodiesMu.Unlock()
+			if len(bodies) != int(test.wantAttempts) {
+				t.Fatalf("captured API bodies = %d, want %d", len(bodies), test.wantAttempts)
+			}
+			if test.callerMiddleware {
+				if bodies[0] != "synthetic-middleware-transformed-body" {
+					t.Errorf("API request body = %q, want caller-transformed body", bodies[0])
+				}
+			} else if bodies[0] != bodies[1] || !strings.Contains(bodies[0], "synthetic-original-body") {
+				t.Errorf("replayed API bodies = %q, want identical serialized JSON", bodies)
+			}
+		})
+	}
+}
+
+func TestWorkloadIdentityPreservesCallerMiddlewareOrdering(t *testing.T) {
+	for _, test := range []struct {
+		name              string
+		callerFirst       bool
+		wantAuthorization string
+	}{
+		{name: "middleware before authentication remains unsigned", callerFirst: true},
+		{name: "middleware after authentication observes signed request", wantAuthorization: "Bearer synthetic-ordinary-token"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("OPENAI_API_KEY", "")
+			t.Setenv("OPENAI_BASE_URL", "https://api.openai.com/v1/")
+			var observedAuthorization string
+			caller := option.WithMiddleware(func(request *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+				observedAuthorization = request.Header.Get("Authorization")
+				return next(request)
+			})
+			ordinary := option.WithWorkloadIdentity(auth.WorkloadIdentity{
+				IdentityProviderID: "synthetic-ordinary-provider",
+				ServiceAccountID:   "synthetic-ordinary-service-account",
+				Provider:           originTestSubjectTokenProvider{},
+			})
+			options := []option.RequestOption{ordinary, caller}
+			if test.callerFirst {
+				options[0], options[1] = options[1], options[0]
+			}
+			options = append(options, option.WithHTTPClient(&http.Client{
+				Transport: &closureTransport{fn: func(request *http.Request) (*http.Response, error) {
+					body := `{}`
+					if strings.Contains(request.URL.Path, "/oauth/token") {
+						body = `{"access_token":"synthetic-ordinary-token","expires_in":3600}`
+					} else if got := request.Header.Get("Authorization"); got != "Bearer synthetic-ordinary-token" {
+						t.Errorf("ordinary authenticated API Authorization = %q, want signed bearer", got)
+					}
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader(body)),
+						Header:     http.Header{"Content-Type": []string{"application/json"}},
+					}, nil
+				}},
+			}))
+			client := openai.NewClient(options...)
+			if err := client.Execute(t.Context(), http.MethodGet, "models", nil, nil); err != nil {
+				t.Fatalf("ordinary authenticated public API request: %v", err)
+			}
+			if observedAuthorization != test.wantAuthorization {
+				t.Errorf("caller middleware observed Authorization = %q, want %q",
+					observedAuthorization, test.wantAuthorization)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Address three late Codex review findings from merged #858: preserve `http.NoBody` throughout generic retry and request cloning, prevent a concurrently invalidated X.509 bearer from being republished, and avoid counting inactive workload-identity middleware as caller middleware.
- Preserve existing normal-401 behavior, middleware ordering, request-scoped retry budgets, and response credential redaction; repeated rejected issuer tokens remain bounded and never populate the cache.
- Add deterministic race regressions, real mTLS public-client retry coverage, real two-page public auto-pagination coverage, and negative controls for body-mutating caller middleware.

## Why a follow-up

#858 merged while its newly posted Codex feedback was undergoing exhaustive review, so these small, patch-identical post-review fixes are delivered separately on top of merged main. During independent review, we also found and fixed a public auto-pagination panic caused by cloning `http.NoBody` with a nil `GetBody` factory.

## Verification

- `go test -race ./...`
- `./scripts/lint` (all six passes)
- `./scripts/check-go-mod` (all four modules)
- `go vet ./...`
- `go test ./...` in `examples`
- `go test -mod=readonly ./...` in `internal/testdata/consumer`
- Repeated focused concurrency, provider-ordering, replay, and pagination race tests.
- Two independent exhaustive reviews: no remaining findings.
- Completed Codex Security scan `990ee4cd-a05a-4ffa-a9ad-5582dba488c3`: complete 18/18-path coverage of the identical final tree, zero findings.
