### PR TITLE
fix(ssestream): synchronize decoder registry

### DIFF
--- a/packages/ssestream/ssestream.go
+++ b/packages/ssestream/ssestream.go
@@ -29,14 +29,14 @@ func NewDecoder(res *http.Response) Decoder {
 	}
 
 	contentType, mediaType := decoderContentTypes(res.Header.Get("content-type"))
-	if t, ok := decoderTypes[contentType]; ok {
+	if t, ok := registeredDecoder(contentType); ok {
 		return t(res.Body)
 	}
 
 	// Preserve parameter-specific registrations while allowing a bare media
 	// type registration to match standard Content-Type parameters.
 	if mediaType != "" {
-		if t, ok := decoderTypes[mediaType]; ok {
+		if t, ok := registeredDecoder(mediaType); ok {
 			return t(res.Body)
 		}
 	}
@@ -46,9 +46,21 @@ func NewDecoder(res *http.Response) Decoder {
 	return &eventStreamDecoder{rc: res.Body, scn: scn}
 }
 
-var decoderTypes = map[string](func(io.ReadCloser) Decoder){}
+var (
+	decoderTypesMu sync.RWMutex
+	decoderTypes   = map[string](func(io.ReadCloser) Decoder){}
+)
+
+func registeredDecoder(contentType string) (func(io.ReadCloser) Decoder, bool) {
+	decoderTypesMu.RLock()
+	defer decoderTypesMu.RUnlock()
+	t, ok := decoderTypes[contentType]
+	return t, ok
+}
 
 func RegisterDecoder(contentType string, decoder func(io.ReadCloser) Decoder) {
+	decoderTypesMu.Lock()
+	defer decoderTypesMu.Unlock()
 	decoderTypes[strings.ToLower(contentType)] = decoder
 }
 

--- a/packages/ssestream/ssestream_test.go
+++ b/packages/ssestream/ssestream_test.go
@@ -3,6 +3,7 @@ package ssestream
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"reflect"
@@ -678,4 +679,42 @@ func TestStreamDiscardsIncompleteEventAtEOF(t *testing.T) {
 	if err := stream.Err(); err != nil {
 		t.Fatalf("unexpected stream error: %v", err)
 	}
+}
+
+func TestRegisterDecoderConcurrentWithNewDecoder(t *testing.T) {
+	const workers = 4
+	const iterations = 200
+	var wg sync.WaitGroup
+	for worker := 0; worker < workers; worker++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				RegisterDecoder(
+					fmt.Sprintf("application/x-openai-test-%d-%d", worker, i),
+					func(io.ReadCloser) Decoder { return nil },
+				)
+			}
+		}(worker)
+	}
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				decoder := NewDecoder(&http.Response{
+					Header: http.Header{"Content-Type": []string{"text/event-stream"}},
+					Body:   io.NopCloser(strings.NewReader("")),
+				})
+				if decoder == nil {
+					t.Error("NewDecoder returned nil")
+					continue
+				}
+				if err := decoder.Close(); err != nil {
+					t.Errorf("close decoder: %v", err)
+				}
+			}
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
## Summary

Make the public SSE decoder registry safe for concurrent registration and stream creation.

`RegisterDecoder` writes the package-level registry while `NewDecoder` reads it. A focused race test on current `main` reports a data race and can terminate with `fatal error: concurrent map writes`.

This change protects registry access with an `RWMutex`. Decoder lookup copies the factory while holding the read lock, then releases the lock before invoking it.

Fixes #886.

## Testing

- pre-fix `go test -race` reproduction: data race plus `fatal error: concurrent map writes`
- `go test -race ./packages/ssestream -count=1`: passed on Go 1.26.7
- `SKIP_MOCK_TESTS=true go test ./...`: passed on Go 1.26.7
- `./scripts/check-go-mod`: all four modules tidy
- `./scripts/lint`: all analyzer passes reported 0 issues
- Castiron custom-code budget check: passed
- `git diff --check`: passed

No decoder-selection semantics or public API signatures change.
