### PR TITLE
docs: show typed response stream failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,14 @@ stream := client.Responses.NewStreaming(ctx, responses.ResponseNewParams{
 defer func() { _ = stream.Close() }()
 
 for stream.Next() {
-	event := stream.Current()
-	print(event.Delta)
+	switch event := stream.Current().AsAny().(type) {
+	case responses.ResponseTextDeltaEvent:
+		print(event.Delta)
+	case responses.ResponseErrorEvent:
+		println("stream error event:", event.Message, "param="+event.Param, "code="+event.Code)
+	case responses.ResponseFailedEvent:
+		println("response failed:", event.Response.ID)
+	}
 }
 
 if stream.Err() != nil {
@@ -188,7 +194,7 @@ if stream.Err() != nil {
 }
 ```
 
-> See the [full streaming example](./examples/responses-streaming/main.go)
+> See the [full streaming example](./examples/responses-streaming/main.go). Typed `responses.ResponseErrorEvent` and `responses.ResponseFailedEvent` values come through `stream.Current().AsAny()`, while transport/API-level streaming failures can instead surface via `stream.Err()`.
 
 </details>
 

--- a/examples/responses-streaming/main.go
+++ b/examples/responses-streaming/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/responses"
@@ -22,18 +23,28 @@ func main() {
 	var completeText string
 
 	for stream.Next() {
-		data := stream.Current()
-		print(data.Delta)
-		if data.JSON.Text.Valid() {
-			println()
-			println("Finished Content")
-			completeText = data.Text
-			break
+		switch event := stream.Current().AsAny().(type) {
+		case responses.ResponseTextDeltaEvent:
+			fmt.Print(event.Delta)
+		case responses.ResponseCompletedEvent:
+			completeText = event.Response.OutputText()
+			fmt.Println("\nResponse completed")
+		case responses.ResponseFailedEvent:
+			fmt.Printf("\nResponse failed: %s\n", event.Response.ID)
+		case responses.ResponseErrorEvent:
+			fmt.Printf(
+				"\nStream error event: %s param=%s code=%s\n",
+				event.Message,
+				event.Param,
+				event.Code,
+			)
 		}
 	}
 
-	if stream.Err() != nil {
-		panic(stream.Err())
+	if err := stream.Err(); err != nil {
+		// Transport/API-level streaming errors can surface here instead of as typed
+		// ResponseErrorEvent / ResponseFailedEvent values.
+		panic(err)
 	}
 
 	_ = completeText


### PR DESCRIPTION
## Summary

- update the Responses streaming README snippet and runnable example to switch on `stream.Current().AsAny()`
- show how to handle `ResponseErrorEvent` and `ResponseFailedEvent`
- distinguish typed stream events from transport/API-level failures returned by `stream.Err()`

## Testing

- `go -C examples vet ./responses-streaming`
- `go -C examples test ./responses-streaming`
- `go -C examples test ./...`
- `git diff --check`

Fixes #585