### PR TITLE
fix(bedrock): use documented Mantle base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1360,10 +1360,7 @@ func main() {
 The region is resolved from `AWSRegion`, `AWS_REGION`, `AWS_DEFAULT_REGION`,
 or the standard AWS config chain. The base URL is resolved from `BaseURL`,
 `AWS_BEDROCK_BASE_URL`, or
-`https://bedrock-mantle.{region}.api.aws/openai/v1`.
-The `/openai/v1` prefix is intentional; Bedrock's generic `/v1` route is a
-different API surface and is not interchangeable with the OpenAI-compatible
-route.
+`https://bedrock-mantle.{region}.api.aws/v1`.
 
 To select a named profile:
 

--- a/bedrock/README.md
+++ b/bedrock/README.md
@@ -1,10 +1,10 @@
 # Amazon Bedrock
 
-Use the `bedrock` package to configure the normal OpenAI client for Amazon Bedrock's OpenAI-compatible API. The default Mantle endpoint and its existing authentication behavior remain unchanged.
+Use the `bedrock` package to configure the normal OpenAI client for Amazon Bedrock's OpenAI-compatible API.
 
 | Endpoint | Default API root | SigV4 service |
 | --- | --- | --- |
-| `bedrock.EndpointMantle` (default) | `https://bedrock-mantle.<region>.api.aws/openai/v1` | `bedrock-mantle` |
+| `bedrock.EndpointMantle` (default) | `https://bedrock-mantle.<region>.api.aws/v1` | `bedrock-mantle` |
 | `bedrock.EndpointRuntime` | `https://bedrock-runtime.<region>.amazonaws.com/openai/v1` | `bedrock` |
 
 Runtime hostnames use the correct suffix for the selected AWS partition. Canonical Runtime, FIPS, and dual-stack `BaseURL` overrides automatically select the endpoint family when `Endpoint` is omitted. Canonical AWS hosts must use HTTPS and match the configured region and endpoint. Custom or proxy hosts default to the Mantle signer; set `EndpointRuntime` explicitly when a custom host requires Runtime signing.

--- a/bedrock/auth.go
+++ b/bedrock/auth.go
@@ -354,7 +354,7 @@ func defaultEndpointURL(endpoint Endpoint, region string) string {
 		standardSuffix, _ := runtimeDNSSuffixes(region)
 		return fmt.Sprintf("https://bedrock-runtime.%s.%s/openai/v1/", region, standardSuffix)
 	}
-	return fmt.Sprintf("https://bedrock-mantle.%s.api.aws/openai/v1/", region)
+	return fmt.Sprintf("https://bedrock-mantle.%s.api.aws/v1/", region)
 }
 
 func runtimeDNSSuffixes(region string) (standard string, dualStack string) {

--- a/bedrock/auth_test.go
+++ b/bedrock/auth_test.go
@@ -116,7 +116,7 @@ region = eu-central-1
 	if err := client.Get(context.Background(), "/models", nil, &response); err != nil {
 		t.Fatal(err)
 	}
-	if got, want := request.URL.String(), "https://bedrock-mantle.eu-central-1.api.aws/openai/v1/models"; got != want {
+	if got, want := request.URL.String(), "https://bedrock-mantle.eu-central-1.api.aws/v1/models"; got != want {
 		t.Fatalf("request URL = %q, want %q", got, want)
 	}
 	authorization := request.Header.Get("Authorization")

--- a/bedrock/bedrock.go
+++ b/bedrock/bedrock.go
@@ -79,7 +79,7 @@ type Config struct {
 	AWSCredentialsProvider aws.CredentialsProvider
 
 	// BaseURL overrides AWS_BEDROCK_BASE_URL and the selected regional endpoint.
-	// Mantle defaults to https://bedrock-mantle.{region}.api.aws/openai/v1;
+	// Mantle defaults to https://bedrock-mantle.{region}.api.aws/v1;
 	// Runtime defaults to https://bedrock-runtime.{region}.amazonaws.com/openai/v1
 	// in the standard AWS partition. Use BaseURL if a deployment requires /v1.
 	BaseURL string

--- a/bedrock/example_test.go
+++ b/bedrock/example_test.go
@@ -130,7 +130,7 @@ func ExampleNewClient_bearer() {
 	client, err := bedrock.NewClient(context.Background(), bedrock.Config{
 		AWSRegion: "us-west-2",
 		APIKey:    "bedrock-bearer-token",
-		BaseURL:   "https://bedrock-mantle.us-west-2.api.aws/openai/v1",
+		BaseURL:   "https://bedrock-mantle.us-west-2.api.aws/v1",
 	})
 	if err != nil {
 		panic(err)

--- a/bedrock/runtime_test.go
+++ b/bedrock/runtime_test.go
@@ -23,7 +23,7 @@ func TestBedrockEndpointResolution(t *testing.T) {
 		endpoint Endpoint
 		baseURL  string
 	}{
-		{"Mantle default", Config{APIKey: "token", AWSRegion: "us-east-1"}, EndpointMantle, "https://bedrock-mantle.us-east-1.api.aws/openai/v1/"},
+		{"Mantle default", Config{APIKey: "token", AWSRegion: "us-east-1"}, EndpointMantle, "https://bedrock-mantle.us-east-1.api.aws/v1/"},
 		{"custom SigV4 Mantle default", Config{AWSRegion: "us-east-1", AWSAccessKeyID: "access", AWSSecretAccessKey: "secret", BaseURL: "https://proxy.example/openai/v1"}, EndpointMantle, "https://proxy.example/openai/v1/"},
 		{"custom SigV4 Runtime", Config{Endpoint: EndpointRuntime, AWSRegion: "us-east-1", AWSAccessKeyID: "access", AWSSecretAccessKey: "secret", BaseURL: "https://proxy.example/openai/v1"}, EndpointRuntime, "https://proxy.example/openai/v1/"},
 		{"Runtime standard", Config{Endpoint: EndpointRuntime, APIKey: "token", AWSRegion: "us-east-1"}, EndpointRuntime, "https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1/"},


### PR DESCRIPTION
Fixes #812

AWS Bedrock Mantle documents the OpenAI-compatible base URL as /v1, but the SDK default used /openai/v1. Update the default and focused URL expectations while preserving Runtime and custom BaseURL behavior.

Validation:
- go test ./bedrock
- git diff --check