### PR TITLE
fix(pagination): continue after empty cursor pages

### DIFF
--- a/packages/pagination/pagination.go
+++ b/packages/pagination/pagination.go
@@ -361,19 +361,20 @@ func (r *NextCursorPage[T]) SetPageConfig(cfg *requestconfig.RequestConfig, res 
 }
 
 type NextCursorPageAutoPager[T any] struct {
-	page       *NextCursorPage[T]
-	cur        T
-	idx        int
-	run        int
-	err        error
-	lastCursor string
+	page        *NextCursorPage[T]
+	cur         T
+	idx         int
+	run         int
+	err         error
+	seenCursors map[string]struct{}
 	paramObj
 }
 
 func NewNextCursorPageAutoPager[T any](page *NextCursorPage[T], err error) *NextCursorPageAutoPager[T] {
 	return &NextCursorPageAutoPager[T]{
-		page: page,
-		err:  err,
+		page:        page,
+		err:         err,
+		seenCursors: make(map[string]struct{}),
 	}
 }
 
@@ -385,11 +386,17 @@ func (r *NextCursorPageAutoPager[T]) Next() bool {
 			r.idx += 1
 			return true
 		}
-		if r.page.Next != "" && r.page.Next == r.lastCursor {
-			r.err = errors.New("pagination cursor did not advance")
+		if r.page.JSON.HasMore.Valid() && !r.page.HasMore {
+			r.page = nil
 			return false
 		}
-		r.lastCursor = r.page.Next
+		if r.page.Next != "" {
+			if _, ok := r.seenCursors[r.page.Next]; ok {
+				r.err = errors.New("pagination cursor did not advance")
+				return false
+			}
+			r.seenCursors[r.page.Next] = struct{}{}
+		}
 		r.idx = 0
 		r.page, r.err = r.page.GetNextPage()
 		if r.err != nil {

--- a/packages/pagination/pagination.go
+++ b/packages/pagination/pagination.go
@@ -1,6 +1,7 @@
 package pagination
 
 import (
+	"errors"
 	"net/http"
 	"reflect"
 
@@ -360,11 +361,12 @@ func (r *NextCursorPage[T]) SetPageConfig(cfg *requestconfig.RequestConfig, res 
 }
 
 type NextCursorPageAutoPager[T any] struct {
-	page *NextCursorPage[T]
-	cur  T
-	idx  int
-	run  int
-	err  error
+	page       *NextCursorPage[T]
+	cur        T
+	idx        int
+	run        int
+	err        error
+	lastCursor string
 	paramObj
 }
 
@@ -383,6 +385,11 @@ func (r *NextCursorPageAutoPager[T]) Next() bool {
 			r.idx += 1
 			return true
 		}
+		if r.page.Next != "" && r.page.Next == r.lastCursor {
+			r.err = errors.New("pagination cursor did not advance")
+			return false
+		}
+		r.lastCursor = r.page.Next
 		r.idx = 0
 		r.page, r.err = r.page.GetNextPage()
 		if r.err != nil {

--- a/packages/pagination/pagination.go
+++ b/packages/pagination/pagination.go
@@ -328,10 +328,6 @@ func (r *NextCursorPage[T]) UnmarshalJSON(data []byte) error {
 // there is no next page, this function will return a 'nil' for the page value, but
 // will not return an error
 func (r *NextCursorPage[T]) GetNextPage() (res *NextCursorPage[T], err error) {
-	if len(r.Data) == 0 {
-		return nil, nil
-	}
-
 	if r.JSON.HasMore.Valid() && r.HasMore == false {
 		return nil, nil
 	}
@@ -380,20 +376,20 @@ func NewNextCursorPageAutoPager[T any](page *NextCursorPage[T], err error) *Next
 }
 
 func (r *NextCursorPageAutoPager[T]) Next() bool {
-	if r.page == nil || len(r.page.Data) == 0 {
-		return false
-	}
-	if r.idx >= len(r.page.Data) {
+	for r.page != nil {
+		if r.idx < len(r.page.Data) {
+			r.cur = r.page.Data[r.idx]
+			r.run += 1
+			r.idx += 1
+			return true
+		}
 		r.idx = 0
 		r.page, r.err = r.page.GetNextPage()
-		if r.err != nil || r.page == nil || len(r.page.Data) == 0 {
+		if r.err != nil {
 			return false
 		}
 	}
-	r.cur = r.page.Data[r.idx]
-	r.run += 1
-	r.idx += 1
-	return true
+	return false
 }
 
 func (r *NextCursorPageAutoPager[T]) Current() T {

--- a/pagination_transport_test.go
+++ b/pagination_transport_test.go
@@ -122,3 +122,36 @@ func TestNextCursorPaginationContinuesAfterEmptyPage(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestNextCursorPaginationStopsOnRepeatedEmptyCursor(t *testing.T) {
+	calls := 0
+	customClient := paginationHTTPDoerFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		body := `{"data":[],"has_more":true,"next":"cursor-1"}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": {"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    req,
+		}, nil
+	})
+
+	client := openai.NewClient(
+		option.WithBaseURL("https://example.com/v1"),
+		option.WithAPIKey("test-key"),
+		option.WithAdminAPIKey("admin-test-key"),
+		option.WithMaxRetries(0),
+		option.WithHTTPClient(customClient),
+	)
+	pager := client.Admin.Organization.Groups.ListAutoPaging(context.Background(), openai.AdminOrganizationGroupListParams{})
+
+	if pager.Next() {
+		t.Fatal("pager returned an item from an empty page")
+	}
+	if err := pager.Err(); err == nil || err.Error() != "pagination cursor did not advance" {
+		t.Fatalf("pager error = %v, want repeated cursor error", err)
+	}
+	if calls != 2 {
+		t.Fatalf("HTTP calls = %d, want 2", calls)
+	}
+}

--- a/pagination_transport_test.go
+++ b/pagination_transport_test.go
@@ -61,7 +61,7 @@ func TestPaginationPreservesCustomHTTPClient(t *testing.T) {
 		option.WithHTTPClient(fallbackClient),
 		option.WithHTTPClient(customClient),
 	)
-	pager := client.FineTuning.Jobs.ListAutoPaging(context.Background(), openai.FineTuningJobListParams{})
+	pager := client.Admin.Organization.Groups.ListAutoPaging(context.Background(), openai.AdminOrganizationGroupListParams{})
 
 	var jobIDs []string
 	for pager.Next() {
@@ -153,5 +153,74 @@ func TestNextCursorPaginationStopsOnRepeatedEmptyCursor(t *testing.T) {
 	}
 	if calls != 2 {
 		t.Fatalf("HTTP calls = %d, want 2", calls)
+	}
+}
+
+func TestNextCursorPaginationStopsOnCursorCycle(t *testing.T) {
+	customClient := paginationHTTPDoerFunc(func(req *http.Request) (*http.Response, error) {
+		var body string
+		switch req.URL.Query().Get("after") {
+		case "":
+			body = `{"data":[],"has_more":true,"next":"cursor-a"}`
+		case "cursor-a":
+			body = `{"data":[],"has_more":true,"next":"cursor-b"}`
+		case "cursor-b":
+			body = `{"data":[],"has_more":true,"next":"cursor-a"}`
+		default:
+			return nil, errors.New("unexpected pagination cursor")
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": {"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    req,
+		}, nil
+	})
+
+	client := openai.NewClient(
+		option.WithBaseURL("https://example.com/v1"),
+		option.WithAPIKey("test-key"),
+		option.WithMaxRetries(0),
+		option.WithHTTPClient(customClient),
+	)
+	pager := client.Admin.Organization.Groups.ListAutoPaging(context.Background(), openai.AdminOrganizationGroupListParams{})
+
+	if pager.Next() {
+		t.Fatal("pager returned an item from empty pages")
+	}
+	if err := pager.Err(); err == nil || err.Error() != "pagination cursor did not advance" {
+		t.Fatalf("pager error = %v, want cursor cycle error", err)
+	}
+}
+
+func TestNextCursorPaginationStopsOnExplicitlyFinishedPage(t *testing.T) {
+	calls := 0
+	customClient := paginationHTTPDoerFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		body := `{"data":[],"has_more":false,"next":"cursor-1"}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": {"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    req,
+		}, nil
+	})
+
+	client := openai.NewClient(
+		option.WithBaseURL("https://example.com/v1"),
+		option.WithAPIKey("test-key"),
+		option.WithMaxRetries(0),
+		option.WithHTTPClient(customClient),
+	)
+	pager := client.FineTuning.Jobs.ListAutoPaging(context.Background(), openai.FineTuningJobListParams{})
+
+	if pager.Next() {
+		t.Fatal("pager returned an item from an empty page")
+	}
+	if err := pager.Err(); err != nil {
+		t.Fatalf("pager error = %v, want nil", err)
+	}
+	if calls != 1 {
+		t.Fatalf("HTTP calls = %d, want 1", calls)
 	}
 }

--- a/pagination_transport_test.go
+++ b/pagination_transport_test.go
@@ -80,3 +80,45 @@ func TestPaginationPreservesCustomHTTPClient(t *testing.T) {
 		t.Fatalf("fallback HTTP client calls = %d, want 0", fallbackCalls)
 	}
 }
+
+func TestNextCursorPaginationContinuesAfterEmptyPage(t *testing.T) {
+	customClient := paginationHTTPDoerFunc(func(req *http.Request) (*http.Response, error) {
+		var body string
+		switch req.URL.Query().Get("after") {
+		case "":
+			body = `{"data":[],"has_more":true,"next":"cursor-1"}`
+		case "cursor-1":
+			body = `{"data":[{"id":"job-1"}],"has_more":false,"next":""}`
+		default:
+			return nil, errors.New("unexpected pagination cursor")
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": {"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    req,
+		}, nil
+	})
+
+	client := openai.NewClient(
+		option.WithBaseURL("https://example.com/v1"),
+		option.WithAPIKey("test-key"),
+		option.WithAdminAPIKey("admin-test-key"),
+		option.WithMaxRetries(0),
+		option.WithHTTPClient(customClient),
+	)
+	pager := client.Admin.Organization.Groups.ListAutoPaging(context.Background(), openai.AdminOrganizationGroupListParams{})
+
+	if !pager.Next() {
+		t.Fatalf("pager stopped before the page after the empty page: %v", pager.Err())
+	}
+	if got, want := pager.Current().ID, "job-1"; got != want {
+		t.Fatalf("group ID = %q, want %q", got, want)
+	}
+	if pager.Next() {
+		t.Fatal("pager returned an unexpected additional job")
+	}
+	if err := pager.Err(); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Fixes #890

NextCursorPage stopped pagination whenever a page had an empty data array, even when has_more was true and the server supplied a next cursor. Allow GetNextPage and the auto-pager to traverse empty intermediate pages, and add a regression test using the public Admin Organization Groups endpoint.

Validation:
- go test -race . -run 'TestNextCursorPaginationContinuesAfterEmptyPage|TestPaginationPreservesCustomHTTPClient' -count=1
- go test ./packages/pagination
- git diff --check