### PR TITLE
fix: harden workload identity transport and request lifecycles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1248,7 +1248,10 @@ client := openai.NewClient(option.WithX509WorkloadIdentity(auth.X509WorkloadIden
 	Transport:          transport,
 }))
 
-if _, err := client.Models.List(context.Background()); err != nil {
+requestContext, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+defer cancel()
+
+if _, err := client.Models.List(requestContext); err != nil {
 	return err
 }
 ```
@@ -1257,6 +1260,15 @@ The application retains ownership of its certificate, private key, trust roots,
 and original transport. The attested capability creates its own isolated
 connection pool, so call `Close` when it is no longer needed. Rotating the
 certificate requires a newly attested transport and client.
+
+The capability always presents its one attested certificate, including when a
+server advertises unrelated acceptable certificate-authority hints. It does not
+accept caller-provided certificate-selection callbacks. When the transport
+template does not specify its own values, the isolated connection pool applies
+a 30-second TCP dial timeout, a 10-second TLS handshake timeout, and the SDK's
+10-minute response-header timeout. Set a request context deadline or use
+`option.WithRequestTimeout` to bound the complete operation; response bodies are
+not given a deadline so long-running streams remain supported.
 
 Token exchange is pinned to `https://mtls.auth.openai.com/oauth/token`; API
 requests use `https://mtls.api.openai.com/v1/`. Existing `OPENAI_BASE_URL` and

--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -1,7 +1,10 @@
 package auth
 
 import (
+	"errors"
 	"net/http"
+
+	"github.com/openai/openai-go/v3/internal/requestconfig"
 )
 
 func WorkloadIdentityMiddleware(
@@ -10,6 +13,10 @@ func WorkloadIdentityMiddleware(
 	req *http.Request,
 	next func(*http.Request) (*http.Response, error),
 ) (*http.Response, error) {
+	if req == nil || req.Header == nil || next == nil {
+		return nil, errors.New("workload identity requires a non-nil request, header map, and handler")
+	}
+	hadBody := req.Body != nil && req.Body != http.NoBody
 	token, err := wia.GetToken(req.Context(), httpClient)
 	if err != nil {
 		return nil, err
@@ -22,9 +29,21 @@ func WorkloadIdentityMiddleware(
 		return resp, err
 	}
 
-	wia.invalidateToken()
+	wia.invalidateToken(token)
 
-	if req.Body != nil && req.GetBody == nil {
+	if scope := requestconfig.RequestRetryScopeFromContext(req.Context()); scope != nil {
+		replayable := !hadBody || (req.GetBody != nil && scope.AllowBodyReplay())
+		if replayable && scope.TryOuterReplay() {
+			return unauthorizedRetryResponse(resp, true), nil
+		}
+		if resp.Header.Get("x-should-retry") == "true" {
+			return unauthorizedRetryResponse(resp, false), nil
+		}
+		return resp, nil
+	}
+	// Direct callers have no original SDK request from which to safely rebuild
+	// a body after caller middleware may have transformed or removed it.
+	if hadBody {
 		return resp, nil
 	}
 
@@ -32,19 +51,15 @@ func WorkloadIdentityMiddleware(
 
 	token, err = wia.GetToken(req.Context(), httpClient)
 	if err != nil {
-		_ = resp.Body.Close()
+		if resp.Body != nil {
+			_ = resp.Body.Close()
+		}
 		return nil, err
 	}
 	retryReq.Header.Set("Authorization", "Bearer "+token)
 
-	if req.GetBody != nil {
-		retryReq.Body, err = req.GetBody()
-		if err != nil {
-			_ = resp.Body.Close()
-			return nil, err
-		}
+	if resp.Body != nil {
+		_ = resp.Body.Close()
 	}
-
-	_ = resp.Body.Close()
 	return next(retryReq)
 }

--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/openai/openai-go/v3/internal/requestconfig"
 )
@@ -23,7 +24,7 @@ func WorkloadIdentityMiddleware(
 	}
 
 	authenticated := req.Clone(req.Context())
-	authenticated.Header.Set("Authorization", "Bearer "+token)
+	setWorkloadIdentityAuthorization(authenticated, token)
 
 	resp, err := next(authenticated)
 	resp = x509UnsignedResponse(resp)
@@ -58,7 +59,7 @@ func WorkloadIdentityMiddleware(
 		}
 		return nil, err
 	}
-	retryReq.Header.Set("Authorization", "Bearer "+token)
+	setWorkloadIdentityAuthorization(retryReq, token)
 
 	if resp.Body != nil {
 		_ = resp.Body.Close()
@@ -68,4 +69,13 @@ func WorkloadIdentityMiddleware(
 		wia.invalidateToken(token)
 	}
 	return x509UnsignedResponse(resp), err
+}
+
+func setWorkloadIdentityAuthorization(request *http.Request, token string) {
+	for name := range request.Header {
+		if strings.EqualFold(strings.ReplaceAll(name, "_", "-"), "authorization") {
+			delete(request.Header, name)
+		}
+	}
+	request.Header.Set("Authorization", "Bearer "+token)
 }

--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -22,9 +22,11 @@ func WorkloadIdentityMiddleware(
 		return nil, err
 	}
 
-	req.Header.Set("Authorization", "Bearer "+token)
+	authenticated := req.Clone(req.Context())
+	authenticated.Header.Set("Authorization", "Bearer "+token)
 
-	resp, err := next(req)
+	resp, err := next(authenticated)
+	resp = x509UnsignedResponse(resp)
 	if err != nil || resp == nil || resp.StatusCode != http.StatusUnauthorized {
 		return resp, err
 	}
@@ -61,5 +63,9 @@ func WorkloadIdentityMiddleware(
 	if resp.Body != nil {
 		_ = resp.Body.Close()
 	}
-	return next(retryReq)
+	resp, err = next(retryReq)
+	if err == nil && resp != nil && resp.StatusCode == http.StatusUnauthorized {
+		wia.invalidateToken(token)
+	}
+	return x509UnsignedResponse(resp), err
 }

--- a/auth/subjecttokenprovider.go
+++ b/auth/subjecttokenprovider.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -111,7 +112,7 @@ func (p *azureManagedIdentityTokenProvider) GetToken(ctx context.Context, httpCl
 	}
 	req.Header.Set("Metadata", "true")
 
-	resp, err := httpClient.Do(req)
+	resp, err := workloadIdentityDo(httpClient, req)
 	if err != nil {
 		return "", &SubjectTokenProviderError{
 			Provider: "azure-imds",
@@ -119,32 +120,18 @@ func (p *azureManagedIdentityTokenProvider) GetToken(ctx context.Context, httpCl
 			Cause:    err,
 		}
 	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		body, readErr := io.ReadAll(resp.Body)
-		msg := fmt.Sprintf("IMDS returned status %d", resp.StatusCode)
-
-		if readErr != nil {
-			msg = fmt.Sprintf("%s (failed to read body: %v)", msg, readErr)
-		} else if len(body) > 0 {
-			msg = fmt.Sprintf("%s: %s", msg, string(body))
-		}
-
-		return "", &SubjectTokenProviderError{
-			Provider: "azure-imds",
-			Message:  msg,
-		}
+	body, err := readSubjectTokenProviderResponse(ctx, resp, "azure-imds", "IMDS")
+	if err != nil {
+		return "", err
 	}
 
 	var result struct {
 		AccessToken string `json:"access_token"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	if err := json.NewDecoder(bytes.NewReader(body)).Decode(&result); err != nil {
 		return "", &SubjectTokenProviderError{
 			Provider: "azure-imds",
 			Message:  "failed to decode IMDS response",
-			Cause:    err,
 		}
 	}
 
@@ -201,7 +188,7 @@ func (p *gcpIDTokenProvider) GetToken(ctx context.Context, httpClient HTTPDoer) 
 	}
 	req.Header.Set("Metadata-Flavor", "Google")
 
-	resp, err := httpClient.Do(req)
+	resp, err := workloadIdentityDo(httpClient, req)
 	if err != nil {
 		return "", &SubjectTokenProviderError{
 			Provider: "gcp-metadata",
@@ -209,23 +196,9 @@ func (p *gcpIDTokenProvider) GetToken(ctx context.Context, httpClient HTTPDoer) 
 			Cause:    err,
 		}
 	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return "", &SubjectTokenProviderError{
-			Provider: "gcp-metadata",
-			Message:  fmt.Sprintf("metadata server returned status %d: %s", resp.StatusCode, string(body)),
-		}
-	}
-
-	token, err := io.ReadAll(resp.Body)
+	token, err := readSubjectTokenProviderResponse(ctx, resp, "gcp-metadata", "metadata server")
 	if err != nil {
-		return "", &SubjectTokenProviderError{
-			Provider: "gcp-metadata",
-			Message:  "failed to read response body",
-			Cause:    err,
-		}
+		return "", err
 	}
 
 	tokenStr := strings.TrimSpace(string(token))
@@ -237,4 +210,50 @@ func (p *gcpIDTokenProvider) GetToken(ctx context.Context, httpClient HTTPDoer) 
 	}
 
 	return tokenStr, nil
+}
+
+func readSubjectTokenProviderResponse(
+	ctx context.Context,
+	response *http.Response,
+	provider, source string,
+) ([]byte, error) {
+	if response == nil || response.Body == nil {
+		return nil, &SubjectTokenProviderError{
+			Provider: provider,
+			Message:  fmt.Sprintf("%s returned an invalid response", source),
+		}
+	}
+	defer func() { _ = response.Body.Close() }()
+
+	maximum := int64(x509SuccessResponseMaximum)
+	if response.StatusCode != http.StatusOK {
+		maximum = x509ErrorResponseMaximum
+	}
+	if response.ContentLength > maximum {
+		return nil, &SubjectTokenProviderError{
+			Provider: provider,
+			Message:  fmt.Sprintf("%s response exceeds its size limit", source),
+		}
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, maximum+1))
+	if err != nil {
+		return nil, &SubjectTokenProviderError{
+			Provider: provider,
+			Message:  fmt.Sprintf("failed to read %s response", source),
+			Cause:    ctx.Err(),
+		}
+	}
+	if int64(len(body)) > maximum {
+		return nil, &SubjectTokenProviderError{
+			Provider: provider,
+			Message:  fmt.Sprintf("%s response exceeds its size limit", source),
+		}
+	}
+	if response.StatusCode != http.StatusOK {
+		return nil, &SubjectTokenProviderError{
+			Provider: provider,
+			Message:  fmt.Sprintf("%s returned status %d", source, response.StatusCode),
+		}
+	}
+	return body, nil
 }

--- a/auth/subjecttokenprovider.go
+++ b/auth/subjecttokenprovider.go
@@ -120,6 +120,13 @@ func (p *azureManagedIdentityTokenProvider) GetToken(ctx context.Context, httpCl
 			Cause:    err,
 		}
 	}
+	if resp == nil || resp.Body == nil {
+		return "", &SubjectTokenProviderError{
+			Provider: "azure-imds",
+			Message:  "IMDS returned an invalid response",
+		}
+	}
+	defer func() { _ = resp.Body.Close() }()
 	body, err := readSubjectTokenProviderResponse(ctx, resp, "azure-imds", "IMDS")
 	if err != nil {
 		return "", err
@@ -196,6 +203,13 @@ func (p *gcpIDTokenProvider) GetToken(ctx context.Context, httpClient HTTPDoer) 
 			Cause:    err,
 		}
 	}
+	if resp == nil || resp.Body == nil {
+		return "", &SubjectTokenProviderError{
+			Provider: "gcp-metadata",
+			Message:  "metadata server returned an invalid response",
+		}
+	}
+	defer func() { _ = resp.Body.Close() }()
 	token, err := readSubjectTokenProviderResponse(ctx, resp, "gcp-metadata", "metadata server")
 	if err != nil {
 		return "", err
@@ -217,14 +231,6 @@ func readSubjectTokenProviderResponse(
 	response *http.Response,
 	provider, source string,
 ) ([]byte, error) {
-	if response == nil || response.Body == nil {
-		return nil, &SubjectTokenProviderError{
-			Provider: provider,
-			Message:  fmt.Sprintf("%s returned an invalid response", source),
-		}
-	}
-	defer func() { _ = response.Body.Close() }()
-
 	maximum := int64(x509SuccessResponseMaximum)
 	if response.StatusCode != http.StatusOK {
 		maximum = x509ErrorResponseMaximum

--- a/auth/subjecttokenprovider_hardening_test.go
+++ b/auth/subjecttokenprovider_hardening_test.go
@@ -1,0 +1,238 @@
+package auth_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/openai/openai-go/v3/auth"
+)
+
+func TestCloudSubjectTokenProvidersBoundAndRedactMetadataResponses(t *testing.T) {
+	const sensitive = "synthetic-private-metadata-access-token"
+	for _, provider := range []struct {
+		name     string
+		identity string
+		new      func() auth.SubjectTokenProvider
+	}{
+		{name: "Azure", identity: "azure-imds", new: func() auth.SubjectTokenProvider {
+			return auth.AzureManagedIdentityTokenProvider(nil)
+		}},
+		{name: "GCP", identity: "gcp-metadata", new: func() auth.SubjectTokenProvider {
+			return auth.GCPIDTokenProvider(nil)
+		}},
+	} {
+		t.Run(provider.name, func(t *testing.T) {
+			for _, test := range []struct {
+				name          string
+				status        int
+				body          string
+				contentLength int64
+				readError     error
+				canceled      bool
+				want          string
+				wantReads     bool
+			}{
+				{name: "private unsuccessful response", status: http.StatusUnauthorized,
+					body: `{"access_token":"` + sensitive + `"}`, contentLength: -1,
+					want: "status 401", wantReads: true},
+				{name: "declared oversized unsuccessful response", status: http.StatusForbidden,
+					contentLength: (4 << 10) + 1, want: "size limit"},
+				{name: "streamed oversized unsuccessful response", status: http.StatusInternalServerError,
+					body: strings.Repeat("a", (4<<10)+1), contentLength: -1,
+					want: "size limit", wantReads: true},
+				{name: "declared oversized successful response", status: http.StatusOK,
+					contentLength: (1 << 20) + 1, want: "size limit"},
+				{name: "streamed oversized successful response", status: http.StatusOK,
+					body: strings.Repeat("a", (1<<20)+1), contentLength: -1,
+					want: "size limit", wantReads: true},
+				{name: "sensitive successful response read failure", status: http.StatusOK,
+					contentLength: -1, readError: errors.New(sensitive),
+					want: "failed to read", wantReads: true},
+				{name: "sensitive unsuccessful response read failure", status: http.StatusForbidden,
+					contentLength: -1, readError: errors.New(sensitive),
+					want: "failed to read", wantReads: true},
+				{name: "canceled metadata response read", status: http.StatusOK,
+					contentLength: -1, readError: errors.New(sensitive), canceled: true,
+					want: "failed to read", wantReads: true},
+			} {
+				t.Run(test.name, func(t *testing.T) {
+					ctx, cancel := context.WithCancel(t.Context())
+					defer cancel()
+					body := &observedMetadataBody{
+						Reader: strings.NewReader(test.body),
+						err:    test.readError,
+					}
+					if test.canceled {
+						body.cancel = cancel
+					}
+					doer := ordinaryOpaqueHTTPDoer(func(*http.Request) (*http.Response, error) {
+						return &http.Response{
+							StatusCode:    test.status,
+							Header:        make(http.Header),
+							Body:          body,
+							ContentLength: test.contentLength,
+						}, nil
+					})
+
+					token, err := provider.new().GetToken(ctx, doer)
+					var typed *auth.SubjectTokenProviderError
+					if token != "" || !errors.As(err, &typed) || typed.Provider != provider.identity ||
+						!strings.Contains(err.Error(), test.want) {
+						t.Fatalf("metadata token=%q error=%v, want provider %q and %q",
+							token, err, provider.identity, test.want)
+					}
+					if strings.Contains(err.Error(), sensitive) {
+						t.Errorf("metadata provider error disclosed its private response: %q", err.Error())
+					}
+					if got := body.reads.Load() != 0; got != test.wantReads {
+						t.Errorf("metadata response was read=%t, want %t", got, test.wantReads)
+					}
+					if got := body.closes.Load(); got != 1 {
+						t.Errorf("metadata response body closes=%d, want exactly one", got)
+					}
+					if got := errors.Is(err, context.Canceled); got != test.canceled {
+						t.Errorf("metadata response preserved caller cancellation=%t, want %t", got, test.canceled)
+					}
+				})
+			}
+
+			t.Run("missing metadata response body", func(t *testing.T) {
+				doer := ordinaryOpaqueHTTPDoer(func(*http.Request) (*http.Response, error) {
+					return &http.Response{StatusCode: http.StatusOK}, nil
+				})
+				token, err := provider.new().GetToken(t.Context(), doer)
+				var typed *auth.SubjectTokenProviderError
+				if token != "" || !errors.As(err, &typed) || typed.Provider != provider.identity ||
+					!strings.Contains(err.Error(), "invalid response") {
+					t.Errorf("missing metadata response body token=%q error=%v", token, err)
+				}
+			})
+		})
+	}
+}
+
+func TestAzureSubjectTokenProviderSanitizesInvalidMetadataJSON(t *testing.T) {
+	const sensitive = "synthetic-private-malformed-access-token"
+	doer := ordinaryOpaqueHTTPDoer(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(fmt.Sprintf(`{"access_token":%q,`, sensitive))),
+		}, nil
+	})
+	token, err := auth.AzureManagedIdentityTokenProvider(nil).GetToken(t.Context(), doer)
+	var typed *auth.SubjectTokenProviderError
+	if token != "" || !errors.As(err, &typed) || typed.Provider != "azure-imds" ||
+		!strings.Contains(err.Error(), "failed to decode") {
+		t.Fatalf("malformed Azure metadata token=%q error=%v", token, err)
+	}
+	if strings.Contains(err.Error(), sensitive) || typed.Cause != nil {
+		t.Errorf("malformed Azure metadata leaked private decoder details: %v", err)
+	}
+}
+
+func TestCloudSubjectTokenProvidersNeverFollowMetadataRedirects(t *testing.T) {
+	for _, provider := range []struct {
+		name        string
+		identity    string
+		metadataKey string
+		metadataVal string
+		new         func() auth.SubjectTokenProvider
+	}{
+		{name: "Azure", identity: "azure-imds", metadataKey: "Metadata", metadataVal: "true",
+			new: func() auth.SubjectTokenProvider { return auth.AzureManagedIdentityTokenProvider(nil) }},
+		{name: "GCP", identity: "gcp-metadata", metadataKey: "Metadata-Flavor", metadataVal: "Google",
+			new: func() auth.SubjectTokenProvider { return auth.GCPIDTokenProvider(nil) }},
+	} {
+		t.Run(provider.name, func(t *testing.T) {
+			for _, status := range []int{
+				http.StatusMovedPermanently,
+				http.StatusFound,
+				http.StatusSeeOther,
+				http.StatusTemporaryRedirect,
+				http.StatusPermanentRedirect,
+			} {
+				t.Run(fmt.Sprintf("HTTP %d", status), func(t *testing.T) {
+					var metadataRequests, redirectedRequests, callerRedirectChecks atomic.Int32
+					target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+						redirectedRequests.Add(1)
+						_, _ = io.WriteString(w, "synthetic-attacker-controlled-subject")
+					}))
+					t.Cleanup(target.Close)
+					metadata := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+						metadataRequests.Add(1)
+						if got := request.Header.Get(provider.metadataKey); got != provider.metadataVal {
+							t.Errorf("metadata proof header %q=%q, want %q", provider.metadataKey, got, provider.metadataVal)
+						}
+						w.Header().Set("Location", target.URL+"/steal?credential=synthetic-private-metadata-location")
+						w.WriteHeader(status)
+					}))
+					t.Cleanup(metadata.Close)
+					caller := &http.Client{
+						Transport: &closureTransport{fn: func(request *http.Request) (*http.Response, error) {
+							if request.URL.Host == "169.254.169.254" || request.URL.Host == "metadata.google.internal" {
+								request = request.Clone(request.Context())
+								request.URL.Scheme = "http"
+								request.URL.Host = metadata.Listener.Addr().String()
+							}
+							return http.DefaultTransport.RoundTrip(request)
+						}},
+						CheckRedirect: func(*http.Request, []*http.Request) error {
+							callerRedirectChecks.Add(1)
+							return nil
+						},
+					}
+
+					token, err := provider.new().GetToken(t.Context(), caller)
+					var typed *auth.SubjectTokenProviderError
+					if token != "" || !errors.As(err, &typed) || typed.Provider != provider.identity ||
+						!strings.Contains(err.Error(), "does not follow redirects") {
+						t.Fatalf("redirected metadata token=%q error=%v", token, err)
+					}
+					if strings.Contains(err.Error(), "synthetic-private") || strings.Contains(err.Error(), target.URL) {
+						t.Errorf("metadata redirect error leaked its destination: %q", err.Error())
+					}
+					if metadataRequests.Load() != 1 || redirectedRequests.Load() != 0 ||
+						callerRedirectChecks.Load() != 0 {
+						t.Errorf("metadata/redirect/caller-policy requests=%d/%d/%d, want 1/0/0",
+							metadataRequests.Load(), redirectedRequests.Load(), callerRedirectChecks.Load())
+					}
+					if caller.CheckRedirect == nil {
+						t.Error("metadata provider mutated its caller-owned native HTTP client")
+					}
+				})
+			}
+		})
+	}
+}
+
+type observedMetadataBody struct {
+	io.Reader
+	err    error
+	cancel context.CancelFunc
+	reads  atomic.Int32
+	closes atomic.Int32
+}
+
+func (body *observedMetadataBody) Read(buffer []byte) (int, error) {
+	body.reads.Add(1)
+	if body.cancel != nil {
+		body.cancel()
+	}
+	if body.err != nil {
+		return 0, body.err
+	}
+	return body.Reader.Read(buffer)
+}
+
+func (body *observedMetadataBody) Close() error {
+	body.closes.Add(1)
+	return nil
+}

--- a/auth/workloadidentity.go
+++ b/auth/workloadidentity.go
@@ -4,23 +4,28 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"sync"
 	"time"
 
+	"github.com/openai/openai-go/v3/internal/requestconfig"
 	"github.com/openai/openai-go/v3/shared"
 )
 
 const (
-	TokenExchangeGrantType = "urn:ietf:params:oauth:grant-type:token-exchange"
-	JWTTokenType           = "urn:ietf:params:oauth:token-type:jwt"
-	IDTokenType            = "urn:ietf:params:oauth:token-type:id_token"
-	DefaultTokenExpiry     = 60 * time.Minute
-	DefaultRefreshBuffer   = 20 * time.Minute
-	TokenExchangeURL       = "https://auth.openai.com/oauth/token"
+	TokenExchangeGrantType         = "urn:ietf:params:oauth:grant-type:token-exchange"
+	JWTTokenType                   = "urn:ietf:params:oauth:token-type:jwt"
+	IDTokenType                    = "urn:ietf:params:oauth:token-type:id_token"
+	DefaultTokenExpiry             = 60 * time.Minute
+	DefaultRefreshBuffer           = 20 * time.Minute
+	TokenExchangeURL               = "https://auth.openai.com/oauth/token"
+	workloadMaximumRefreshAttempts = 3
 )
+
+var errInvalidatedWorkloadBearer = errors.New("workload identity token exchange returned an invalidated bearer")
 
 type WorkloadIdentityAuth struct {
 	config WorkloadIdentity
@@ -28,6 +33,7 @@ type WorkloadIdentityAuth struct {
 	// Protects cachedToken, tokenExpiry, and refreshInFlight
 	mu              sync.Mutex
 	cachedToken     string
+	rejectedToken   string
 	tokenExpiry     time.Time
 	refreshInFlight *tokenRefreshState
 }
@@ -40,8 +46,9 @@ type tokenRefreshResult struct {
 // Coordinates concurrent access to a single in-flight refresh operation
 // done channel signals completion to all waiting goroutines
 type tokenRefreshState struct {
-	done   chan struct{}
-	result tokenRefreshResult
+	done       chan struct{}
+	generation string
+	result     tokenRefreshResult
 }
 
 type tokenExchangeRequest struct {
@@ -126,22 +133,28 @@ func (w *WorkloadIdentityAuth) handleLockedRefresh(ctx context.Context, httpClie
 	return w.waitForRefresh(ctx, state)
 }
 
-func (w *WorkloadIdentityAuth) invalidateToken() {
+func (w *WorkloadIdentityAuth) invalidateToken(value string) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	if w.cachedToken != value {
+		return
+	}
 	w.cachedToken = ""
 	w.tokenExpiry = time.Time{}
+	if current := w.refreshInFlight; current != nil && current.generation == value {
+		w.rejectedToken = value
+	}
 }
 
 func (w *WorkloadIdentityAuth) beginRefreshLocked() *tokenRefreshState {
-	w.refreshInFlight = &tokenRefreshState{done: make(chan struct{})}
+	w.refreshInFlight = &tokenRefreshState{done: make(chan struct{}), generation: w.cachedToken}
 	return w.refreshInFlight
 }
 
 func (w *WorkloadIdentityAuth) completeForegroundRefresh(ctx context.Context, state *tokenRefreshState, httpClient HTTPDoer) (string, error) {
 	token, err := w.refreshToken(ctx, httpClient)
 	w.finishRefresh(state, token, err)
-	return token, err
+	return state.result.token, state.result.err
 }
 
 // Atomically publishes refresh result and signals all waiting goroutines via channel close
@@ -150,6 +163,14 @@ func (w *WorkloadIdentityAuth) finishRefresh(state *tokenRefreshState, token str
 	defer w.mu.Unlock()
 	if w.refreshInFlight != state {
 		return
+	}
+	if err == nil && token == w.rejectedToken {
+		if w.cachedToken == token {
+			w.cachedToken = ""
+			w.tokenExpiry = time.Time{}
+		}
+		token = ""
+		err = errInvalidatedWorkloadBearer
 	}
 	state.result = tokenRefreshResult{token: token, err: err}
 	close(state.done) // Broadcasts completion to all waiters
@@ -167,13 +188,43 @@ func (w *WorkloadIdentityAuth) waitForRefresh(ctx context.Context, state *tokenR
 }
 
 func (w *WorkloadIdentityAuth) refreshToken(ctx context.Context, httpClient HTTPDoer) (string, error) {
+	for attempt := 0; attempt < workloadMaximumRefreshAttempts; attempt++ {
+		token, expiry, err := w.exchangeToken(ctx, httpClient)
+		if err != nil {
+			return "", err
+		}
+
+		w.mu.Lock()
+		if token != w.rejectedToken {
+			w.cachedToken = token
+			w.tokenExpiry = expiry
+			w.rejectedToken = ""
+			w.mu.Unlock()
+			return token, nil
+		}
+		w.mu.Unlock()
+
+		if attempt+1 >= workloadMaximumRefreshAttempts {
+			return "", errInvalidatedWorkloadBearer
+		}
+		if scope := requestconfig.RequestRetryScopeFromContext(ctx); scope != nil && !scope.TryRetry() {
+			return "", errInvalidatedWorkloadBearer
+		}
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+	}
+	return "", errInvalidatedWorkloadBearer
+}
+
+func (w *WorkloadIdentityAuth) exchangeToken(ctx context.Context, httpClient HTTPDoer) (string, time.Time, error) {
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
 
 	subjectToken, err := w.config.Provider.GetToken(ctx, httpClient)
 	if err != nil {
-		return "", err
+		return "", time.Time{}, err
 	}
 
 	subjectTokenType := w.config.Provider.TokenType()
@@ -184,7 +235,7 @@ func (w *WorkloadIdentityAuth) refreshToken(ctx context.Context, httpClient HTTP
 	case SubjectTokenTypeID:
 		subjectTokenTypeURN = IDTokenType
 	default:
-		return "", fmt.Errorf("unsupported subject token type %q", subjectTokenType)
+		return "", time.Time{}, fmt.Errorf("unsupported subject token type %q", subjectTokenType)
 	}
 
 	requestBody := tokenExchangeRequest{
@@ -198,51 +249,71 @@ func (w *WorkloadIdentityAuth) refreshToken(ctx context.Context, httpClient HTTP
 
 	jsonBody, err := json.Marshal(requestBody)
 	if err != nil {
-		return "", fmt.Errorf("failed to marshal token exchange request: %w", err)
+		return "", time.Time{}, fmt.Errorf("failed to marshal token exchange request: %w", err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, "POST", TokenExchangeURL, bytes.NewReader(jsonBody))
 	if err != nil {
-		return "", fmt.Errorf("failed to create token exchange request: %w", err)
+		return "", time.Time{}, fmt.Errorf("failed to create token exchange request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("failed to exchange token: %w", err)
+		return "", time.Time{}, fmt.Errorf("failed to exchange token: %w", err)
+	}
+	if resp == nil || resp.Body == nil {
+		return "", time.Time{}, errors.New("token exchange returned an invalid response")
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	body, err := io.ReadAll(resp.Body)
+	maximum := int64(x509SuccessResponseMaximum)
+	if resp.StatusCode != http.StatusOK {
+		maximum = x509ErrorResponseMaximum
+	}
+	if resp.ContentLength > maximum {
+		return "", time.Time{}, errors.New("token exchange response exceeds its size limit")
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maximum+1))
 	if err != nil {
-		return "", fmt.Errorf("failed to read token exchange response: %w", err)
+		if contextErr := ctx.Err(); contextErr != nil {
+			return "", time.Time{}, contextErr
+		}
+		return "", time.Time{}, errors.New("failed to read token exchange response")
+	}
+	if int64(len(body)) > maximum {
+		return "", time.Time{}, errors.New("token exchange response exceeds its size limit")
 	}
 
 	if resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
 		var oauthErr struct {
-			Error            string `json:"error"`
-			ErrorDescription string `json:"error_description"`
+			Error string `json:"error"`
 		}
 		if json.Unmarshal(body, &oauthErr) == nil {
-			return "", &OAuthError{
-				StatusCode:       resp.StatusCode,
-				ErrorCode:        shared.OAuthErrorCode(oauthErr.Error),
-				ErrorDescription: oauthErr.ErrorDescription,
+			result := &OAuthError{
+				StatusCode: resp.StatusCode,
 			}
+			switch oauthErr.Error {
+			case "invalid_request", "invalid_client", "invalid_grant", "invalid_scope", "invalid_target",
+				"unauthorized_client", "unsupported_grant_type", "invalid_subject_token", "access_denied",
+				"temporarily_unavailable", "server_error":
+				result.ErrorCode = shared.OAuthErrorCode(oauthErr.Error)
+			}
+			return "", time.Time{}, result
 		}
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("token exchange failed with status %d: %s", resp.StatusCode, string(body))
+		return "", time.Time{}, fmt.Errorf("token exchange failed with status %d", resp.StatusCode)
 	}
 
 	var tokenResp TokenExchangeResponse
 	if err := json.Unmarshal(body, &tokenResp); err != nil {
-		return "", fmt.Errorf("failed to decode token exchange response: %w", err)
+		return "", time.Time{}, errors.New("failed to decode token exchange response")
 	}
 
 	if tokenResp.AccessToken == "" {
-		return "", fmt.Errorf("token exchange response missing 'access_token' field. Response: %s", string(body))
+		return "", time.Time{}, errors.New("token exchange response missing 'access_token' field")
 	}
 
 	expiresIn := int(DefaultTokenExpiry / time.Second)
@@ -250,11 +321,5 @@ func (w *WorkloadIdentityAuth) refreshToken(ctx context.Context, httpClient HTTP
 		expiresIn = *tokenResp.ExpiresIn
 	}
 
-	// Atomically update cached token and expiry
-	w.mu.Lock()
-	w.cachedToken = tokenResp.AccessToken
-	w.tokenExpiry = time.Now().Add(time.Duration(expiresIn) * time.Second)
-	w.mu.Unlock()
-
-	return tokenResp.AccessToken, nil
+	return tokenResp.AccessToken, time.Now().Add(time.Duration(expiresIn) * time.Second), nil
 }

--- a/auth/workloadidentity.go
+++ b/auth/workloadidentity.go
@@ -25,7 +25,10 @@ const (
 	workloadMaximumRefreshAttempts = 3
 )
 
-var errInvalidatedWorkloadBearer = errors.New("workload identity token exchange returned an invalidated bearer")
+var (
+	errInvalidatedWorkloadBearer = errors.New("workload identity token exchange returned an invalidated bearer")
+	errWorkloadIdentityRedirect  = errors.New("workload identity does not follow redirects")
+)
 
 type WorkloadIdentityAuth struct {
 	config WorkloadIdentity
@@ -258,8 +261,11 @@ func (w *WorkloadIdentityAuth) exchangeToken(ctx context.Context, httpClient HTT
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := httpClient.Do(req)
+	resp, err := workloadIdentityDo(httpClient, req)
 	if err != nil {
+		if errors.Is(err, errWorkloadIdentityRedirect) {
+			return "", time.Time{}, err
+		}
 		return "", time.Time{}, fmt.Errorf("failed to exchange token: %w", err)
 	}
 	if resp == nil || resp.Body == nil {
@@ -322,4 +328,29 @@ func (w *WorkloadIdentityAuth) exchangeToken(ctx context.Context, httpClient HTT
 	}
 
 	return tokenResp.AccessToken, time.Now().Add(time.Duration(expiresIn) * time.Second), nil
+}
+
+func workloadIdentityDo(client HTTPDoer, request *http.Request) (*http.Response, error) {
+	if native, ok := client.(*http.Client); ok {
+		isolated := *native
+		isolated.CheckRedirect = func(*http.Request, []*http.Request) error {
+			return errWorkloadIdentityRedirect
+		}
+		client = &isolated
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		if errors.Is(err, errWorkloadIdentityRedirect) {
+			return nil, requestconfig.WithNoRetryError(errWorkloadIdentityRedirect)
+		}
+		return response, err
+	}
+	if response != nil && response.StatusCode >= http.StatusMultipleChoices &&
+		response.StatusCode < http.StatusBadRequest {
+		if response.Body != nil {
+			_ = response.Body.Close()
+		}
+		return nil, requestconfig.WithNoRetryError(errWorkloadIdentityRedirect)
+	}
+	return response, nil
 }

--- a/auth/workloadidentity_hardening_test.go
+++ b/auth/workloadidentity_hardening_test.go
@@ -125,6 +125,143 @@ func TestWorkloadIdentityMiddlewareClosesOnlyPresentUnauthorizedBodies(t *testin
 	}
 }
 
+func TestWorkloadIdentityMiddlewareInvalidatesRejectedReplayBearer(t *testing.T) {
+	identity := newOrdinaryWorkloadIdentity(t)
+	var exchanges atomic.Int32
+	httpClient := ordinaryWorkloadIssuer(t, func() string {
+		return fmt.Sprintf("synthetic-bearer-%d", exchanges.Add(1))
+	})
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodGet,
+		"https://api.openai.com/v1/models", nil)
+	if err != nil {
+		t.Fatalf("construct repeatedly unauthorized request: %v", err)
+	}
+	var rejected int
+	response, err := auth.WorkloadIdentityMiddleware(identity, httpClient, request,
+		func(*http.Request) (*http.Response, error) {
+			rejected++
+			return ordinaryWorkloadResponse(http.StatusUnauthorized, `{}`), nil
+		})
+	if err != nil || response == nil || response.StatusCode != http.StatusUnauthorized || rejected != 2 {
+		t.Fatalf("repeatedly unauthorized response=%v attempts=%d error=%v", response, rejected, err)
+	}
+	if closeErr := response.Body.Close(); closeErr != nil {
+		t.Fatalf("close repeatedly unauthorized response: %v", closeErr)
+	}
+
+	response, err = auth.WorkloadIdentityMiddleware(identity, httpClient, request,
+		func(sent *http.Request) (*http.Response, error) {
+			if got := sent.Header.Get("Authorization"); got != "Bearer synthetic-bearer-3" {
+				t.Errorf("new request reused a previously rejected bearer: %q", got)
+			}
+			return ordinaryWorkloadResponse(http.StatusOK, `{}`), nil
+		})
+	if err != nil || response == nil || response.StatusCode != http.StatusOK {
+		t.Fatalf("request after rejected replay response=%v error=%v", response, err)
+	}
+	if closeErr := response.Body.Close(); closeErr != nil {
+		t.Fatalf("close refreshed response: %v", closeErr)
+	}
+	if got := exchanges.Load(); got != 3 {
+		t.Errorf("rejected-replay issuer exchanges=%d, want three", got)
+	}
+}
+
+func TestWorkloadIdentityMiddlewareNeverReturnsSignedRequestMetadata(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		status        int
+		dispatchError bool
+		unauthorized  bool
+		nilRequest    bool
+		nilHeader     bool
+		wantAttempts  int
+	}{
+		{name: "successful response", status: http.StatusOK, wantAttempts: 1},
+		{name: "API error response", status: http.StatusForbidden, wantAttempts: 1},
+		{name: "response with dispatch error", status: http.StatusOK, dispatchError: true, wantAttempts: 1},
+		{name: "unsigned unauthorized replay", status: http.StatusOK, unauthorized: true, wantAttempts: 2},
+		{name: "response without request", status: http.StatusOK, nilRequest: true, wantAttempts: 1},
+		{name: "response request without headers", status: http.StatusOK, nilHeader: true, wantAttempts: 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			identity := newOrdinaryWorkloadIdentity(t)
+			var exchanges atomic.Int32
+			httpClient := ordinaryWorkloadIssuer(t, func() string {
+				return fmt.Sprintf("synthetic-private-bearer-%d", exchanges.Add(1))
+			})
+			request, err := http.NewRequestWithContext(t.Context(), http.MethodGet,
+				"https://api.openai.com/v1/models", nil)
+			if err != nil {
+				t.Fatalf("construct unsigned workload request: %v", err)
+			}
+			request.Header.Set("X-Synthetic-Metadata", "preserved")
+			failure := errors.New("synthetic dispatch error")
+			var attempts int
+			var wire []*http.Response
+			response, dispatchErr := auth.WorkloadIdentityMiddleware(identity, httpClient, request,
+				func(authenticated *http.Request) (*http.Response, error) {
+					attempts++
+					if got, want := authenticated.Header.Get("Authorization"),
+						fmt.Sprintf("Bearer synthetic-private-bearer-%d", attempts); got != want {
+						t.Errorf("wire bearer on attempt %d = %q, want %q", attempts, got, want)
+					}
+					status := test.status
+					if test.unauthorized && attempts == 1 {
+						status = http.StatusUnauthorized
+					}
+					result := ordinaryWorkloadResponse(status, `{}`)
+					result.Request = authenticated
+					if test.nilRequest {
+						result.Request = nil
+					} else if test.nilHeader {
+						result.Request = authenticated.Clone(authenticated.Context())
+						result.Request.Header = nil
+					} else {
+						result.Request.Header["aUtHoRiZaTiOn"] = []string{"Bearer synthetic-private-alias"}
+					}
+					wire = append(wire, result)
+					if test.dispatchError {
+						return result, failure
+					}
+					return result, nil
+				})
+			if response == nil || response.StatusCode != test.status {
+				t.Fatalf("unsigned response = %v, error = %v", response, dispatchErr)
+			}
+			if closeErr := response.Body.Close(); closeErr != nil {
+				t.Fatalf("close unsigned workload response: %v", closeErr)
+			}
+			if got := errors.Is(dispatchErr, failure); got != test.dispatchError {
+				t.Errorf("dispatch error preservation = %v, want %v", got, test.dispatchError)
+			}
+			if got := request.Header.Get("Authorization"); got != "" {
+				t.Errorf("caller-owned request retained a private bearer: %q", got)
+			}
+			if response.Request != nil && response.Request.Header != nil {
+				for name, values := range response.Request.Header {
+					if strings.EqualFold(strings.ReplaceAll(name, "_", "-"), "authorization") {
+						t.Errorf("returned response exposed credential header %q: %q", name, values)
+					}
+				}
+				if got := response.Request.Header.Get("X-Synthetic-Metadata"); got != "preserved" {
+					t.Errorf("returned response dropped unrelated metadata: %q", got)
+				}
+			}
+			if !test.nilRequest && !test.nilHeader {
+				for _, original := range wire {
+					if original.Request.Header.Get("Authorization") == "" {
+						t.Error("response redaction modified the live authenticated wire request")
+					}
+				}
+			}
+			if attempts != test.wantAttempts {
+				t.Errorf("authenticated API attempts = %d, want %d", attempts, test.wantAttempts)
+			}
+		})
+	}
+}
+
 func TestWorkloadIdentityIssuerErrorsRemainBoundedAndRedacted(t *testing.T) {
 	const sensitive = "synthetic-private-issuer-bearer"
 	for _, test := range []struct {

--- a/auth/workloadidentity_hardening_test.go
+++ b/auth/workloadidentity_hardening_test.go
@@ -99,6 +99,72 @@ func TestWorkloadIdentityMiddlewareRejectsUnprovableBodyReplay(t *testing.T) {
 	}
 }
 
+func TestWorkloadIdentityMiddlewareReplacesAllAuthorizationAliases(t *testing.T) {
+	identity := newOrdinaryWorkloadIdentity(t)
+	var exchanges atomic.Int32
+	httpClient := ordinaryWorkloadIssuer(t, func() string {
+		return fmt.Sprintf("synthetic-trusted-bearer-%d", exchanges.Add(1))
+	})
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodGet,
+		"https://api.openai.com/v1/models", nil)
+	if err != nil {
+		t.Fatalf("construct request with ambiguous credentials: %v", err)
+	}
+	request.Header["Authorization"] = []string{"Bearer synthetic-canonical-attacker", "Bearer synthetic-extra-attacker"}
+	request.Header["authorization"] = []string{"Bearer synthetic-lowercase-attacker"}
+	request.Header["aUtHoRiZaTiOn"] = []string{"Bearer synthetic-mixed-case-attacker"}
+	request.Header.Set("X-Synthetic-Metadata", "preserved")
+
+	var attempts int
+	response, err := auth.WorkloadIdentityMiddleware(identity, httpClient, request,
+		func(authenticated *http.Request) (*http.Response, error) {
+			attempts++
+			var authorizationHeaders int
+			for name, values := range authenticated.Header {
+				if !strings.EqualFold(strings.ReplaceAll(name, "_", "-"), "authorization") {
+					continue
+				}
+				authorizationHeaders++
+				want := fmt.Sprintf("Bearer synthetic-trusted-bearer-%d", attempts)
+				if name != "Authorization" || len(values) != 1 || values[0] != want {
+					t.Errorf("attempt %d authorization header %q=%q, want exactly %q",
+						attempts, name, values, want)
+				}
+			}
+			if authorizationHeaders != 1 {
+				t.Errorf("attempt %d authorization headers=%d, want one", attempts, authorizationHeaders)
+			}
+			if got := authenticated.Header.Get("X-Synthetic-Metadata"); got != "preserved" {
+				t.Errorf("attempt %d dropped unrelated header: %q", attempts, got)
+			}
+			status := http.StatusOK
+			if attempts == 1 {
+				status = http.StatusUnauthorized
+			}
+			response := ordinaryWorkloadResponse(status, `{}`)
+			response.Request = authenticated
+			return response, nil
+		})
+	if err != nil || response == nil || response.StatusCode != http.StatusOK {
+		t.Fatalf("ambiguous-credential replay response=%v error=%v", response, err)
+	}
+	if closeErr := response.Body.Close(); closeErr != nil {
+		t.Fatalf("close ambiguous-credential response: %v", closeErr)
+	}
+	if attempts != 2 || exchanges.Load() != 2 {
+		t.Errorf("authenticated attempts/exchanges=%d/%d, want 2/2", attempts, exchanges.Load())
+	}
+	if len(request.Header["Authorization"]) != 2 || len(request.Header["authorization"]) != 1 ||
+		len(request.Header["aUtHoRiZaTiOn"]) != 1 {
+		t.Error("authentication changed caller-owned authorization headers")
+	}
+	for name := range response.Request.Header {
+		if strings.EqualFold(strings.ReplaceAll(name, "_", "-"), "authorization") {
+			t.Errorf("returned response exposed authorization alias %q", name)
+		}
+	}
+}
+
 func TestWorkloadIdentityMiddlewareClosesOnlyPresentUnauthorizedBodies(t *testing.T) {
 	identity := newOrdinaryWorkloadIdentity(t)
 	httpClient := ordinaryWorkloadIssuer(t, func() string { return "synthetic-bearer" })

--- a/auth/workloadidentity_hardening_test.go
+++ b/auth/workloadidentity_hardening_test.go
@@ -154,9 +154,22 @@ func TestWorkloadIdentityMiddlewareReplacesAllAuthorizationAliases(t *testing.T)
 	if attempts != 2 || exchanges.Load() != 2 {
 		t.Errorf("authenticated attempts/exchanges=%d/%d, want 2/2", attempts, exchanges.Load())
 	}
-	if len(request.Header["Authorization"]) != 2 || len(request.Header["authorization"]) != 1 ||
-		len(request.Header["aUtHoRiZaTiOn"]) != 1 {
-		t.Error("authentication changed caller-owned authorization headers")
+	var callerAuthorizationHeaders int
+	for name, values := range request.Header {
+		if !strings.EqualFold(strings.ReplaceAll(name, "_", "-"), "authorization") {
+			continue
+		}
+		callerAuthorizationHeaders++
+		want := 1
+		if name == "Authorization" {
+			want = 2
+		}
+		if len(values) != want {
+			t.Errorf("caller-owned authorization header %q values=%q, want %d", name, values, want)
+		}
+	}
+	if callerAuthorizationHeaders != 3 {
+		t.Errorf("caller-owned authorization headers=%d, want three", callerAuthorizationHeaders)
 	}
 	for name := range response.Request.Header {
 		if strings.EqualFold(strings.ReplaceAll(name, "_", "-"), "authorization") {

--- a/auth/workloadidentity_hardening_test.go
+++ b/auth/workloadidentity_hardening_test.go
@@ -1,0 +1,355 @@
+package auth_test
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/openai/openai-go/v3/auth"
+)
+
+func TestWorkloadIdentityMiddlewarePreservesBodylessRequests(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		noBody bool
+	}{
+		{name: "nil body"},
+		{name: "http.NoBody sentinel", noBody: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			identity := newOrdinaryWorkloadIdentity(t)
+			var issuerCalls atomic.Int32
+			httpClient := ordinaryWorkloadIssuer(t, func() string {
+				return fmt.Sprintf("synthetic-bearer-%d", issuerCalls.Add(1))
+			})
+			request, err := http.NewRequestWithContext(t.Context(), http.MethodPost,
+				"https://api.openai.com/v1/responses", nil)
+			if err != nil {
+				t.Fatalf("construct bodyless request: %v", err)
+			}
+			if test.noBody {
+				request.Body = http.NoBody
+			}
+			var recreated atomic.Int32
+			request.GetBody = func() (io.ReadCloser, error) {
+				recreated.Add(1)
+				return io.NopCloser(strings.NewReader("synthetic-removed-payload")), nil
+			}
+
+			var attempts int
+			response, err := auth.WorkloadIdentityMiddleware(identity, httpClient, request,
+				func(sent *http.Request) (*http.Response, error) {
+					attempts++
+					if sent.Body != nil && sent.Body != http.NoBody {
+						t.Error("bodyless replay restored a removed payload")
+					}
+					status := http.StatusOK
+					if attempts == 1 {
+						status = http.StatusUnauthorized
+					}
+					return ordinaryWorkloadResponse(status, `{}`), nil
+				})
+			if err != nil || response == nil || response.StatusCode != http.StatusOK {
+				t.Fatalf("bodyless authentication replay: response=%v error=%v", response, err)
+			}
+			if closeErr := response.Body.Close(); closeErr != nil {
+				t.Fatalf("close bodyless authentication response: %v", closeErr)
+			}
+			if attempts != 2 || recreated.Load() != 0 || issuerCalls.Load() != 2 {
+				t.Errorf("bodyless API attempts/recreated bodies/exchanges = %d/%d/%d, want 2/0/2",
+					attempts, recreated.Load(), issuerCalls.Load())
+			}
+		})
+	}
+}
+
+func TestWorkloadIdentityMiddlewareRejectsUnprovableBodyReplay(t *testing.T) {
+	identity := newOrdinaryWorkloadIdentity(t)
+	httpClient := ordinaryWorkloadIssuer(t, func() string { return "synthetic-bearer" })
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodPost,
+		"https://api.openai.com/v1/responses", strings.NewReader("synthetic-original-payload"))
+	if err != nil {
+		t.Fatalf("construct transformed request: %v", err)
+	}
+	request.Body = io.NopCloser(strings.NewReader("synthetic-transformed-payload"))
+	request.ContentLength = int64(len("synthetic-transformed-payload"))
+	var attempts int
+	response, err := auth.WorkloadIdentityMiddleware(identity, httpClient, request,
+		func(sent *http.Request) (*http.Response, error) {
+			attempts++
+			body, readErr := io.ReadAll(sent.Body)
+			if readErr != nil || string(body) != "synthetic-transformed-payload" {
+				t.Errorf("transformed request body = %q, error = %v", body, readErr)
+			}
+			return ordinaryWorkloadResponse(http.StatusUnauthorized, `{}`), nil
+		})
+	if err != nil || response == nil || response.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("transformed body authentication response=%v error=%v", response, err)
+	}
+	if closeErr := response.Body.Close(); closeErr != nil {
+		t.Fatalf("close transformed authentication response: %v", closeErr)
+	}
+	if attempts != 1 {
+		t.Errorf("transformed request API attempts = %d, want exactly one", attempts)
+	}
+}
+
+func TestWorkloadIdentityMiddlewareClosesOnlyPresentUnauthorizedBodies(t *testing.T) {
+	identity := newOrdinaryWorkloadIdentity(t)
+	httpClient := ordinaryWorkloadIssuer(t, func() string { return "synthetic-bearer" })
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodGet,
+		"https://api.openai.com/v1/models", nil)
+	if err != nil {
+		t.Fatalf("construct synthetic unauthorized request: %v", err)
+	}
+	var attempts int
+	response, err := auth.WorkloadIdentityMiddleware(identity, httpClient, request,
+		func(*http.Request) (*http.Response, error) {
+			attempts++
+			if attempts == 1 {
+				return &http.Response{StatusCode: http.StatusUnauthorized, Header: make(http.Header)}, nil
+			}
+			return ordinaryWorkloadResponse(http.StatusOK, `{}`), nil
+		})
+	if err != nil || response == nil || response.StatusCode != http.StatusOK || attempts != 2 {
+		t.Fatalf("nil unauthorized response-body recovery: response=%v attempts=%d error=%v",
+			response, attempts, err)
+	}
+	if closeErr := response.Body.Close(); closeErr != nil {
+		t.Fatalf("close recovered synthetic response: %v", closeErr)
+	}
+}
+
+func TestWorkloadIdentityIssuerErrorsRemainBoundedAndRedacted(t *testing.T) {
+	const sensitive = "synthetic-private-issuer-bearer"
+	for _, test := range []struct {
+		name        string
+		status      int
+		body        string
+		wantOAuth   bool
+		wantCode    string
+		wantLimited bool
+	}{
+		{name: "server error body", status: 500, body: `{"access_token":"` + sensitive + `"}`},
+		{name: "OAuth description", status: 400,
+			body:      `{"error":"invalid_grant","error_description":"` + sensitive + `"}`,
+			wantOAuth: true, wantCode: "invalid_grant"},
+		{name: "untrusted OAuth error code", status: 403,
+			body: `{"error":"` + sensitive + `"}`, wantOAuth: true},
+		{name: "missing bearer response", status: 200, body: `{"detail":"` + sensitive + `"}`},
+		{name: "oversized successful response", status: 200,
+			body: strings.Repeat("a", (1<<20)+1), wantLimited: true},
+		{name: "oversized unsuccessful response", status: 500,
+			body: strings.Repeat("a", (4<<10)+1), wantLimited: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			identity := newOrdinaryWorkloadIdentity(t)
+			httpClient := mockOAuthServer(test.body, test.status)
+			token, err := identity.GetToken(t.Context(), httpClient)
+			if token != "" || err == nil {
+				t.Fatalf("unsafe issuer response: token=%q error=%v", token, err)
+			}
+			if strings.Contains(err.Error(), sensitive) {
+				t.Error("issuer response content escaped into the returned error")
+			}
+			if test.wantLimited && !strings.Contains(err.Error(), "size limit") {
+				t.Errorf("oversized issuer response error = %v, want a safe limit error", err)
+			}
+			var oauthError *auth.OAuthError
+			if got := errors.As(err, &oauthError); got != test.wantOAuth {
+				t.Fatalf("typed OAuth error = %t, want %t", got, test.wantOAuth)
+			}
+			if oauthError != nil && (string(oauthError.ErrorCode) != test.wantCode ||
+				oauthError.ErrorDescription != "") {
+				t.Errorf("safe OAuth error code/description = %q/%q, want %q/empty",
+					oauthError.ErrorCode, oauthError.ErrorDescription, test.wantCode)
+			}
+		})
+	}
+}
+
+func TestWorkloadIdentityIssuerClosesOversizedAndUnreadableResponses(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		contentLength int64
+		readError     error
+		wantReads     int32
+	}{
+		{name: "declared oversized issuer response", contentLength: (1 << 20) + 1},
+		{name: "private response read failure", readError: errors.New("synthetic-private-read-cause"), wantReads: 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			identity := newOrdinaryWorkloadIdentity(t)
+			body := &ordinaryObservedBody{readError: test.readError}
+			httpClient := &http.Client{Transport: &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode:    http.StatusOK,
+					Header:        make(http.Header),
+					Body:          body,
+					ContentLength: test.contentLength,
+				}, nil
+			}}}
+			token, err := identity.GetToken(t.Context(), httpClient)
+			if token != "" || err == nil || strings.Contains(err.Error(), "synthetic-private-read-cause") {
+				t.Errorf("unsafe issuer read response: token=%q error=%v", token, err)
+			}
+			if got := body.reads.Load(); got != test.wantReads {
+				t.Errorf("issuer response reads=%d, want %d", got, test.wantReads)
+			}
+			if got := body.closes.Load(); got != 1 {
+				t.Errorf("issuer response body closes=%d, want exactly one", got)
+			}
+		})
+	}
+}
+
+func TestWorkloadIdentityRefreshDoesNotRestoreRejectedGeneration(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		alwaysReject  bool
+		wantExchanges int32
+	}{
+		{name: "replacement generation", wantExchanges: 3},
+		{name: "repeated rejected generation is bounded", alwaysReject: true, wantExchanges: 4},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			identity := newOrdinaryWorkloadIdentity(t)
+			const rejected = "synthetic-rejected-generation"
+			refreshStarted := make(chan struct{})
+			releaseRefresh := make(chan struct{})
+			var exchanges atomic.Int32
+			httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+				call := exchanges.Add(1)
+				if call == 2 {
+					close(refreshStarted)
+					select {
+					case <-releaseRefresh:
+					case <-req.Context().Done():
+						return nil, req.Context().Err()
+					}
+				}
+				token := rejected
+				if call >= 3 && !test.alwaysReject {
+					token = "synthetic-replacement-generation"
+				}
+				return ordinaryWorkloadResponse(http.StatusOK,
+					fmt.Sprintf(`{"access_token":%q,"expires_in":600}`, token)), nil
+			}}}
+			if token, err := identity.GetToken(t.Context(), httpClient); token != rejected || err != nil {
+				t.Fatalf("prime cached generation: token=%q error=%v", token, err)
+			}
+			if token, err := identity.GetToken(t.Context(), httpClient); token != rejected || err != nil {
+				t.Fatalf("begin proactive refresh: token=%q error=%v", token, err)
+			}
+			select {
+			case <-refreshStarted:
+			case <-time.After(5 * time.Second):
+				t.Fatal("proactive refresh never reached its synchronized issuer")
+			}
+
+			request, err := http.NewRequestWithContext(t.Context(), http.MethodGet,
+				"https://api.openai.com/v1/models", nil)
+			if err != nil {
+				t.Fatalf("construct rejected-generation request: %v", err)
+			}
+			apiRejected := make(chan struct{})
+			type outcome struct {
+				header string
+				err    error
+			}
+			completed := make(chan outcome, 1)
+			go func() {
+				var attempts int
+				var replayed string
+				response, authErr := auth.WorkloadIdentityMiddleware(identity, httpClient, request,
+					func(sent *http.Request) (*http.Response, error) {
+						attempts++
+						if attempts == 1 {
+							close(apiRejected)
+							return ordinaryWorkloadResponse(http.StatusUnauthorized, `{}`), nil
+						}
+						replayed = sent.Header.Get("Authorization")
+						return ordinaryWorkloadResponse(http.StatusOK, `{}`), nil
+					})
+				if response != nil && response.Body != nil {
+					_ = response.Body.Close()
+				}
+				completed <- outcome{header: replayed, err: authErr}
+			}()
+			select {
+			case <-apiRejected:
+			case <-time.After(5 * time.Second):
+				t.Fatal("API never rejected its cached generation")
+			}
+			close(releaseRefresh)
+			select {
+			case result := <-completed:
+				if test.alwaysReject {
+					if result.err == nil || strings.Contains(result.err.Error(), rejected) || result.header != "" {
+						t.Errorf("repeated rejected bearer escaped: replay=%q error=%v", result.header, result.err)
+					}
+				} else if result.err != nil || result.header != "Bearer synthetic-replacement-generation" {
+					t.Errorf("replacement generation replay=%q error=%v", result.header, result.err)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("invalidated background refresh did not complete")
+			}
+			if got := exchanges.Load(); got != test.wantExchanges {
+				t.Errorf("generation refresh exchanges=%d, want %d", got, test.wantExchanges)
+			}
+		})
+	}
+}
+
+func newOrdinaryWorkloadIdentity(t *testing.T) *auth.WorkloadIdentityAuth {
+	t.Helper()
+	identity, err := auth.NewWorkloadIdentityAuth(auth.WorkloadIdentity{
+		IdentityProviderID: "synthetic-provider",
+		ServiceAccountID:   "synthetic-service-account",
+		Provider:           &mockProvider{token: "synthetic-subject", tokenType: auth.SubjectTokenTypeJWT},
+	})
+	if err != nil {
+		t.Fatalf("construct ordinary workload identity: %v", err)
+	}
+	return identity
+}
+
+func ordinaryWorkloadIssuer(t *testing.T, token func() string) *http.Client {
+	t.Helper()
+	return &http.Client{Transport: &closureTransport{fn: func(*http.Request) (*http.Response, error) {
+		return ordinaryWorkloadResponse(http.StatusOK,
+			fmt.Sprintf(`{"access_token":%q,"expires_in":3600}`, token())), nil
+	}}}
+}
+
+func ordinaryWorkloadResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+type ordinaryObservedBody struct {
+	reads     atomic.Int32
+	closes    atomic.Int32
+	readError error
+}
+
+func (body *ordinaryObservedBody) Read([]byte) (int, error) {
+	body.reads.Add(1)
+	if body.readError != nil {
+		return 0, body.readError
+	}
+	return 0, io.EOF
+}
+
+func (body *ordinaryObservedBody) Close() error {
+	body.closes.Add(1)
+	return nil
+}

--- a/auth/workloadidentity_hardening_test.go
+++ b/auth/workloadidentity_hardening_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -341,6 +342,99 @@ func TestWorkloadIdentityMiddlewareNeverReturnsSignedRequestMetadata(t *testing.
 	}
 }
 
+func TestWorkloadIdentityNativeIssuerRejectsRedirectsWithoutMutatingItsClient(t *testing.T) {
+	for _, status := range []int{
+		http.StatusMovedPermanently,
+		http.StatusFound,
+		http.StatusSeeOther,
+		http.StatusTemporaryRedirect,
+		http.StatusPermanentRedirect,
+	} {
+		t.Run(fmt.Sprintf("HTTP %d", status), func(t *testing.T) {
+			var issuerRequests, redirectedRequests, callerRedirectChecks atomic.Int32
+			target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				redirectedRequests.Add(1)
+				w.WriteHeader(http.StatusOK)
+			}))
+			t.Cleanup(target.Close)
+			issuer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+				issuerRequests.Add(1)
+				body, err := io.ReadAll(request.Body)
+				if err != nil || !strings.Contains(string(body), "synthetic-subject") {
+					t.Errorf("original issuer did not receive its expected subject token: body=%q error=%v", body, err)
+				}
+				w.Header().Set("Location", target.URL+"/steal?credential=synthetic-private-redirect-location")
+				w.WriteHeader(status)
+			}))
+			t.Cleanup(issuer.Close)
+			caller := &http.Client{
+				Transport: &closureTransport{fn: func(request *http.Request) (*http.Response, error) {
+					if request.URL.Host == "auth.openai.com" {
+						request = request.Clone(request.Context())
+						request.URL.Scheme = "http"
+						request.URL.Host = issuer.Listener.Addr().String()
+					}
+					return http.DefaultTransport.RoundTrip(request)
+				}},
+				CheckRedirect: func(*http.Request, []*http.Request) error {
+					callerRedirectChecks.Add(1)
+					return nil
+				},
+			}
+			identity := newOrdinaryWorkloadIdentity(t)
+
+			token, err := identity.GetToken(t.Context(), caller)
+			if token != "" || err == nil || !strings.Contains(err.Error(), "does not follow redirects") {
+				t.Fatalf("redirected token exchange returned token=%q error=%v", token, err)
+			}
+			if strings.Contains(err.Error(), "synthetic-private") || strings.Contains(err.Error(), target.URL) {
+				t.Errorf("issuer redirect error disclosed its attacker-controlled destination: %q", err.Error())
+			}
+			if issuerRequests.Load() != 1 || redirectedRequests.Load() != 0 || callerRedirectChecks.Load() != 0 {
+				t.Errorf("issuer/redirect/caller-policy requests=%d/%d/%d, want 1/0/0",
+					issuerRequests.Load(), redirectedRequests.Load(), callerRedirectChecks.Load())
+			}
+			if caller.CheckRedirect == nil {
+				t.Fatal("isolated issuer exchange removed the caller's redirect policy")
+			}
+			if err := caller.CheckRedirect(nil, nil); err != nil || callerRedirectChecks.Load() != 1 {
+				t.Errorf("isolated issuer exchange modified its caller-owned redirect policy: %v", err)
+			}
+		})
+	}
+}
+
+func TestWorkloadIdentityRejectsOpaqueIssuerRedirectResponses(t *testing.T) {
+	for _, status := range []int{
+		http.StatusMovedPermanently,
+		http.StatusFound,
+		http.StatusSeeOther,
+		http.StatusTemporaryRedirect,
+		http.StatusPermanentRedirect,
+	} {
+		t.Run(fmt.Sprintf("HTTP %d", status), func(t *testing.T) {
+			body := &ordinaryObservedBody{}
+			var requests atomic.Int32
+			doer := ordinaryOpaqueHTTPDoer(func(*http.Request) (*http.Response, error) {
+				requests.Add(1)
+				return &http.Response{
+					StatusCode: status,
+					Header:     http.Header{"Location": []string{"https://synthetic.invalid/private"}},
+					Body:       body,
+				}, nil
+			})
+			token, err := newOrdinaryWorkloadIdentity(t).GetToken(t.Context(), doer)
+			if token != "" || err == nil || !strings.Contains(err.Error(), "does not follow redirects") {
+				t.Fatalf("opaque redirect response token=%q error=%v", token, err)
+			}
+			if requests.Load() != 1 || body.reads.Load() != 0 || body.closes.Load() != 1 {
+				t.Errorf("opaque issuer requests/body reads/closes=%d/%d/%d, want 1/0/1",
+					requests.Load(), body.reads.Load(), body.closes.Load())
+			}
+		})
+	}
+}
+
 func TestWorkloadIdentityIssuerErrorsRemainBoundedAndRedacted(t *testing.T) {
 	const sensitive = "synthetic-private-issuer-bearer"
 	for _, test := range []struct {
@@ -555,6 +649,12 @@ type ordinaryObservedBody struct {
 	reads     atomic.Int32
 	closes    atomic.Int32
 	readError error
+}
+
+type ordinaryOpaqueHTTPDoer func(*http.Request) (*http.Response, error)
+
+func (do ordinaryOpaqueHTTPDoer) Do(request *http.Request) (*http.Response, error) {
+	return do(request)
 }
 
 func (body *ordinaryObservedBody) Read([]byte) (int, error) {

--- a/auth/workloadidentity_test.go
+++ b/auth/workloadidentity_test.go
@@ -459,8 +459,8 @@ func TestOAuthErrorHandling(t *testing.T) {
 			if oauthErr.ErrorCode != "invalid_grant" {
 				t.Errorf("ErrorCode = %q, want %q", oauthErr.ErrorCode, "invalid_grant")
 			}
-			if oauthErr.ErrorDescription != "Token exchange failed" {
-				t.Errorf("ErrorDescription = %q, want %q", oauthErr.ErrorDescription, "Token exchange failed")
+			if oauthErr.ErrorDescription != "" {
+				t.Errorf("ErrorDescription = %q, want redacted issuer description", oauthErr.ErrorDescription)
 			}
 		}
 	}

--- a/auth/x509middleware.go
+++ b/auth/x509middleware.go
@@ -48,10 +48,10 @@ func X509WorkloadIdentityMiddleware(
 	if scope != nil {
 		replayable := !hadBody || (request.GetBody != nil && scope.AllowBodyReplay())
 		if replayable && scope.TryOuterReplay() {
-			return x509UnauthorizedRetryResponse(response, true), nil
+			return unauthorizedRetryResponse(response, true), nil
 		}
 		if response.Header.Get("x-should-retry") == "true" {
-			return x509UnauthorizedRetryResponse(response, false), nil
+			return unauthorizedRetryResponse(response, false), nil
 		}
 		return response, nil
 	}
@@ -95,7 +95,7 @@ func x509UnsignedResponse(response *http.Response) *http.Response {
 	return response
 }
 
-func x509UnauthorizedRetryResponse(response *http.Response, retry bool) *http.Response {
+func unauthorizedRetryResponse(response *http.Response, retry bool) *http.Response {
 	clone := *response
 	clone.Header = response.Header.Clone()
 	if clone.Header == nil {

--- a/auth/x509transport.go
+++ b/auth/x509transport.go
@@ -18,11 +18,17 @@ import (
 	"slices"
 	"strings"
 	"sync/atomic"
+	"time"
+
+	"github.com/openai/openai-go/v3/internal/requestconfig"
 )
 
 const (
-	x509AuthenticationHost = "mtls.auth.openai.com"
-	x509APIHost            = "mtls.api.openai.com"
+	x509AuthenticationHost           = "mtls.auth.openai.com"
+	x509APIHost                      = "mtls.api.openai.com"
+	x509DefaultDialTimeout           = 30 * time.Second
+	x509DefaultTLSHandshakeTimeout   = 10 * time.Second
+	x509DefaultResponseHeaderTimeout = 10 * time.Minute
 )
 
 var (
@@ -73,6 +79,7 @@ type X509Transport struct {
 	transport         *http.Transport
 	tlsConfig         *tls.Config
 	certificateDigest [sha256.Size]byte
+	certificateSelect uintptr
 	client            *http.Client
 	closed            atomic.Bool
 }
@@ -115,6 +122,11 @@ func NewX509Transport(template *http.Transport) (*X509Transport, error) {
 	config.CipherSuites = slices.Clone(config.CipherSuites)
 	config.CurvePreferences = slices.Clone(config.CurvePreferences)
 	config.EncryptedClientHelloConfigList = slices.Clone(config.EncryptedClientHelloConfigList)
+	// The sole attested certificate remains static even when the server advertises
+	// an unrelated acceptable-CA hint. Caller-controlled selectors remain forbidden.
+	config.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+		return &config.Certificates[0], nil
+	}
 	transport := &http.Transport{
 		DialContext:            template.DialContext,
 		TLSClientConfig:        config,
@@ -133,7 +145,18 @@ func NewX509Transport(template *http.Transport) (*X509Transport, error) {
 		ForceAttemptHTTP2:      template.ForceAttemptHTTP2,
 	}
 	//nolint:staticcheck // Preserve a legacy TCP dialer; unlike DialTLS, it cannot bypass native TLS.
-	transport.Dial = template.Dial
+	if transport.Dial = template.Dial; transport.Dial == nil && transport.DialContext == nil {
+		transport.DialContext = (&net.Dialer{
+			Timeout:   x509DefaultDialTimeout,
+			KeepAlive: x509DefaultDialTimeout,
+		}).DialContext
+	}
+	if transport.TLSHandshakeTimeout == 0 {
+		transport.TLSHandshakeTimeout = x509DefaultTLSHandshakeTimeout
+	}
+	if transport.ResponseHeaderTimeout == 0 {
+		transport.ResponseHeaderTimeout = x509DefaultResponseHeaderTimeout
+	}
 	if template.Protocols != nil {
 		protocols := *template.Protocols
 		transport.Protocols = &protocols
@@ -185,6 +208,7 @@ func NewX509Transport(template *http.Transport) (*X509Transport, error) {
 		transport:         transport,
 		tlsConfig:         config,
 		certificateDigest: x509CertificateDigest(config.Certificates[0].Certificate),
+		certificateSelect: reflect.ValueOf(config.GetClientCertificate).Pointer(),
 		client: &http.Client{
 			Transport: transport,
 			CheckRedirect: func(*http.Request, []*http.Request) error {
@@ -234,6 +258,13 @@ func validateX509NativeTransport(transport *http.Transport) error {
 }
 
 func validateX509TLSConfig(config *tls.Config) error {
+	if config.GetClientCertificate != nil {
+		return errors.New("X.509 transport does not support dynamic client-certificate callbacks")
+	}
+	return validateX509StaticTLSConfig(config)
+}
+
+func validateX509StaticTLSConfig(config *tls.Config) error {
 	var signer crypto.Signer
 	if len(config.Certificates) == 1 {
 		signer, _ = config.Certificates[0].PrivateKey.(crypto.Signer)
@@ -241,9 +272,6 @@ func validateX509TLSConfig(config *tls.Config) error {
 	if len(config.Certificates) != 1 || len(config.Certificates[0].Certificate) == 0 ||
 		len(config.Certificates[0].Certificate[0]) == 0 || x509PrivateKeyIsNil(signer) {
 		return errors.New("X.509 transport requires exactly one static certificate and private key")
-	}
-	if config.GetClientCertificate != nil {
-		return errors.New("X.509 transport does not support dynamic client-certificate callbacks")
 	}
 	if len(config.EncryptedClientHelloConfigList) != 0 || config.EncryptedClientHelloRejectionVerify != nil {
 		return errors.New("X.509 transport does not support encrypted client hello")
@@ -338,10 +366,18 @@ func (transport *X509Transport) validateAttestation() error {
 		transport.transport.TLSClientConfig != transport.tlsConfig {
 		return errors.New("X.509 transport TLS configuration changed after attestation")
 	}
+	if err := validateX509StaticTLSConfig(transport.tlsConfig); err != nil {
+		return fmt.Errorf("X.509 transport TLS configuration changed after attestation: %w", err)
+	}
+	selector := transport.tlsConfig.GetClientCertificate
+	if selector == nil || reflect.ValueOf(selector).Pointer() != transport.certificateSelect {
+		return errors.New("X.509 transport client-certificate selection changed after attestation")
+	}
+	selected, err := selector(new(tls.CertificateRequestInfo))
+	if err != nil || selected != &transport.tlsConfig.Certificates[0] {
+		return errors.New("X.509 transport client-certificate selection changed after attestation")
+	}
 	for _, config := range []*tls.Config{transport.templateTLS, transport.tlsConfig} {
-		if err := validateX509TLSConfig(config); err != nil {
-			return fmt.Errorf("X.509 transport TLS configuration changed after attestation: %w", err)
-		}
 		digest := x509CertificateDigest(config.Certificates[0].Certificate)
 		if subtle.ConstantTimeCompare(digest[:], transport.certificateDigest[:]) != 1 {
 			return errors.New("X.509 transport certificate changed after attestation")
@@ -413,7 +449,8 @@ func (transport *X509Transport) Do(request *http.Request) (*http.Response, error
 			redacted.cause = context.Canceled
 		case errors.Is(err, context.DeadlineExceeded):
 			redacted.cause = context.DeadlineExceeded
-		case errors.Is(err, errX509TLSVerification) || errors.As(err, &verificationError):
+		case errors.Is(err, errX509TLSVerification) || errors.As(err, &verificationError) ||
+			x509PermanentClientCertificateAlert(err):
 			redacted.cause = errX509TLSVerification
 		}
 		return nil, redacted
@@ -428,6 +465,22 @@ func (transport *X509Transport) Do(request *http.Request) (*http.Response, error
 		return nil, &x509TransportError{cause: errX509Redirect}
 	}
 	return response, nil
+}
+
+func x509PermanentClientCertificateAlert(err error) bool {
+	var operation *net.OpError
+	if !errors.As(err, &operation) || operation.Op != "remote error" || operation.Err == nil {
+		return false
+	}
+	switch operation.Err.Error() {
+	case "tls: bad certificate", "tls: unsupported certificate", "tls: revoked certificate",
+		"tls: expired certificate", "tls: unknown certificate", "tls: unknown certificate authority",
+		"tls: bad certificate status response", "tls: bad certificate hash value",
+		"tls: certificate unobtainable", "tls: certificate required":
+		return true
+	default:
+		return false
+	}
 }
 
 func validateX509Request(request *http.Request) error {
@@ -478,11 +531,11 @@ func validateX509Request(request *http.Request) error {
 
 	authorizationCount := 0
 	for name, values := range request.Header {
-		if !validX509HeaderName(name) {
+		if !requestconfig.ValidHTTPHeaderName(name) {
 			return errors.New("X.509 requests require valid HTTP header names")
 		}
 		for _, value := range values {
-			if !validX509HeaderValue(value) {
+			if !requestconfig.ValidHTTPHeaderValue(value) {
 				return errors.New("X.509 requests require valid HTTP header values")
 			}
 		}
@@ -521,32 +574,6 @@ func validateX509Request(request *http.Request) error {
 		return errors.New("X.509 API requests must remain inside the /v1/ path")
 	}
 	return nil
-}
-
-func validX509HeaderName(name string) bool {
-	if name == "" {
-		return false
-	}
-	for _, value := range []byte(name) {
-		switch {
-		case value >= 'A' && value <= 'Z', value >= 'a' && value <= 'z', value >= '0' && value <= '9':
-		case value == '!', value == '#', value == '$', value == '%', value == '&', value == '\'',
-			value == '*', value == '+', value == '-', value == '.', value == '^', value == '_',
-			value == '`', value == '|', value == '~':
-		default:
-			return false
-		}
-	}
-	return true
-}
-
-func validX509HeaderValue(value string) bool {
-	for _, character := range []byte(value) {
-		if (character < ' ' && character != '\t') || character == 0x7f {
-			return false
-		}
-	}
-	return true
 }
 
 func validX509BearerHeader(value string) bool {

--- a/auth/x509transport_attestation_test.go
+++ b/auth/x509transport_attestation_test.go
@@ -1,0 +1,167 @@
+package auth
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestX509TransportUsesBoundedNativeDefaultsWithoutMutatingItsTemplate(t *testing.T) {
+	fixture := newX509ExchangeFixture(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, x509ValidExchangeResponse())
+	}))
+	template := fixture.template
+	template.DialContext = nil
+	capability, err := NewX509Transport(template)
+	if err != nil {
+		t.Fatalf("attest timeout-default workload transport: %v", err)
+	}
+	t.Cleanup(func() { _ = capability.Close() })
+	if capability.transport.DialContext == nil {
+		t.Fatal("attested native transport did not install a bounded default TCP dialer")
+	}
+	if got := capability.transport.TLSHandshakeTimeout; got != x509DefaultTLSHandshakeTimeout {
+		t.Errorf("default TLS handshake timeout = %s, want %s", got, x509DefaultTLSHandshakeTimeout)
+	}
+	if got := capability.transport.ResponseHeaderTimeout; got != x509DefaultResponseHeaderTimeout {
+		t.Errorf("default response-header timeout = %s, want %s", got, x509DefaultResponseHeaderTimeout)
+	}
+	if template.DialContext != nil || template.TLSHandshakeTimeout != 0 || template.ResponseHeaderTimeout != 0 {
+		t.Error("installing private bounded defaults mutated the caller-owned transport template")
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	if _, err := capability.transport.DialContext(ctx, "tcp", "127.0.0.1:1"); !errors.Is(err, context.Canceled) {
+		t.Errorf("bounded TCP dialer ignored caller cancellation: %v", err)
+	}
+}
+
+func TestX509TransportPreservesExplicitNativeTimeoutAndDialConfiguration(t *testing.T) {
+	fixture := newX509ExchangeFixture(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, x509ValidExchangeResponse())
+	}))
+	template := fixture.template
+	var dialed atomic.Int32
+	original := template.DialContext
+	template.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		dialed.Add(1)
+		return original(ctx, network, address)
+	}
+	template.TLSHandshakeTimeout = 3 * time.Second
+	template.ResponseHeaderTimeout = 4 * time.Second
+	capability, err := NewX509Transport(template)
+	if err != nil {
+		t.Fatalf("attest explicitly configured workload transport: %v", err)
+	}
+	t.Cleanup(func() { _ = capability.Close() })
+	if got := capability.transport.TLSHandshakeTimeout; got != 3*time.Second {
+		t.Errorf("explicit TLS handshake timeout = %s, want three seconds", got)
+	}
+	if got := capability.transport.ResponseHeaderTimeout; got != 4*time.Second {
+		t.Errorf("explicit response-header timeout = %s, want four seconds", got)
+	}
+	if _, err := x509Exchange(t.Context(), capability, "synthetic-provider", "synthetic-account"); err != nil {
+		t.Fatalf("exchange using the preserved caller TCP dialer: %v", err)
+	}
+	if got := dialed.Load(); got != 1 {
+		t.Errorf("preserved custom TCP dialer ran %d times, want one", got)
+	}
+}
+
+func TestX509TransportRejectsReplacedCapabilityOwnedCertificateSelector(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		replace func(*X509Transport, *X509Transport, *atomic.Int32)
+	}{
+		{name: "removed internal selector", replace: func(first, _ *X509Transport, _ *atomic.Int32) {
+			first.tlsConfig.GetClientCertificate = nil
+		}},
+		{name: "caller-controlled callback", replace: func(first, _ *X509Transport, invoked *atomic.Int32) {
+			first.tlsConfig.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+				invoked.Add(1)
+				return &first.tlsConfig.Certificates[0], nil
+			}
+		}},
+		{name: "another capability with the same closure code", replace: func(first, second *X509Transport, _ *atomic.Int32) {
+			if reflect.ValueOf(first.tlsConfig.GetClientCertificate).Pointer() !=
+				reflect.ValueOf(second.tlsConfig.GetClientCertificate).Pointer() {
+				t.Fatal("separate capabilities unexpectedly used different static-selector function code")
+			}
+			first.tlsConfig.GetClientCertificate = second.tlsConfig.GetClientCertificate
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			first := newX509ExchangeFixture(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+			second := newX509ExchangeFixture(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+			var invoked atomic.Int32
+			test.replace(first.capability, second.capability, &invoked)
+			if err := first.capability.validateAttestation(); err == nil || !strings.Contains(err.Error(), "selection changed") {
+				t.Fatalf("replaced private selector attestation error = %v", err)
+			}
+			if got := invoked.Load(); got != 0 {
+				t.Errorf("untrusted replacement selector executed %d times", got)
+			}
+		})
+	}
+}
+
+func TestX509TransportRejectsMissingAttestedCertificatesWithoutPanic(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		remove func(*X509Transport)
+	}{
+		{name: "caller template", remove: func(transport *X509Transport) {
+			transport.templateTLS.Certificates = nil
+		}},
+		{name: "capability-owned configuration", remove: func(transport *X509Transport) {
+			transport.tlsConfig.Certificates = nil
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newX509ExchangeFixture(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+			test.remove(fixture.capability)
+			if err := fixture.capability.validateAttestation(); err == nil ||
+				!strings.Contains(err.Error(), "requires exactly one static certificate") {
+				t.Fatalf("missing attested certificate error = %v, want a safe validation failure", err)
+			}
+		})
+	}
+}
+
+func TestX509TransportClassifiesOnlyPermanentRemoteCertificateAlerts(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		operation string
+		message   string
+		permanent bool
+	}{
+		{name: "bad certificate", operation: "remote error", message: "tls: bad certificate", permanent: true},
+		{name: "unsupported certificate", operation: "remote error", message: "tls: unsupported certificate", permanent: true},
+		{name: "revoked certificate", operation: "remote error", message: "tls: revoked certificate", permanent: true},
+		{name: "expired certificate", operation: "remote error", message: "tls: expired certificate", permanent: true},
+		{name: "unknown certificate", operation: "remote error", message: "tls: unknown certificate", permanent: true},
+		{name: "unknown authority", operation: "remote error", message: "tls: unknown certificate authority", permanent: true},
+		{name: "required certificate", operation: "remote error", message: "tls: certificate required", permanent: true},
+		{name: "transient internal TLS error", operation: "remote error", message: "tls: internal error"},
+		{name: "local certificate-shaped error", operation: "dial", message: "tls: bad certificate"},
+		{name: "sensitive unrelated network error", operation: "remote error", message: "synthetic-private-token"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := &net.OpError{Op: test.operation, Err: errors.New(test.message)}
+			if got := x509PermanentClientCertificateAlert(err); got != test.permanent {
+				t.Errorf("remote TLS alert permanent = %v, want %v", got, test.permanent)
+			}
+		})
+	}
+	if x509PermanentClientCertificateAlert(nil) {
+		t.Error("nil transport error was classified as a permanent TLS rejection")
+	}
+}

--- a/auth/x509transport_hardening_test.go
+++ b/auth/x509transport_hardening_test.go
@@ -1,0 +1,147 @@
+package auth_test
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/openai/openai-go/v3/auth"
+)
+
+func TestX509TransportPresentsStaticCertificateDespiteMismatchedCAHints(t *testing.T) {
+	for _, host := range []string{x509TransportIssuer, x509TransportAPI} {
+		t.Run(host, func(t *testing.T) {
+			fixture := newX509TransportFixture(t)
+			advertised := x509.NewCertPool()
+			advertised.AddCert(fixture.certificate(t, "synthetic unrelated CA hint", nil, false).Leaf)
+			var presented atomic.Int32
+			server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+				presented.Store(int32(len(request.TLS.PeerCertificates)))
+				w.WriteHeader(http.StatusOK)
+			}))
+			server.Config.ErrorLog = log.New(io.Discard, "", 0)
+			server.TLS = &tls.Config{
+				MinVersion:   tls.VersionTLS12,
+				Certificates: []tls.Certificate{fixture.certificate(t, "synthetic hint server", []string{host}, false)},
+				ClientAuth:   tls.RequireAnyClientCert,
+				ClientCAs:    advertised,
+				VerifyConnection: func(state tls.ConnectionState) error {
+					if len(state.PeerCertificates) == 0 {
+						return errors.New("the attested client certificate was not presented")
+					}
+					_, err := state.PeerCertificates[0].Verify(x509.VerifyOptions{
+						Roots:     fixture.trust,
+						KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+					})
+					return err
+				},
+			}
+			server.StartTLS()
+			t.Cleanup(server.Close)
+			capability := newX509Capability(t, fixture.transport(t, server))
+			method, target := http.MethodGet, "https://"+host+"/v1/models"
+			if host == x509TransportIssuer {
+				method, target = http.MethodPost, "https://"+host+"/oauth/token"
+			}
+			request := x509TransportRequest(t, method, target)
+			if host == x509TransportAPI {
+				request.Header.Set("Authorization", "Bearer synthetic-attested-token")
+			}
+			response, err := capability.Do(request)
+			if err != nil {
+				t.Fatalf("mutually authenticated handshake with an unrelated acceptable-CA hint: %v", err)
+			}
+			if err := response.Body.Close(); err != nil {
+				t.Fatalf("close mutually authenticated response: %v", err)
+			}
+			if got := presented.Load(); got != 1 {
+				t.Errorf("presented workload certificates = %d, want one", got)
+			}
+		})
+	}
+}
+
+func TestX509WorkloadIdentityRejectsPermanentRemoteCertificateAlertsWithoutRetry(t *testing.T) {
+	fixture := newX509TransportFixture(t)
+	unrelated := x509.NewCertPool()
+	unrelated.AddCert(fixture.certificate(t, "synthetic unrelated client authority", nil, false).Leaf)
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("untrusted workload certificate reached the issuer handler")
+		w.WriteHeader(http.StatusOK)
+	}))
+	server.Config.ErrorLog = log.New(io.Discard, "", 0)
+	server.TLS = &tls.Config{
+		MinVersion:   tls.VersionTLS12,
+		Certificates: []tls.Certificate{fixture.certificate(t, "synthetic refusing issuer", []string{x509TransportIssuer}, false)},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    unrelated,
+	}
+	server.StartTLS()
+	t.Cleanup(server.Close)
+	template := fixture.transport(t, server)
+	dial := template.DialContext
+	var handshakes atomic.Int32
+	template.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		handshakes.Add(1)
+		return dial(ctx, network, address)
+	}
+	capability := newX509Capability(t, template)
+	identity, err := auth.NewX509WorkloadIdentityAuth(auth.X509WorkloadIdentity{
+		IdentityProviderID: "synthetic-identity-provider",
+		ServiceAccountID:   "synthetic-service-account",
+		Transport:          capability,
+	})
+	if err != nil {
+		t.Fatalf("create statically attested workload identity: %v", err)
+	}
+	token, err := identity.GetToken(t.Context(), capability)
+	if err == nil || token != "" {
+		t.Fatalf("permanently rejected workload certificate returned token=%q error=%v", token, err)
+	}
+	if got := handshakes.Load(); got != 1 {
+		t.Errorf("permanent client-certificate rejection attempted %d TLS handshakes, want one", got)
+	}
+	if cause := errors.Unwrap(err); cause == nil || strings.Contains(cause.Error(), "synthetic") {
+		t.Errorf("permanent TLS classification = %v, want a safe non-sensitive sentinel", cause)
+	}
+}
+
+func TestX509TransportResponseHeaderTimeoutDoesNotLimitStreamingBodies(t *testing.T) {
+	fixture := newX509TransportFixture(t)
+	server := fixture.server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Error("synthetic streaming response cannot flush headers")
+			return
+		}
+		flusher.Flush()
+		timer := time.NewTimer(75 * time.Millisecond)
+		defer timer.Stop()
+		<-timer.C
+		_, _ = io.WriteString(w, "synthetic delayed streaming payload")
+	}))
+	template := fixture.transport(t, server)
+	template.ResponseHeaderTimeout = 20 * time.Millisecond
+	capability := newX509Capability(t, template)
+	request := x509TransportRequest(t, http.MethodGet, "https://"+x509TransportAPI+"/v1/models")
+	response, err := capability.Do(request)
+	if err != nil {
+		t.Fatalf("start bounded-header streaming response: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	body, err := io.ReadAll(response.Body)
+	if err != nil || string(body) != "synthetic delayed streaming payload" {
+		t.Errorf("streaming body beyond header deadline = %q, error=%v", body, err)
+	}
+}

--- a/internal/requestconfig/clone.go
+++ b/internal/requestconfig/clone.go
@@ -7,8 +7,23 @@ import (
 )
 
 func (cfg *RequestConfig) Clone(ctx context.Context) *RequestConfig {
-	clone, _ := cfg.CloneWithError(ctx)
-	return clone
+	clone, err := cfg.CloneWithError(ctx)
+	if err == nil || cfg == nil || cfg.Request == nil || ctx == nil {
+		return clone
+	}
+
+	failed := *cfg
+	failed.Context = ctx
+	failed.Request = cfg.Request.Clone(ctx)
+	failed.Request.Body = nil
+	failed.Request.GetBody = nil
+	failed.Request.ContentLength = 0
+	failed.Body = nil
+	failed.cloneError = err
+	failed.Middlewares = append([]middleware(nil), cfg.Middlewares...)
+	failed.finalizers = append([]requestFinalizer(nil), cfg.finalizers...)
+	failed.authentication = cfg.authentication.cloneAsInherited(&failed)
+	return &failed
 }
 
 // CloneWithError copies request configuration while reporting body-replay
@@ -17,6 +32,9 @@ func (cfg *RequestConfig) Clone(ctx context.Context) *RequestConfig {
 func (cfg *RequestConfig) CloneWithError(ctx context.Context) (*RequestConfig, error) {
 	if cfg == nil {
 		return nil, errors.New("requestconfig: cannot clone a nil request configuration")
+	}
+	if cfg.cloneError != nil {
+		return nil, cfg.cloneError
 	}
 	if cfg.Request == nil {
 		return nil, errors.New("requestconfig: cannot clone a nil request")

--- a/internal/requestconfig/clone.go
+++ b/internal/requestconfig/clone.go
@@ -1,0 +1,52 @@
+package requestconfig
+
+import (
+	"context"
+	"errors"
+	"net/http"
+)
+
+func (cfg *RequestConfig) Clone(ctx context.Context) *RequestConfig {
+	clone, _ := cfg.CloneWithError(ctx)
+	return clone
+}
+
+// CloneWithError copies request configuration while reporting body-replay
+// failures without disclosing request content or caller-supplied errors.
+// This function is internal API and may change without notice.
+func (cfg *RequestConfig) CloneWithError(ctx context.Context) (*RequestConfig, error) {
+	if cfg == nil {
+		return nil, errors.New("requestconfig: cannot clone a nil request configuration")
+	}
+	if cfg.Request == nil {
+		return nil, errors.New("requestconfig: cannot clone a nil request")
+	}
+	if ctx == nil {
+		return nil, errors.New("requestconfig: cannot clone a request without a context")
+	}
+	req := cfg.Request.Clone(ctx)
+	if req.Body != nil && req.Body != http.NoBody {
+		if req.GetBody == nil {
+			return nil, errors.New("requestconfig: cannot clone a non-replayable request body")
+		}
+		body, err := req.GetBody()
+		if err != nil {
+			if body != nil {
+				_ = body.Close()
+			}
+			return nil, errors.New("requestconfig: could not recreate request body")
+		}
+		if body == nil {
+			return nil, errors.New("requestconfig: could not recreate request body")
+		}
+		req.Body = body
+	}
+	clone := *cfg
+	clone.Context = ctx
+	clone.Request = req
+	clone.Middlewares = append([]middleware(nil), cfg.Middlewares...)
+	clone.finalizers = append([]requestFinalizer(nil), cfg.finalizers...)
+	clone.authentication = cfg.authentication.cloneAsInherited(&clone)
+
+	return &clone, nil
+}

--- a/internal/requestconfig/clone_test.go
+++ b/internal/requestconfig/clone_test.go
@@ -52,8 +52,18 @@ func TestCloneWithErrorRejectsNonReplayableRequestBodies(t *testing.T) {
 			if strings.Contains(err.Error(), "synthetic-private") {
 				t.Errorf("clone error disclosed sensitive request or body-factory content: %q", err.Error())
 			}
-			if legacy := cfg.Clone(t.Context()); legacy != nil {
-				t.Errorf("legacy Clone returned %v for an unrecoverable request body", legacy)
+			legacy := cfg.Clone(t.Context())
+			if legacy == nil {
+				t.Fatal("legacy Clone returned nil instead of a safely failed configuration")
+			}
+			if legacy.Request.Body != nil || legacy.Request.GetBody != nil || legacy.Body != nil {
+				t.Error("failed clone retained a caller-owned request body or body factory")
+			}
+			if cloneErr := legacy.Execute(); cloneErr == nil || !strings.Contains(cloneErr.Error(), test.want) {
+				t.Errorf("failed clone Execute error = %v, want %q", cloneErr, test.want)
+			}
+			if descendant := legacy.Clone(t.Context()); descendant == nil || descendant.cloneError == nil {
+				t.Error("failed cloning state was not preserved by a subsequent Clone")
 			}
 		})
 	}

--- a/internal/requestconfig/clone_test.go
+++ b/internal/requestconfig/clone_test.go
@@ -1,0 +1,122 @@
+package requestconfig
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestCloneWithErrorRejectsNonReplayableRequestBodies(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		configure func(*RequestConfig)
+		want      string
+	}{
+		{
+			name: "stream without body factory",
+			configure: func(cfg *RequestConfig) {
+				cfg.Request.Body = io.NopCloser(strings.NewReader("synthetic-private-stream"))
+				cfg.Request.GetBody = nil
+			},
+			want: "non-replayable request body",
+		},
+		{
+			name: "body factory failure is sanitized",
+			configure: func(cfg *RequestConfig) {
+				cfg.Request.Body = io.NopCloser(strings.NewReader("synthetic-private-stream"))
+				cfg.Request.GetBody = func() (io.ReadCloser, error) {
+					return nil, errors.New("synthetic-private-factory-detail")
+				}
+			},
+			want: "could not recreate request body",
+		},
+		{
+			name: "body factory returning nil",
+			configure: func(cfg *RequestConfig) {
+				cfg.Request.Body = io.NopCloser(strings.NewReader("synthetic-private-stream"))
+				cfg.Request.GetBody = func() (io.ReadCloser, error) { return nil, nil }
+			},
+			want: "could not recreate request body",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := newBodyCloseRequestConfig(t, http.NoBody)
+			test.configure(cfg)
+			clone, err := cfg.CloneWithError(t.Context())
+			if clone != nil || err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("clone = %v, error = %v, want nil and %q", clone, err, test.want)
+			}
+			if strings.Contains(err.Error(), "synthetic-private") {
+				t.Errorf("clone error disclosed sensitive request or body-factory content: %q", err.Error())
+			}
+			if legacy := cfg.Clone(t.Context()); legacy != nil {
+				t.Errorf("legacy Clone returned %v for an unrecoverable request body", legacy)
+			}
+		})
+	}
+}
+
+func TestCloneWithErrorRejectsInvalidInputs(t *testing.T) {
+	var missing *RequestConfig
+	if clone, err := missing.CloneWithError(t.Context()); clone != nil || err == nil {
+		t.Errorf("nil configuration clone = %v, error = %v", clone, err)
+	}
+	if clone := missing.Clone(t.Context()); clone != nil {
+		t.Errorf("legacy nil configuration clone = %v, want nil", clone)
+	}
+	if clone, err := (&RequestConfig{}).CloneWithError(t.Context()); clone != nil || err == nil {
+		t.Errorf("nil request clone = %v, error = %v", clone, err)
+	}
+	cfg := newBodyCloseRequestConfig(t, http.NoBody)
+	var absent context.Context
+	if clone, err := cfg.CloneWithError(absent); clone != nil || err == nil {
+		t.Errorf("nil context clone = %v, error = %v", clone, err)
+	}
+}
+
+func TestCloneWithErrorClosesBodyReturnedWithFactoryError(t *testing.T) {
+	cfg := newBodyCloseRequestConfig(t, http.NoBody)
+	cfg.Request.Body = io.NopCloser(strings.NewReader("synthetic-private-stream"))
+	recreated := &closeTrackingReadCloser{
+		ReadCloser: io.NopCloser(strings.NewReader("synthetic-private-recreated-stream")),
+	}
+	cfg.Request.GetBody = func() (io.ReadCloser, error) {
+		return recreated, errors.New("synthetic-private-factory-detail")
+	}
+
+	clone, err := cfg.CloneWithError(t.Context())
+	if clone != nil || err == nil {
+		t.Fatalf("clone = %v, error = %v, want nil and a sanitized body-factory error", clone, err)
+	}
+	if strings.Contains(err.Error(), "synthetic-private") {
+		t.Errorf("clone error disclosed sensitive body-factory content: %q", err.Error())
+	}
+	if recreated.closes != 1 {
+		t.Errorf("failed body-factory result was closed %d times, want once", recreated.closes)
+	}
+}
+
+func TestCloneWithErrorPreservesReplayableBodyAndContext(t *testing.T) {
+	cfg := newBodyCloseRequestConfig(t, http.NoBody)
+	cfg.Request.Body = io.NopCloser(strings.NewReader("synthetic-replayable-body"))
+	cfg.Request.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(strings.NewReader("synthetic-replayable-body")), nil
+	}
+	clone, err := cfg.CloneWithError(t.Context())
+	if err != nil || clone == nil {
+		t.Fatalf("clone replayable request = %v, error = %v", clone, err)
+	}
+	body, readErr := io.ReadAll(clone.Request.Body)
+	if readErr != nil || string(body) != "synthetic-replayable-body" {
+		t.Errorf("cloned request body = %q, error = %v", body, readErr)
+	}
+	if closeErr := clone.Request.Body.Close(); closeErr != nil {
+		t.Errorf("close cloned replayable body: %v", closeErr)
+	}
+	if clone.Request.Context() != t.Context() || clone.Context != t.Context() {
+		t.Error("cloned replayable request did not preserve its selected context")
+	}
+}

--- a/internal/requestconfig/http_header.go
+++ b/internal/requestconfig/http_header.go
@@ -1,0 +1,33 @@
+package requestconfig
+
+// ValidHTTPHeaderName reports whether name contains only HTTP token characters.
+// This is internal API and may change without notice.
+func ValidHTTPHeaderName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for index := 0; index < len(name); index++ {
+		value := name[index]
+		switch {
+		case value >= 'A' && value <= 'Z', value >= 'a' && value <= 'z', value >= '0' && value <= '9':
+		case value == '!', value == '#', value == '$', value == '%', value == '&', value == '\'',
+			value == '*', value == '+', value == '-', value == '.', value == '^', value == '_',
+			value == '`', value == '|', value == '~':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// ValidHTTPHeaderValue reports whether value contains no prohibited HTTP
+// control characters. This is internal API and may change without notice.
+func ValidHTTPHeaderValue(value string) bool {
+	for index := 0; index < len(value); index++ {
+		character := value[index]
+		if character < ' ' && character != '\t' || character == 0x7f {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/requestconfig/http_header_test.go
+++ b/internal/requestconfig/http_header_test.go
@@ -1,0 +1,48 @@
+package requestconfig
+
+import "testing"
+
+func TestValidHTTPHeaderName(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		value string
+		valid bool
+	}{
+		{name: "letters and digits", value: "X-Request-123", valid: true},
+		{name: "all token punctuation", value: "!#$%&'*+-.^_`|~", valid: true},
+		{name: "empty"},
+		{name: "colon", value: "X:Unsafe"},
+		{name: "space", value: "X Unsafe"},
+		{name: "newline", value: "X\nUnsafe"},
+		{name: "non ASCII", value: "X-\xff"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := ValidHTTPHeaderName(test.value); got != test.valid {
+				t.Errorf("ValidHTTPHeaderName(%q) = %v, want %v", test.value, got, test.valid)
+			}
+		})
+	}
+}
+
+func TestValidHTTPHeaderValue(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		value string
+		valid bool
+	}{
+		{name: "empty", valid: true},
+		{name: "printable", value: "Bearer synthetic-token", valid: true},
+		{name: "horizontal tab", value: "first\tsecond", valid: true},
+		{name: "extended bytes", value: "\xff", valid: true},
+		{name: "null", value: "first\x00second"},
+		{name: "carriage return", value: "first\rsecond"},
+		{name: "newline", value: "first\nsecond"},
+		{name: "delete", value: "first\x7fsecond"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := ValidHTTPHeaderValue(test.value); got != test.valid {
+				t.Errorf("ValidHTTPHeaderValue(%q) = %v, want %v", test.value, got, test.valid)
+			}
+		})
+	}
+}

--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -343,6 +343,7 @@ type RequestConfig struct {
 	configuredProviderEndpoint string
 	dataResidencyEndpoint      bool
 	authentication             authenticationState
+	cloneError                 error
 	// DefaultBaseURL will be used if BaseURL is not explicitly overridden using
 	// WithBaseURL.
 	DefaultBaseURL *url.URL
@@ -578,6 +579,9 @@ func WaitForDelay(ctx context.Context, delay time.Duration) error {
 }
 
 func (cfg *RequestConfig) Execute() (err error) {
+	if cfg.cloneError != nil {
+		return cfg.cloneError
+	}
 	if cfg.BaseURL == nil {
 		if cfg.DefaultBaseURL != nil {
 			cfg.BaseURL = cfg.DefaultBaseURL

--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -796,28 +796,6 @@ func ExecuteNewRequest(ctx context.Context, method string, u string, body any, d
 	return cfg.Execute()
 }
 
-func (cfg *RequestConfig) Clone(ctx context.Context) *RequestConfig {
-	if cfg == nil {
-		return nil
-	}
-	req := cfg.Request.Clone(ctx)
-	var err error
-	if req.Body != nil && req.Body != http.NoBody {
-		req.Body, err = req.GetBody()
-	}
-	if err != nil {
-		return nil
-	}
-	clone := *cfg
-	clone.Context = ctx
-	clone.Request = req
-	clone.Middlewares = append([]middleware(nil), cfg.Middlewares...)
-	clone.finalizers = append([]requestFinalizer(nil), cfg.finalizers...)
-	clone.authentication = cfg.authentication.cloneAsInherited(&clone)
-
-	return &clone
-}
-
 func (cfg *RequestConfig) SetHeader(key, value string) {
 	cfg.Request.Header.Set(key, value)
 	cfg.authentication.recordHeader(key)

--- a/option/requestoption.go
+++ b/option/requestoption.go
@@ -378,6 +378,9 @@ func WithWorkloadIdentity(config auth.WorkloadIdentity) RequestOption {
 
 				return auth.WorkloadIdentityMiddleware(wia, httpDoer, req, next)
 			}
+			allowBodyReplay := len(final.Middlewares) == 1
+			final.InstallRequestRetryScope(allowBodyReplay)
+			final.InstallRequestAttemptMiddleware()
 			return nil
 		}).Apply(r)
 	})

--- a/option/requestoption.go
+++ b/option/requestoption.go
@@ -362,6 +362,11 @@ func WithWorkloadIdentity(config auth.WorkloadIdentity) RequestOption {
 				if !workloadIdentityAuth.Selected(final) {
 					return next(req)
 				}
+				if req == nil || requestconfig.RequestRetryScopeFromContext(req.Context()) == nil {
+					return nil, requestconfig.WithNoRetryError(
+						errors.New("workload identity requires its request-owned retry scope"),
+					)
+				}
 				initOnce.Do(func() {
 					wia, initErr = auth.NewWorkloadIdentityAuth(config)
 				})

--- a/option/requestoption.go
+++ b/option/requestoption.go
@@ -2,6 +2,7 @@ package option
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -376,7 +377,13 @@ func WithWorkloadIdentity(config auth.WorkloadIdentity) RequestOption {
 					httpDoer = final.HTTPClient
 				}
 
-				return auth.WorkloadIdentityMiddleware(wia, httpDoer, req, next)
+				response, err := auth.WorkloadIdentityMiddleware(wia, httpDoer, req, next)
+				var oauthError *auth.OAuthError
+				if errors.As(err, &oauthError) && oauthError.ErrorCode != "temporarily_unavailable" &&
+					oauthError.ErrorCode != "server_error" {
+					return response, requestconfig.WithNoRetryError(err)
+				}
+				return response, err
 			}
 			allowBodyReplay := len(final.Middlewares) == 1
 			final.InstallRequestRetryScope(allowBodyReplay)

--- a/option/requestoption.go
+++ b/option/requestoption.go
@@ -349,12 +349,19 @@ func WithWorkloadIdentity(config auth.WorkloadIdentity) RequestOption {
 		if err := workloadIdentityAuth.Apply(r); err != nil {
 			return err
 		}
+		r.ClearInheritedAuthentication()
 		r.SetAPIKey("")
 
 		middlewareIndex := len(r.Middlewares)
 		return requestconfig.WithRequestFinalizer(func(final *requestconfig.RequestConfig) error {
 			if !workloadIdentityAuth.Selected(final) {
 				return nil
+			}
+			if !final.Security.BearerAuth {
+				return errors.New("workload identity cannot authenticate an admin-only API operation")
+			}
+			if final.APIKey != "" || final.AdminAPIKey != "" || final.AuthorizationHeaderOverridden() {
+				return errors.New("workload identity cannot be combined with other Authorization credentials")
 			}
 			final.Middlewares = append(final.Middlewares, nil)
 			copy(final.Middlewares[middlewareIndex+1:], final.Middlewares[middlewareIndex:])

--- a/option/x509workloadidentity.go
+++ b/option/x509workloadidentity.go
@@ -149,11 +149,11 @@ func validX509WorkloadAPIRequest(request *http.Request) bool {
 		return false
 	}
 	for name, values := range request.Header {
-		if !validX509HeaderName(name) {
+		if !requestconfig.ValidHTTPHeaderName(name) {
 			return false
 		}
 		for _, value := range values {
-			if !validX509HeaderValue(value) {
+			if !requestconfig.ValidHTTPHeaderValue(value) {
 				return false
 			}
 		}
@@ -165,31 +165,6 @@ func validX509WorkloadAPIRequest(request *http.Request) bool {
 	}
 	return strings.HasPrefix(request.URL.Path, "/v1/") && strings.HasPrefix(request.URL.EscapedPath(), "/v1/") &&
 		path.Clean(request.URL.Path) == request.URL.Path
-}
-
-func validX509HeaderName(name string) bool {
-	if name == "" {
-		return false
-	}
-	for index := 0; index < len(name); index++ {
-		value := name[index]
-		if value >= 'A' && value <= 'Z' || value >= 'a' && value <= 'z' || value >= '0' && value <= '9' {
-			continue
-		}
-		if !strings.ContainsRune("!#$%&'*+-.^_`|~", rune(value)) {
-			return false
-		}
-	}
-	return true
-}
-
-func validX509HeaderValue(value string) bool {
-	for index := 0; index < len(value); index++ {
-		if value[index] < ' ' && value[index] != '\t' || value[index] == 0x7f {
-			return false
-		}
-	}
-	return true
 }
 
 func unsafeX509CredentialHeaders(headers http.Header) bool {

--- a/packages/pagination/pagination.go
+++ b/packages/pagination/pagination.go
@@ -125,10 +125,7 @@ func (r *CursorPage[T]) GetNextPage() (res *CursorPage[T], err error) {
 		return nil, nil
 	}
 	items := r.Data
-	cfg, err := r.cfg.CloneWithError(r.cfg.Context)
-	if err != nil {
-		return nil, err
-	}
+	cfg := r.cfg.Clone(r.cfg.Context)
 	value := reflect.ValueOf(items[len(items)-1])
 	field := value.FieldByName("ID")
 	err = cfg.Apply(option.WithQuery("after", field.Interface().(string)))
@@ -236,10 +233,7 @@ func (r *ConversationCursorPage[T]) GetNextPage() (res *ConversationCursorPage[T
 	if len(next) == 0 {
 		return nil, nil
 	}
-	cfg, err := r.cfg.CloneWithError(r.cfg.Context)
-	if err != nil {
-		return nil, err
-	}
+	cfg := r.cfg.Clone(r.cfg.Context)
 	err = cfg.Apply(option.WithQuery("after", next))
 	if err != nil {
 		return nil, err
@@ -345,10 +339,7 @@ func (r *NextCursorPage[T]) GetNextPage() (res *NextCursorPage[T], err error) {
 	if len(next) == 0 {
 		return nil, nil
 	}
-	cfg, err := r.cfg.CloneWithError(r.cfg.Context)
-	if err != nil {
-		return nil, err
-	}
+	cfg := r.cfg.Clone(r.cfg.Context)
 	err = cfg.Apply(option.WithQuery("after", next))
 	if err != nil {
 		return nil, err

--- a/packages/pagination/pagination.go
+++ b/packages/pagination/pagination.go
@@ -125,7 +125,10 @@ func (r *CursorPage[T]) GetNextPage() (res *CursorPage[T], err error) {
 		return nil, nil
 	}
 	items := r.Data
-	cfg := r.cfg.Clone(r.cfg.Context)
+	cfg, err := r.cfg.CloneWithError(r.cfg.Context)
+	if err != nil {
+		return nil, err
+	}
 	value := reflect.ValueOf(items[len(items)-1])
 	field := value.FieldByName("ID")
 	err = cfg.Apply(option.WithQuery("after", field.Interface().(string)))
@@ -233,7 +236,10 @@ func (r *ConversationCursorPage[T]) GetNextPage() (res *ConversationCursorPage[T
 	if len(next) == 0 {
 		return nil, nil
 	}
-	cfg := r.cfg.Clone(r.cfg.Context)
+	cfg, err := r.cfg.CloneWithError(r.cfg.Context)
+	if err != nil {
+		return nil, err
+	}
 	err = cfg.Apply(option.WithQuery("after", next))
 	if err != nil {
 		return nil, err
@@ -339,7 +345,10 @@ func (r *NextCursorPage[T]) GetNextPage() (res *NextCursorPage[T], err error) {
 	if len(next) == 0 {
 		return nil, nil
 	}
-	cfg := r.cfg.Clone(r.cfg.Context)
+	cfg, err := r.cfg.CloneWithError(r.cfg.Context)
+	if err != nil {
+		return nil, err
+	}
 	err = cfg.Apply(option.WithQuery("after", next))
 	if err != nil {
 		return nil, err

--- a/pagination_streaming_body_test.go
+++ b/pagination_streaming_body_test.go
@@ -1,0 +1,141 @@
+package openai_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/conversations"
+	"github.com/openai/openai-go/v3/option"
+)
+
+func TestPaginationRejectsNonReplayableStreamingBodies(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		family string
+		auto   bool
+	}{
+		{name: "cursor manual pagination", family: "cursor"},
+		{name: "cursor auto-pagination", family: "cursor", auto: true},
+		{name: "conversation manual pagination", family: "conversation"},
+		{name: "conversation auto-pagination", family: "conversation", auto: true},
+		{name: "next-cursor manual pagination", family: "next"},
+		{name: "next-cursor auto-pagination", family: "next", auto: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var requests atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+				requests.Add(1)
+				if body, err := io.ReadAll(request.Body); err != nil || string(body) != "synthetic-private-stream" {
+					t.Errorf("initial streamed request body = %q, error = %v", body, err)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w,
+					`{"data":[{"id":"synthetic-first","type":"message","role":"user","content":[]}],`+
+						`"has_more":true,"last_id":"synthetic-next","next":"synthetic-next"}`,
+				)
+			}))
+			t.Cleanup(server.Close)
+			client := openai.NewClient(
+				option.WithBaseURL(server.URL+"/v1/"),
+				option.WithAPIKey("synthetic-ordinary-key"),
+				option.WithAdminAPIKey("synthetic-admin-key"),
+				option.WithMaxRetries(0),
+			)
+			body := option.WithRequestBody("application/octet-stream", strings.NewReader("synthetic-private-stream"))
+			var paginationErr error
+			switch test.family {
+			case "cursor":
+				if test.auto {
+					pager := client.Batches.ListAutoPaging(t.Context(), openai.BatchListParams{}, body)
+					if !pager.Next() || pager.Next() {
+						t.Error("cursor auto-pager did not stop safely after its first streamed item")
+					}
+					paginationErr = pager.Err()
+				} else {
+					page, err := client.Batches.List(t.Context(), openai.BatchListParams{}, body)
+					if err != nil {
+						t.Fatalf("load initial cursor page: %v", err)
+					}
+					_, paginationErr = page.GetNextPage()
+				}
+			case "conversation":
+				if test.auto {
+					pager := client.Conversations.Items.ListAutoPaging(
+						t.Context(), "synthetic-conversation", conversations.ItemListParams{}, body,
+					)
+					if !pager.Next() || pager.Next() {
+						t.Error("conversation auto-pager did not stop safely after its first streamed item")
+					}
+					paginationErr = pager.Err()
+				} else {
+					page, err := client.Conversations.Items.List(
+						t.Context(), "synthetic-conversation", conversations.ItemListParams{}, body,
+					)
+					if err != nil {
+						t.Fatalf("load initial conversation page: %v", err)
+					}
+					_, paginationErr = page.GetNextPage()
+				}
+			case "next":
+				if test.auto {
+					pager := client.Admin.Organization.Groups.ListAutoPaging(
+						t.Context(), openai.AdminOrganizationGroupListParams{}, body,
+					)
+					if !pager.Next() || pager.Next() {
+						t.Error("next-cursor auto-pager did not stop safely after its first streamed item")
+					}
+					paginationErr = pager.Err()
+				} else {
+					page, err := client.Admin.Organization.Groups.List(
+						t.Context(), openai.AdminOrganizationGroupListParams{}, body,
+					)
+					if err != nil {
+						t.Fatalf("load initial next-cursor page: %v", err)
+					}
+					_, paginationErr = page.GetNextPage()
+				}
+			}
+			if paginationErr == nil || !strings.Contains(paginationErr.Error(), "non-replayable request body") {
+				t.Errorf("streaming pagination error = %v, want a meaningful non-replayable-body error", paginationErr)
+			}
+			if paginationErr != nil && strings.Contains(paginationErr.Error(), "synthetic-private") {
+				t.Errorf("streaming pagination error disclosed private request data: %q", paginationErr.Error())
+			}
+			if got := requests.Load(); got != 1 {
+				t.Errorf("streaming pagination dispatched %d requests, want only the replayable initial request", got)
+			}
+		})
+	}
+}
+
+func TestX509PaginationRejectsNonReplayableStreamingBodies(t *testing.T) {
+	t.Setenv("OPENAI_BASE_URL", "https://mtls.api.openai.com/v1/")
+	config, issuer, api := newX509WorkloadIdentityIntegration(t)
+	var requests atomic.Int32
+	api.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		requests.Add(1)
+		if body, err := io.ReadAll(request.Body); err != nil || string(body) != "synthetic-private-stream" {
+			t.Errorf("initial mutually authenticated streaming body = %q, error = %v", body, err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":[{"id":"synthetic-first"}],"has_more":true}`)
+	})
+	client := openai.NewClient(option.WithX509WorkloadIdentity(config), option.WithMaxRetries(0))
+	pager := client.Batches.ListAutoPaging(t.Context(), openai.BatchListParams{},
+		option.WithRequestBody("application/octet-stream", strings.NewReader("synthetic-private-stream")))
+	if !pager.Next() || pager.Next() {
+		t.Error("mutually authenticated auto-pager did not stop after its first streamed item")
+	}
+	if err := pager.Err(); err == nil || !strings.Contains(err.Error(), "non-replayable request body") {
+		t.Errorf("mutually authenticated streaming pagination error = %v", err)
+	}
+	if requests.Load() != 1 || len(issuer.requests()) != 1 {
+		t.Errorf("streaming X.509 pagination API/issuer calls = %d/%d, want 1/1",
+			requests.Load(), len(issuer.requests()))
+	}
+}

--- a/workload_identity_hardening_test.go
+++ b/workload_identity_hardening_test.go
@@ -1,6 +1,7 @@
 package openai_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -83,6 +84,134 @@ func TestWorkloadIdentityUnauthorizedRecoveryRunsCompleteMiddlewareChain(t *test
 					test.wantAttempts, test.wantAttempts, test.wantIssuerCalls)
 			}
 		})
+	}
+}
+
+func TestWorkloadIdentityRejectsRequestsWithoutOwnedRetryScope(t *testing.T) {
+	for _, test := range []struct {
+		name           string
+		maximumRetries int
+		nilRequest     bool
+	}{
+		{name: "caller removes retry scope with retries disabled"},
+		{name: "caller removes retry scope with retries enabled", maximumRetries: 2},
+		{name: "caller replaces request with nil", maximumRetries: 2, nilRequest: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var issuerCalls, apiCalls, middlewareCalls int
+			httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+				if req.URL.Host == "auth.openai.com" {
+					issuerCalls++
+					return rootWorkloadResponse(http.StatusOK,
+						`{"access_token":"synthetic-private-bearer","expires_in":3600}`), nil
+				}
+				apiCalls++
+				return rootWorkloadResponse(http.StatusOK, `{"data":[]}`), nil
+			}}}
+			provider := &mockSubjectTokenProvider{
+				token: "synthetic-subject", tokenType: auth.SubjectTokenTypeJWT,
+			}
+			client := openai.NewClient(
+				option.WithHTTPClient(httpClient),
+				option.WithMaxRetries(test.maximumRetries),
+				option.WithMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+					middlewareCalls++
+					if test.nilRequest {
+						return next(nil)
+					}
+					return next(req.WithContext(context.Background()))
+				}),
+				option.WithWorkloadIdentity(testWorkloadIdentity(provider)),
+			)
+
+			_, err := client.Models.List(t.Context())
+			if err == nil || !strings.Contains(err.Error(), "request-owned retry scope") {
+				t.Fatalf("missing request-owned scope error=%v", err)
+			}
+			if issuerCalls != 0 || apiCalls != 0 || middlewareCalls != 1 {
+				t.Errorf("issuer/API/middleware attempts=%d/%d/%d, want 0/0/1",
+					issuerCalls, apiCalls, middlewareCalls)
+			}
+		})
+	}
+}
+
+func TestWorkloadIdentitySendsExactlyOneTrustedAuthorizationHeader(t *testing.T) {
+	var issuerCalls, apiCalls, middlewareCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if req.URL.Path == "/oauth/token" {
+			call := issuerCalls.Add(1)
+			_, _ = fmt.Fprintf(w, `{"access_token":"synthetic-trusted-bearer-%d","expires_in":3600}`, call)
+			return
+		}
+		call := apiCalls.Add(1)
+		values := req.Header.Values("Authorization")
+		want := fmt.Sprintf("Bearer synthetic-trusted-bearer-%d", call)
+		if len(values) != 1 || values[0] != want {
+			t.Errorf("real-wire API attempt %d Authorization values=%q, want exactly %q", call, values, want)
+		}
+		if call == 1 {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = io.WriteString(w, `{"error":{"message":"synthetic rejected bearer"}}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"data":[]}`)
+	}))
+	t.Cleanup(server.Close)
+	httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+		if req.URL.Host == "auth.openai.com" {
+			req = req.Clone(req.Context())
+			req.URL.Scheme = "http"
+			req.URL.Host = server.Listener.Addr().String()
+		}
+		return http.DefaultTransport.RoundTrip(req)
+	}}}
+	provider := &mockSubjectTokenProvider{
+		token: "synthetic-subject", tokenType: auth.SubjectTokenTypeJWT,
+	}
+	var captured *http.Response
+	client := openai.NewClient(
+		option.WithBaseURL(server.URL+"/v1/"),
+		option.WithHTTPClient(httpClient),
+		option.WithMaxRetries(1),
+		option.WithMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+			middlewareCalls.Add(1)
+			req.Header["Authorization"] = []string{"Bearer synthetic-canonical-attacker", "Bearer synthetic-extra-attacker"}
+			req.Header["authorization"] = []string{"Bearer synthetic-lowercase-attacker"}
+			req.Header["aUtHoRiZaTiOn"] = []string{"Bearer synthetic-mixed-case-attacker"}
+			response, err := next(req)
+			if len(req.Header["Authorization"]) != 2 || len(req.Header["authorization"]) != 1 ||
+				len(req.Header["aUtHoRiZaTiOn"]) != 1 {
+				t.Error("signer modified caller-owned request credentials")
+			}
+			if response != nil && response.Request != nil {
+				for name := range response.Request.Header {
+					if strings.EqualFold(strings.ReplaceAll(name, "_", "-"), "authorization") {
+						t.Errorf("outer middleware observed response authorization alias %q", name)
+					}
+				}
+			}
+			return response, err
+		}),
+		option.WithWorkloadIdentity(testWorkloadIdentity(provider)),
+	)
+
+	_, err := client.Models.List(t.Context(), option.WithResponseInto(&captured))
+	if err != nil {
+		t.Fatalf("public workload authentication with ambiguous credentials: %v", err)
+	}
+	if issuerCalls.Load() != 2 || apiCalls.Load() != 2 || middlewareCalls.Load() != 2 {
+		t.Errorf("issuer/API/middleware attempts=%d/%d/%d, want 2/2/2",
+			issuerCalls.Load(), apiCalls.Load(), middlewareCalls.Load())
+	}
+	if captured == nil || captured.Request == nil {
+		t.Fatal("public response did not preserve its unsigned request metadata")
+	}
+	for name := range captured.Request.Header {
+		if strings.EqualFold(strings.ReplaceAll(name, "_", "-"), "authorization") {
+			t.Errorf("WithResponseInto exposed authorization alias %q", name)
+		}
 	}
 }
 

--- a/workload_identity_hardening_test.go
+++ b/workload_identity_hardening_test.go
@@ -181,9 +181,22 @@ func TestWorkloadIdentitySendsExactlyOneTrustedAuthorizationHeader(t *testing.T)
 			req.Header["authorization"] = []string{"Bearer synthetic-lowercase-attacker"}
 			req.Header["aUtHoRiZaTiOn"] = []string{"Bearer synthetic-mixed-case-attacker"}
 			response, err := next(req)
-			if len(req.Header["Authorization"]) != 2 || len(req.Header["authorization"]) != 1 ||
-				len(req.Header["aUtHoRiZaTiOn"]) != 1 {
-				t.Error("signer modified caller-owned request credentials")
+			var callerAuthorizationHeaders int
+			for name, values := range req.Header {
+				if !strings.EqualFold(strings.ReplaceAll(name, "_", "-"), "authorization") {
+					continue
+				}
+				callerAuthorizationHeaders++
+				want := 1
+				if name == "Authorization" {
+					want = 2
+				}
+				if len(values) != want {
+					t.Errorf("caller-owned authorization header %q values=%q, want %d", name, values, want)
+				}
+			}
+			if callerAuthorizationHeaders != 3 {
+				t.Errorf("caller-owned authorization headers=%d, want three", callerAuthorizationHeaders)
 			}
 			if response != nil && response.Request != nil {
 				for name := range response.Request.Header {

--- a/workload_identity_hardening_test.go
+++ b/workload_identity_hardening_test.go
@@ -1,10 +1,13 @@
 package openai_test
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -152,6 +155,167 @@ func TestWorkloadIdentityNeverReplaysCallerTransformedBody(t *testing.T) {
 			if apiAttempts != test.wantAttempts || middlewareCalls != test.wantAttempts {
 				t.Errorf("API/middleware attempts=%d/%d, want %d/%d",
 					apiAttempts, middlewareCalls, test.wantAttempts, test.wantAttempts)
+			}
+		})
+	}
+}
+
+func TestWorkloadIdentityNeverExposesSignedResponseMetadata(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		status        int
+		unauthorized  bool
+		wantAPICalls  int32
+		wantClientErr bool
+	}{
+		{name: "successful response", status: http.StatusOK, wantAPICalls: 1},
+		{name: "API error response", status: http.StatusForbidden, wantAPICalls: 1, wantClientErr: true},
+		{name: "unauthorized outer retry", status: http.StatusOK, unauthorized: true, wantAPICalls: 2},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var issuerCalls, apiCalls, observed atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if req.URL.Path == "/oauth/token" {
+					call := issuerCalls.Add(1)
+					_, _ = fmt.Fprintf(w, `{"access_token":"synthetic-private-bearer-%d","expires_in":3600}`, call)
+					return
+				}
+				call := apiCalls.Add(1)
+				if got, want := req.Header.Get("Authorization"),
+					fmt.Sprintf("Bearer synthetic-private-bearer-%d", call); got != want {
+					t.Errorf("real-wire API attempt %d Authorization=%q, want %q", call, got, want)
+				}
+				status := test.status
+				if test.unauthorized && call == 1 {
+					status = http.StatusUnauthorized
+				}
+				w.WriteHeader(status)
+				if status >= http.StatusBadRequest {
+					_, _ = io.WriteString(w, `{"error":{"message":"synthetic API failure"}}`)
+					return
+				}
+				_, _ = io.WriteString(w, `{"data":[]}`)
+			}))
+			t.Cleanup(server.Close)
+			httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+				if req.URL.Host == "auth.openai.com" {
+					req = req.Clone(req.Context())
+					req.URL.Scheme = "http"
+					req.URL.Host = server.Listener.Addr().String()
+				}
+				return http.DefaultTransport.RoundTrip(req)
+			}}}
+			provider := &mockSubjectTokenProvider{
+				token: "synthetic-subject", tokenType: auth.SubjectTokenTypeJWT,
+			}
+			var captured *http.Response
+			client := openai.NewClient(
+				option.WithBaseURL(server.URL+"/v1/"),
+				option.WithHTTPClient(httpClient),
+				option.WithMaxRetries(1),
+				option.WithMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+					if got := req.Header.Get("Authorization"); got != "" {
+						t.Errorf("outer caller request exposed credentials before authentication: %q", got)
+					}
+					response, err := next(req)
+					if got := req.Header.Get("Authorization"); got != "" {
+						t.Errorf("ordinary signer modified caller-owned request headers: %q", got)
+					}
+					if response != nil && response.Request != nil {
+						observed.Add(1)
+						if got := response.Request.Header.Get("Authorization"); got != "" {
+							t.Errorf("outer caller observed response bearer credentials: %q", got)
+						}
+					}
+					return response, err
+				}),
+				option.WithWorkloadIdentity(testWorkloadIdentity(provider)),
+			)
+			_, err := client.Models.List(t.Context(), option.WithResponseInto(&captured))
+			if (err != nil) != test.wantClientErr {
+				t.Errorf("public workload request error=%v, want error=%t", err, test.wantClientErr)
+			}
+			if captured == nil || captured.Request == nil {
+				t.Fatal("WithResponseInto did not preserve its response and request metadata")
+			}
+			if got := captured.Request.Header.Get("Authorization"); got != "" {
+				t.Errorf("WithResponseInto exposed private bearer credentials: %q", got)
+			}
+			if got := apiCalls.Load(); got != test.wantAPICalls {
+				t.Errorf("real-wire API requests=%d, want %d", got, test.wantAPICalls)
+			}
+			if got := observed.Load(); got != test.wantAPICalls {
+				t.Errorf("outer caller response observations=%d, want %d", got, test.wantAPICalls)
+			}
+		})
+	}
+}
+
+func TestWorkloadIdentityRetriesOnlyTransientIssuerOAuthFailures(t *testing.T) {
+	for _, test := range []struct {
+		name            string
+		status          int
+		code            string
+		transient       bool
+		wantIssuerCalls int32
+	}{
+		{name: "permanent bad request", status: http.StatusBadRequest,
+			code: "invalid_grant", wantIssuerCalls: 1},
+		{name: "permanent unauthorized", status: http.StatusUnauthorized,
+			code: "invalid_client", wantIssuerCalls: 1},
+		{name: "permanent forbidden", status: http.StatusForbidden,
+			code: "access_denied", wantIssuerCalls: 1},
+		{name: "unknown OAuth rejection", status: http.StatusBadRequest,
+			code: "synthetic-unknown-code", wantIssuerCalls: 1},
+		{name: "temporarily unavailable", status: http.StatusBadRequest,
+			code: "temporarily_unavailable", transient: true, wantIssuerCalls: 2},
+		{name: "temporary server error", status: http.StatusForbidden,
+			code: "server_error", transient: true, wantIssuerCalls: 2},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var issuerCalls, apiCalls atomic.Int32
+			httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+				if req.URL.Host == "auth.openai.com" {
+					call := issuerCalls.Add(1)
+					if !test.transient || call == 1 {
+						return rootWorkloadResponse(test.status,
+							fmt.Sprintf(`{"error":%q,"error_description":"synthetic-private-description"}`, test.code)), nil
+					}
+					return rootWorkloadResponse(http.StatusOK,
+						`{"access_token":"synthetic-refreshed-bearer","expires_in":3600}`), nil
+				}
+				apiCalls.Add(1)
+				return rootWorkloadResponse(http.StatusOK, `{"data":[]}`), nil
+			}}}
+			provider := &mockSubjectTokenProvider{
+				token: "synthetic-subject", tokenType: auth.SubjectTokenTypeJWT,
+			}
+			client := openai.NewClient(
+				option.WithWorkloadIdentity(testWorkloadIdentity(provider)),
+				option.WithHTTPClient(httpClient),
+				option.WithMaxRetries(2),
+				option.WithMaxRetryDelay(time.Millisecond),
+			)
+			_, err := client.Models.List(t.Context())
+			if test.transient {
+				if err != nil || apiCalls.Load() != 1 {
+					t.Errorf("transient OAuth recovery error=%v API requests=%d", err, apiCalls.Load())
+				}
+			} else {
+				var oauthError *auth.OAuthError
+				if !errors.As(err, &oauthError) || oauthError.StatusCode != test.status {
+					t.Errorf("permanent OAuth error lost its typed public status: %v", err)
+				}
+				if err != nil && strings.Contains(err.Error(), "synthetic-private-description") {
+					t.Error("permanent OAuth error exposed its issuer description")
+				}
+				if apiCalls.Load() != 0 {
+					t.Errorf("permanently rejected workload dispatched %d API requests", apiCalls.Load())
+				}
+			}
+			if got := issuerCalls.Load(); got != test.wantIssuerCalls {
+				t.Errorf("issuer exchanges=%d, want %d", got, test.wantIssuerCalls)
 			}
 		})
 	}

--- a/workload_identity_hardening_test.go
+++ b/workload_identity_hardening_test.go
@@ -136,6 +136,305 @@ func TestWorkloadIdentityRejectsRequestsWithoutOwnedRetryScope(t *testing.T) {
 	}
 }
 
+func TestWorkloadIdentityPreservesExplicitCredentialOptionPrecedence(t *testing.T) {
+	deleted := option.WithHeaderDel("Authorization")
+	explicit := option.WithHeader("Authorization", "Bearer synthetic-explicit-credential")
+	apiKey := option.WithAPIKey("synthetic-explicit-api-key")
+	adminKey := option.WithAdminAPIKey("synthetic-explicit-admin-key")
+	for _, test := range []struct {
+		name           string
+		clientBefore   []option.RequestOption
+		clientAfter    []option.RequestOption
+		requestBefore  []option.RequestOption
+		requestAfter   []option.RequestOption
+		methodIdentity bool
+		rejected       bool
+	}{
+		{name: "ambient inherited credentials are replaced"},
+		{name: "earlier same-layer API key is replaced", clientBefore: []option.RequestOption{apiKey}},
+		{name: "later same-layer API key conflicts", clientAfter: []option.RequestOption{apiKey}, rejected: true},
+		{name: "earlier same-layer admin key conflicts", clientBefore: []option.RequestOption{adminKey}, rejected: true},
+		{name: "later same-layer admin key conflicts", clientAfter: []option.RequestOption{adminKey}, rejected: true},
+		{name: "earlier same-layer header deletion conflicts", clientBefore: []option.RequestOption{deleted}, rejected: true},
+		{name: "later same-layer header deletion conflicts", clientAfter: []option.RequestOption{deleted}, rejected: true},
+		{name: "earlier same-layer explicit header conflicts", clientBefore: []option.RequestOption{explicit}, rejected: true},
+		{name: "later same-layer explicit header conflicts", clientAfter: []option.RequestOption{explicit}, rejected: true},
+		{name: "method header deletion conflicts", requestAfter: []option.RequestOption{deleted}, rejected: true},
+		{name: "method explicit header conflicts", requestAfter: []option.RequestOption{explicit}, rejected: true},
+		{name: "method API key conflicts", requestAfter: []option.RequestOption{apiKey}, rejected: true},
+		{name: "method admin key conflicts", requestAfter: []option.RequestOption{adminKey}, rejected: true},
+		{name: "method workload replaces inherited header deletion", clientBefore: []option.RequestOption{deleted}, methodIdentity: true},
+		{name: "method workload replaces inherited explicit header", clientBefore: []option.RequestOption{explicit}, methodIdentity: true},
+		{name: "method workload replaces inherited API key", clientBefore: []option.RequestOption{apiKey}, methodIdentity: true},
+		{name: "method workload replaces inherited admin key", clientBefore: []option.RequestOption{adminKey}, methodIdentity: true},
+		{name: "earlier method header deletion conflicts", requestBefore: []option.RequestOption{deleted}, methodIdentity: true, rejected: true},
+		{name: "later method header deletion conflicts", requestAfter: []option.RequestOption{deleted}, methodIdentity: true, rejected: true},
+		{name: "earlier method explicit header conflicts", requestBefore: []option.RequestOption{explicit}, methodIdentity: true, rejected: true},
+		{name: "later method explicit header conflicts", requestAfter: []option.RequestOption{explicit}, methodIdentity: true, rejected: true},
+		{name: "earlier method API key is replaced", requestBefore: []option.RequestOption{apiKey}, methodIdentity: true},
+		{name: "later method API key conflicts", requestAfter: []option.RequestOption{apiKey}, methodIdentity: true, rejected: true},
+		{name: "earlier method admin key conflicts", requestBefore: []option.RequestOption{adminKey}, methodIdentity: true, rejected: true},
+		{name: "later method admin key conflicts", requestAfter: []option.RequestOption{adminKey}, methodIdentity: true, rejected: true},
+		{name: "empty API key cannot erase explicit header deletion",
+			requestAfter: []option.RequestOption{deleted, option.WithAPIKey("")}, rejected: true},
+		{name: "unrelated explicit header remains compatible",
+			requestAfter: []option.RequestOption{option.WithHeader("X-Synthetic-Metadata", "preserved")}},
+		{name: "unrelated header deletion remains compatible",
+			requestAfter: []option.RequestOption{option.WithHeaderDel("X-Synthetic-Metadata")}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("OPENAI_API_KEY", "synthetic-ambient-api-key")
+			t.Setenv("OPENAI_ADMIN_KEY", "synthetic-ambient-admin-key")
+			t.Setenv("OPENAI_CUSTOM_HEADERS", "")
+			var issuerCalls, apiCalls int
+			httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+				if req.URL.Host == "auth.openai.com" {
+					issuerCalls++
+					return rootWorkloadResponse(http.StatusOK,
+						`{"access_token":"synthetic-workload-bearer","expires_in":3600}`), nil
+				}
+				apiCalls++
+				if got := req.Header.Values("Authorization"); len(got) != 1 ||
+					got[0] != "Bearer synthetic-workload-bearer" {
+					t.Errorf("API Authorization values=%q, want only the selected workload bearer", got)
+				}
+				return rootWorkloadResponse(http.StatusOK, `{"data":[]}`), nil
+			}}}
+			provider := &mockSubjectTokenProvider{
+				token: "synthetic-subject", tokenType: auth.SubjectTokenTypeJWT,
+			}
+			identity := option.WithWorkloadIdentity(testWorkloadIdentity(provider))
+			clientOptions := []option.RequestOption{option.WithHTTPClient(httpClient), option.WithMaxRetries(0)}
+			clientOptions = append(clientOptions, test.clientBefore...)
+			if !test.methodIdentity {
+				clientOptions = append(clientOptions, identity)
+			}
+			clientOptions = append(clientOptions, test.clientAfter...)
+			client := openai.NewClient(clientOptions...)
+			requestOptions := append([]option.RequestOption(nil), test.requestBefore...)
+			if test.methodIdentity {
+				requestOptions = append(requestOptions, identity)
+			}
+			requestOptions = append(requestOptions, test.requestAfter...)
+
+			_, err := client.Models.List(t.Context(), requestOptions...)
+			if test.rejected {
+				if err == nil || !strings.Contains(err.Error(), "cannot be combined") {
+					t.Errorf("conflicting workload credential error=%v", err)
+				}
+				if issuerCalls != 0 || apiCalls != 0 {
+					t.Errorf("conflicting credentials reached issuer/API %d/%d times, want 0/0", issuerCalls, apiCalls)
+				}
+				return
+			}
+			if err != nil || issuerCalls != 1 || apiCalls != 1 {
+				t.Errorf("selected workload authentication error=%v issuer/API=%d/%d, want nil and 1/1",
+					err, issuerCalls, apiCalls)
+			}
+		})
+	}
+}
+
+func TestWorkloadIdentityRejectsAdminOnlyOperationsBeforeTokenExchange(t *testing.T) {
+	var issuerCalls, apiCalls int
+	httpClient := &http.Client{Transport: &closureTransport{fn: func(request *http.Request) (*http.Response, error) {
+		if request.URL.Host == "auth.openai.com" {
+			issuerCalls++
+			return rootWorkloadResponse(http.StatusOK,
+				`{"access_token":"synthetic-workload-bearer","expires_in":3600}`), nil
+		}
+		apiCalls++
+		return rootWorkloadResponse(http.StatusOK, `{}`), nil
+	}}}
+	provider := &mockSubjectTokenProvider{
+		token: "synthetic-subject", tokenType: auth.SubjectTokenTypeJWT,
+	}
+	client := openai.NewClient(
+		option.WithHTTPClient(httpClient),
+		option.WithWorkloadIdentity(testWorkloadIdentity(provider)),
+		option.WithMaxRetries(2),
+	)
+
+	_, err := client.Admin.Organization.DataRetention.Get(t.Context())
+	if err == nil || !strings.Contains(err.Error(), "admin-only API operation") {
+		t.Fatalf("ordinary workload identity authenticated an admin-only operation: %v", err)
+	}
+	if issuerCalls != 0 || apiCalls != 0 {
+		t.Errorf("admin-only workload issuer/API requests=%d/%d, want 0/0", issuerCalls, apiCalls)
+	}
+}
+
+func TestWorkloadIdentityCloudMetadataFailuresRemainPrivate(t *testing.T) {
+	for _, provider := range []struct {
+		name     string
+		identity string
+		new      func() auth.SubjectTokenProvider
+	}{
+		{name: "Azure", identity: "azure-imds", new: func() auth.SubjectTokenProvider {
+			return auth.AzureManagedIdentityTokenProvider(nil)
+		}},
+		{name: "GCP", identity: "gcp-metadata", new: func() auth.SubjectTokenProvider {
+			return auth.GCPIDTokenProvider(nil)
+		}},
+	} {
+		for _, failure := range []struct {
+			name      string
+			redirect  bool
+			oversized bool
+		}{
+			{name: "private unsuccessful metadata response"},
+			{name: "oversized unsuccessful metadata response", oversized: true},
+			{name: "cross-origin metadata redirect", redirect: true},
+		} {
+			t.Run(provider.name+" "+failure.name, func(t *testing.T) {
+				var metadataCalls, issuerCalls, apiCalls, redirectedCalls atomic.Int32
+				target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					redirectedCalls.Add(1)
+					_, _ = io.WriteString(w, "synthetic-attacker-subject-token")
+				}))
+				t.Cleanup(target.Close)
+				metadata := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					metadataCalls.Add(1)
+					if failure.redirect {
+						w.Header().Set("Location", target.URL+"/steal?credential=synthetic-private-metadata")
+						w.WriteHeader(http.StatusTemporaryRedirect)
+						return
+					}
+					w.WriteHeader(http.StatusUnauthorized)
+					body := `{"access_token":"synthetic-private-metadata-token"}`
+					if failure.oversized {
+						body = strings.Repeat("a", (4<<10)+1)
+					}
+					_, _ = io.WriteString(w, body)
+				}))
+				t.Cleanup(metadata.Close)
+				httpClient := &http.Client{Transport: &closureTransport{fn: func(request *http.Request) (*http.Response, error) {
+					switch request.URL.Host {
+					case "169.254.169.254", "metadata.google.internal":
+						request = request.Clone(request.Context())
+						request.URL.Scheme = "http"
+						request.URL.Host = metadata.Listener.Addr().String()
+						return http.DefaultTransport.RoundTrip(request)
+					case "auth.openai.com":
+						issuerCalls.Add(1)
+						return rootWorkloadResponse(http.StatusOK,
+							`{"access_token":"synthetic-workload-bearer","expires_in":3600}`), nil
+					default:
+						apiCalls.Add(1)
+						return rootWorkloadResponse(http.StatusOK, `{"data":[]}`), nil
+					}
+				}}}
+				retries := 0
+				if failure.redirect {
+					retries = 2
+				}
+				client := openai.NewClient(
+					option.WithHTTPClient(httpClient),
+					option.WithWorkloadIdentity(auth.WorkloadIdentity{
+						IdentityProviderID: "synthetic-provider",
+						ServiceAccountID:   "synthetic-account",
+						Provider:           provider.new(),
+					}),
+					option.WithMaxRetries(retries),
+				)
+
+				_, err := client.Models.List(t.Context())
+				var typed *auth.SubjectTokenProviderError
+				if !errors.As(err, &typed) || typed.Provider != provider.identity {
+					t.Fatalf("public metadata failure lost its provider identity: %v", err)
+				}
+				if strings.Contains(err.Error(), "synthetic-private") || strings.Contains(err.Error(), target.URL) {
+					t.Errorf("public metadata failure exposed credentials: %q", err.Error())
+				}
+				if failure.redirect && !strings.Contains(err.Error(), "does not follow redirects") {
+					t.Errorf("public metadata redirect error=%v", err)
+				}
+				if failure.oversized && !strings.Contains(err.Error(), "size limit") {
+					t.Errorf("public oversized metadata error=%v", err)
+				}
+				if metadataCalls.Load() != 1 || issuerCalls.Load() != 0 || apiCalls.Load() != 0 ||
+					redirectedCalls.Load() != 0 {
+					t.Errorf("metadata/issuer/API/redirect requests=%d/%d/%d/%d, want 1/0/0/0",
+						metadataCalls.Load(), issuerCalls.Load(), apiCalls.Load(), redirectedCalls.Load())
+				}
+			})
+		}
+	}
+}
+
+func TestWorkloadIdentityNeverFollowsIssuerRedirects(t *testing.T) {
+	for _, status := range []int{
+		http.StatusMovedPermanently,
+		http.StatusFound,
+		http.StatusSeeOther,
+		http.StatusTemporaryRedirect,
+		http.StatusPermanentRedirect,
+	} {
+		t.Run(fmt.Sprintf("HTTP %d", status), func(t *testing.T) {
+			var issuerCalls, apiCalls, redirectedCalls, callerRedirectChecks atomic.Int32
+			target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				redirectedCalls.Add(1)
+				_, _ = io.WriteString(w, `{"access_token":"synthetic-attacker-bearer","expires_in":3600}`)
+			}))
+			t.Cleanup(target.Close)
+			issuer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+				if request.URL.Path != "/oauth/token" {
+					apiCalls.Add(1)
+					_, _ = io.WriteString(w, `{"data":[]}`)
+					return
+				}
+				issuerCalls.Add(1)
+				body, err := io.ReadAll(request.Body)
+				if err != nil || !strings.Contains(string(body), "synthetic-private-subject") {
+					t.Errorf("original issuer subject token body=%q error=%v", body, err)
+				}
+				w.Header().Set("Location", target.URL+"/steal?credential=synthetic-private-destination")
+				w.WriteHeader(status)
+			}))
+			t.Cleanup(issuer.Close)
+			caller := &http.Client{
+				Transport: &closureTransport{fn: func(request *http.Request) (*http.Response, error) {
+					if request.URL.Host == "auth.openai.com" {
+						request = request.Clone(request.Context())
+						request.URL.Scheme = "http"
+						request.URL.Host = issuer.Listener.Addr().String()
+					}
+					return http.DefaultTransport.RoundTrip(request)
+				}},
+				CheckRedirect: func(*http.Request, []*http.Request) error {
+					callerRedirectChecks.Add(1)
+					return nil
+				},
+			}
+			provider := &mockSubjectTokenProvider{
+				token: "synthetic-private-subject", tokenType: auth.SubjectTokenTypeJWT,
+			}
+			client := openai.NewClient(
+				option.WithBaseURL(issuer.URL+"/v1/"),
+				option.WithHTTPClient(caller),
+				option.WithWorkloadIdentity(testWorkloadIdentity(provider)),
+				option.WithMaxRetries(2),
+			)
+
+			_, err := client.Models.List(t.Context())
+			if err == nil || !strings.Contains(err.Error(), "does not follow redirects") {
+				t.Fatalf("redirected public token exchange error=%v", err)
+			}
+			if strings.Contains(err.Error(), "synthetic-private") || strings.Contains(err.Error(), target.URL) {
+				t.Errorf("redirect error exposed its private destination or subject token: %q", err.Error())
+			}
+			if issuerCalls.Load() != 1 || apiCalls.Load() != 0 || redirectedCalls.Load() != 0 ||
+				callerRedirectChecks.Load() != 0 {
+				t.Errorf("issuer/API/redirect/caller-policy requests=%d/%d/%d/%d, want 1/0/0/0",
+					issuerCalls.Load(), apiCalls.Load(), redirectedCalls.Load(), callerRedirectChecks.Load())
+			}
+			if caller.CheckRedirect == nil {
+				t.Error("issuer exchange modified its caller-owned native HTTP client")
+			}
+		})
+	}
+}
+
 func TestWorkloadIdentitySendsExactlyOneTrustedAuthorizationHeader(t *testing.T) {
 	var issuerCalls, apiCalls, middlewareCalls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {

--- a/workload_identity_hardening_test.go
+++ b/workload_identity_hardening_test.go
@@ -1,0 +1,166 @@
+package openai_test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	openai "github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/auth"
+	"github.com/openai/openai-go/v3/option"
+)
+
+func TestWorkloadIdentityUnauthorizedRecoveryRunsCompleteMiddlewareChain(t *testing.T) {
+	for _, test := range []struct {
+		name            string
+		callerFirst     bool
+		maximumRetries  int
+		wantAttempts    int
+		wantIssuerCalls int
+	}{
+		{name: "middleware before authentication", callerFirst: true,
+			maximumRetries: 1, wantAttempts: 2, wantIssuerCalls: 2},
+		{name: "middleware after authentication", maximumRetries: 1,
+			wantAttempts: 2, wantIssuerCalls: 2},
+		{name: "disabled retries", callerFirst: true,
+			maximumRetries: 0, wantAttempts: 1, wantIssuerCalls: 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var apiAttempts, issuerCalls, middlewareCalls int
+			httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+				if req.URL.Host == "auth.openai.com" {
+					issuerCalls++
+					return rootWorkloadResponse(http.StatusOK,
+						fmt.Sprintf(`{"access_token":"synthetic-bearer-%d","expires_in":3600}`, issuerCalls)), nil
+				}
+				apiAttempts++
+				if got, want := req.Header.Get("X-Synthetic-Attempt"), fmt.Sprintf("attempt-%d", apiAttempts); got != want {
+					t.Errorf("API attempt %d caller header=%q, want %q", apiAttempts, got, want)
+				}
+				if apiAttempts == 1 {
+					return rootWorkloadResponse(http.StatusUnauthorized,
+						`{"error":{"message":"synthetic rejected bearer"}}`), nil
+				}
+				return rootWorkloadResponse(http.StatusOK, `{"data":[]}`), nil
+			}}}
+			provider := &mockSubjectTokenProvider{
+				token: "synthetic-subject", tokenType: auth.SubjectTokenTypeJWT,
+			}
+			caller := option.WithMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+				middlewareCalls++
+				req.Header.Set("X-Synthetic-Attempt", fmt.Sprintf("attempt-%d", middlewareCalls))
+				return next(req)
+			})
+			identity := option.WithWorkloadIdentity(testWorkloadIdentity(provider))
+			opts := []option.RequestOption{
+				option.WithHTTPClient(httpClient), option.WithMaxRetries(test.maximumRetries),
+				option.WithMaxRetryDelay(time.Millisecond),
+			}
+			if test.callerFirst {
+				opts = append(opts, caller, identity)
+			} else {
+				opts = append(opts, identity, caller)
+			}
+			client := openai.NewClient(opts...)
+			_, err := client.Models.List(t.Context())
+			if test.maximumRetries == 0 {
+				if err == nil {
+					t.Error("unauthorized request exceeded its zero retry budget")
+				}
+			} else if err != nil {
+				t.Fatalf("complete unauthorized recovery: %v", err)
+			}
+			if apiAttempts != test.wantAttempts || middlewareCalls != test.wantAttempts ||
+				issuerCalls != test.wantIssuerCalls {
+				t.Errorf("API/middleware/issuer attempts=%d/%d/%d, want %d/%d/%d",
+					apiAttempts, middlewareCalls, issuerCalls,
+					test.wantAttempts, test.wantAttempts, test.wantIssuerCalls)
+			}
+		})
+	}
+}
+
+func TestWorkloadIdentityNeverReplaysCallerTransformedBody(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		remove       bool
+		wantAttempts int
+	}{
+		{name: "transformed body", wantAttempts: 1},
+		{name: "explicitly removed body remains empty", remove: true, wantAttempts: 2},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var apiAttempts, middlewareCalls int
+			httpClient := &http.Client{Transport: &closureTransport{fn: func(req *http.Request) (*http.Response, error) {
+				if req.URL.Host == "auth.openai.com" {
+					return rootWorkloadResponse(http.StatusOK,
+						`{"access_token":"synthetic-bearer","expires_in":3600}`), nil
+				}
+				apiAttempts++
+				var payload []byte
+				if req.Body != nil {
+					var readErr error
+					payload, readErr = io.ReadAll(req.Body)
+					if readErr != nil {
+						t.Fatalf("read caller-transformed request body: %v", readErr)
+					}
+				}
+				if test.remove && len(payload) != 0 {
+					t.Error("caller-removed payload was restored on an outer retry")
+				}
+				if !test.remove && string(payload) != "synthetic-transformed" {
+					t.Errorf("caller-transformed payload=%q", payload)
+				}
+				if apiAttempts == 1 {
+					return rootWorkloadResponse(http.StatusUnauthorized,
+						`{"error":{"message":"synthetic rejected bearer"}}`), nil
+				}
+				return rootWorkloadResponse(http.StatusOK, `{"ok":true}`), nil
+			}}}
+			provider := &mockSubjectTokenProvider{
+				token: "synthetic-subject", tokenType: auth.SubjectTokenTypeJWT,
+			}
+			client := openai.NewClient(
+				option.WithMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+					middlewareCalls++
+					if test.remove {
+						req.Body = http.NoBody
+						req.ContentLength = 0
+					} else {
+						req.Body = io.NopCloser(strings.NewReader("synthetic-transformed"))
+						req.ContentLength = int64(len("synthetic-transformed"))
+					}
+					return next(req)
+				}),
+				option.WithWorkloadIdentity(testWorkloadIdentity(provider)),
+				option.WithHTTPClient(httpClient),
+				option.WithMaxRetries(1),
+				option.WithMaxRetryDelay(time.Millisecond),
+			)
+			var result map[string]any
+			err := client.Execute(t.Context(), http.MethodPost, "/responses", nil, &result,
+				option.WithRequestBody("application/json", []byte("synthetic-original")))
+			if test.remove && err != nil {
+				t.Errorf("removed body did not recover through a fresh middleware attempt: %v", err)
+			}
+			if !test.remove && err == nil {
+				t.Error("transformed caller body was retried without proving its replay safety")
+			}
+			if apiAttempts != test.wantAttempts || middlewareCalls != test.wantAttempts {
+				t.Errorf("API/middleware attempts=%d/%d, want %d/%d",
+					apiAttempts, middlewareCalls, test.wantAttempts, test.wantAttempts)
+			}
+		})
+	}
+}
+
+func rootWorkloadResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}


### PR DESCRIPTION
## Summary

- Harden X.509 certificate selection and attestation, restore bounded transport defaults, and classify permanent client-certificate failures consistently.
- Make workload-identity authentication, credential precedence, token refresh, request replay, middleware execution, retry budgets, and response metadata follow one request-owned lifecycle.
- Restrict issuer redirect handling; bound and sanitize issuer and cloud-metadata responses; normalize authentication headers; and make streaming pagination fail safely without modifying Castiron-owned generated pagination code.
- Consolidate HTTP header validation and document X.509 certificate-selection and timeout behavior.

## Validation

- `go test -race ./...`
- `./scripts/lint`
- `./scripts/check-go-mod`
- `go vet ./...`
- `govulncheck ./...` in the root and examples modules using patched Go 1.26.6
- `go test ./...` in `examples`
- `go test -mod=readonly ./...` in `internal/testdata/consumer`
- Focused public-entrypoint and real-TLS regression coverage for authentication, retry, pagination, issuer-response, and transport behavior.
- Independent exhaustive maintainer reviews and a commit-pinned authentication/security review.
- Main-enforced Castiron custom-code budget verified without a ratchet change.

Live verification with an enrolled production X.509 issuer remains a separate release gate.
