### PR TITLE
docs: explain omitempty behavior in structured outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,11 @@ import (
 	// ...
 )
 
-// A struct that will be converted to a Structured Outputs response schema
+// A struct that will be converted to a Structured Outputs response schema.
+//
+// Avoid `omitempty` in JSON tags here: jsonschema treats those fields as optional
+// and leaves them out of the schema's required array. With Strict enabled, the API
+// can reject that schema; otherwise, the model may omit the fields.
 type HistoricalComputer struct {
 	Origin       Origin   `json:"origin" jsonschema_description:"The origin of the computer"`
 	Name         string   `json:"full_name" jsonschema_description:"The name of the device model"`


### PR DESCRIPTION
## Summary

Fixes #539.

The full structured-outputs example already warns that `omitempty` changes how `invopop/jsonschema` builds the schema, but the copy-paste example in the README omitted that warning.

This adds the same guidance at the point where readers define their response struct, explaining that `omitempty` removes fields from the schema's required array and can therefore lead to strict-schema rejection or omitted output fields.

## Validation

- Confirmed the wording matches the behavior documented in `examples/structured-outputs/main.go`.
- `git diff --check`

AI assistance was used to locate the duplicated example and draft concise wording. I reviewed the final documentation change.
