### PR TITLE
fix(ssestream): synchronize decoder registry access

### DIFF
--- a/packages/ssestream/ssestream.go
+++ b/packages/ssestream/ssestream.go
@@ -29,16 +29,14 @@ func NewDecoder(res *http.Response) Decoder {
 	}
 
 	contentType, mediaType := decoderContentTypes(res.Header.Get("content-type"))
-	if t, ok := decoderTypes[contentType]; ok {
-		return t(res.Body)
+	decoderTypesMu.RLock()
+	t, ok := decoderTypes[contentType]
+	if !ok && mediaType != "" {
+		t, ok = decoderTypes[mediaType]
 	}
-
-	// Preserve parameter-specific registrations while allowing a bare media
-	// type registration to match standard Content-Type parameters.
-	if mediaType != "" {
-		if t, ok := decoderTypes[mediaType]; ok {
-			return t(res.Body)
-		}
+	decoderTypesMu.RUnlock()
+	if ok {
+		return t(res.Body)
 	}
 
 	scn := bufio.NewScanner(res.Body)
@@ -47,8 +45,11 @@ func NewDecoder(res *http.Response) Decoder {
 }
 
 var decoderTypes = map[string](func(io.ReadCloser) Decoder){}
+var decoderTypesMu sync.RWMutex
 
 func RegisterDecoder(contentType string, decoder func(io.ReadCloser) Decoder) {
+	decoderTypesMu.Lock()
+	defer decoderTypesMu.Unlock()
 	decoderTypes[strings.ToLower(contentType)] = decoder
 }
 

--- a/packages/ssestream/ssestream_test.go
+++ b/packages/ssestream/ssestream_test.go
@@ -109,6 +109,43 @@ func TestNewDecoderMatchesRegisteredMediaTypeWithCaseAndParameters(t *testing.T)
 	}
 }
 
+func TestDecoderRegistryIsSafeForConcurrentAccess(t *testing.T) {
+	const contentType = "application/x-openai-go-concurrent"
+	decoder := &testDecoder{}
+	register := func(io.ReadCloser) Decoder { return decoder }
+
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 1000; j++ {
+				RegisterDecoder(contentType, register)
+			}
+		}()
+	}
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 1000; j++ {
+				got := NewDecoder(&http.Response{
+					Header: http.Header{"Content-Type": {contentType}},
+					Body:   io.NopCloser(strings.NewReader("")),
+				})
+				if got != decoder {
+					got.Close()
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	decoderTypesMu.Lock()
+	delete(decoderTypes, contentType)
+	decoderTypesMu.Unlock()
+}
+
 func TestNewDecoderPreservesRegisteredContentTypeParameters(t *testing.T) {
 	const (
 		mediaType = "application/x-openai-go-test-parameters"


### PR DESCRIPTION
Fixes #886

RegisterDecoder and NewDecoder accessed the package-level decoder registry without synchronization, allowing concurrent map writes and race detector failures. Protect registry reads and writes with an RWMutex and add concurrent coverage.

Validation:
- go test -race ./packages/ssestream
- go test ./packages/ssestream
- go test ./... (fails in existing tests because the localhost:4010 mock server is not running; also TestMultipartFilenameMetadata/backslash fails independently)