### PR TITLE
docs(bedrock): clarify Mantle model-family API roots

### DIFF
--- a/README.md
+++ b/README.md
@@ -1361,9 +1361,10 @@ The region is resolved from `AWSRegion`, `AWS_REGION`, `AWS_DEFAULT_REGION`,
 or the standard AWS config chain. The base URL is resolved from `BaseURL`,
 `AWS_BEDROCK_BASE_URL`, or
 `https://bedrock-mantle.{region}.api.aws/openai/v1`.
-The `/openai/v1` prefix is intentional; Bedrock's generic `/v1` route is a
-different API surface and is not interchangeable with the OpenAI-compatible
-route.
+The default Mantle base URL remains `/openai/v1`, which AWS documents for OpenAI
+model families. Some other Mantle model families use `/v1` instead; see
+[Mantle API roots](bedrock/README.md#mantle-api-roots) and the AWS model card for
+your deployment before overriding `BaseURL`.
 
 To select a named profile:
 

--- a/bedrock/README.md
+++ b/bedrock/README.md
@@ -9,6 +9,22 @@ Use the `bedrock` package to configure the normal OpenAI client for Amazon Bedro
 
 Runtime hostnames use the correct suffix for the selected AWS partition. Canonical Runtime, FIPS, and dual-stack `BaseURL` overrides automatically select the endpoint family when `Endpoint` is omitted. Canonical AWS hosts must use HTTPS and match the configured region and endpoint. Custom or proxy hosts default to the Mantle signer; set `EndpointRuntime` explicitly when a custom host requires Runtime signing.
 
+### Mantle API roots
+
+Amazon Bedrock exposes more than one OpenAI-compatible API root on `bedrock-mantle`, and the route depends on the model family. OpenAI model pages such as [GPT-5.5](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-55.html) document `/openai/v1`, while other model pages such as [Kimi K2.5](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-moonshot-ai-kimi-k2-5.html) document `/v1`. `EndpointMantle` keeps `/openai/v1` as its default for backwards compatibility; choosing `EndpointMantle` does not automatically select a route from the model name.
+
+When the AWS model card for a deployment documents `/v1`, set the Mantle `BaseURL` explicitly:
+
+```go
+bedrock.Config{
+	Endpoint:  bedrock.EndpointMantle,
+	AWSRegion: "us-east-1",
+	BaseURL:   "https://bedrock-mantle.us-east-1.api.aws/v1",
+}
+```
+
+See the AWS model card for the model you are using before choosing the route. For example, AWS documents `https://bedrock-mantle.<region>.api.aws/openai/v1` for GPT-5.5 and `https://bedrock-mantle.<region>.api.aws/v1` for Kimi K2.5.
+
 ## Runtime Chat Completions
 
 ```go


### PR DESCRIPTION
## Summary

Clarifies the route selection described in #812 without changing the existing Mantle default.

AWS currently documents different `bedrock-mantle` API roots for different model families:

- OpenAI model pages such as GPT-5.5 use `/openai/v1`.
- Other model pages such as Kimi K2.5 use `/v1`.

This documents that `EndpointMantle` intentionally preserves `/openai/v1` for backwards compatibility, does not infer the route from the model name, and shows the existing `Config.BaseURL` escape hatch for deployments whose AWS model card requires `/v1`.

No SDK behavior, authentication, signing, generated code, or exported API is changed.

## Competing implementation / design boundary

PR #894 now provides a competing implementation for #812 by changing the SDK-wide Mantle default from `/openai/v1` to `/v1`. Both approaches remain open; no maintainer preference or merge decision is inferred here.

The distinction is material rather than cosmetic: current AWS model-family documentation uses both roots. A global default flip can fix families documented on `/v1` while changing behavior for OpenAI model families documented on `/openai/v1`. This PR therefore keeps the existing compatibility default and documents `Config.BaseURL` for deployments whose model card requires the alternate root.

## Validation

- `git diff --check`
- Fresh collision reconciliation on 2026-09-13: #894 is the competing open implementation for #812; no maintainer decision between the two approaches is proven.
- Cross-checked the documented roots against the current AWS GPT-5.5 and Kimi K2.5 model cards.
- Fresh upstream-drift audit on 2026-09-13: the branch is behind active `main`, but the Bedrock README target was not changed by the intervening upstream commits and the root README's Bedrock block remains unchanged; GitHub still reports this PR mergeable. No rebase is performed solely for unrelated base drift.

Local Go tests were not run because Go is not installed on this host; this is a documentation-only change and normal repository CI remains authoritative. Current exact-head Actions remain externally gated as `action_required` before jobs are created; this is not represented as a test pass or failure.

Closes #812.