### PR TITLE
apijson: avoid recursive decoder restarts for generated response types

### DIFF
--- a/internal/apijson/decoder.go
+++ b/internal/apijson/decoder.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 	"unsafe"
@@ -188,6 +189,13 @@ func isRegisteredStructUnionSlice(t reflect.Type) bool {
 func isRecursiveGeneratedType(t reflect.Type) bool {
 	if cached, ok := recursiveGeneratedTypes.Load(t); ok {
 		return cached.(bool)
+	}
+	// Consumers can embed generated metadata in recursive types with their own
+	// UnmarshalJSON methods. Only SDK-owned types may bypass that method.
+	const sdkPackage = "github.com/openai/openai-go/v3"
+	if t.PkgPath() != sdkPackage && !strings.HasPrefix(t.PkgPath(), sdkPackage+"/") {
+		recursiveGeneratedTypes.Store(t, false)
+		return false
 	}
 	if t.Kind() != reflect.Struct {
 		recursiveGeneratedTypes.Store(t, false)

--- a/internal/apijson/decoder.go
+++ b/internal/apijson/decoder.go
@@ -8,19 +8,24 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/openai/openai-go/v3/packages/param"
 	"reflect"
 	"strconv"
 	"sync"
 	"time"
 	"unsafe"
 
+	"github.com/openai/openai-go/v3/packages/param"
 	"github.com/tidwall/gjson"
 )
 
 // decoders is a synchronized map with roughly the following type:
 // map[reflect.Type]decoderFunc
 var decoders sync.Map
+
+// recursiveGeneratedTypes caches whether a generated response type contains
+// itself. Calling its generated UnmarshalJSON method while decoding a nested
+// value would restart decoding with a copy of the remaining JSON subtree.
+var recursiveGeneratedTypes sync.Map
 
 // Unmarshal is similar to [encoding/json.Unmarshal] and parses the JSON-encoded
 // data and stores it in the given pointer.
@@ -180,6 +185,58 @@ func isRegisteredStructUnionSlice(t reflect.Type) bool {
 	return registered && isStructUnion(t.Elem())
 }
 
+func isRecursiveGeneratedType(t reflect.Type) bool {
+	if cached, ok := recursiveGeneratedTypes.Load(t); ok {
+		return cached.(bool)
+	}
+	if t.Kind() != reflect.Struct {
+		recursiveGeneratedTypes.Store(t, false)
+		return false
+	}
+
+	jsonField, ok := t.FieldByName("JSON")
+	if !ok || jsonField.Type.Kind() != reflect.Struct {
+		recursiveGeneratedTypes.Store(t, false)
+		return false
+	}
+	if rawField, ok := jsonField.Type.FieldByName("raw"); !ok || rawField.Type.Kind() != reflect.String {
+		recursiveGeneratedTypes.Store(t, false)
+		return false
+	}
+
+	var contains func(reflect.Type, map[reflect.Type]bool) bool
+	contains = func(current reflect.Type, seen map[reflect.Type]bool) bool {
+		if current == t {
+			return true
+		}
+		if seen[current] {
+			return false
+		}
+		seen[current] = true
+
+		switch current.Kind() {
+		case reflect.Array, reflect.Pointer, reflect.Slice:
+			return contains(current.Elem(), seen)
+		case reflect.Map:
+			return contains(current.Key(), seen) || contains(current.Elem(), seen)
+		case reflect.Struct:
+			for i := 0; i < current.NumField(); i++ {
+				if contains(current.Field(i).Type, seen) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	recursive := false
+	for i := 0; i < t.NumField() && !recursive; i++ {
+		recursive = contains(t.Field(i).Type, make(map[reflect.Type]bool))
+	}
+	recursiveGeneratedTypes.Store(t, recursive)
+	return recursive
+}
+
 func (d *decoderBuilder) newTypeDecoder(t reflect.Type) decoderFunc {
 	isRoot := d.root
 
@@ -202,7 +259,7 @@ func (d *decoderBuilder) newTypeDecoder(t reflect.Type) decoderFunc {
 		return unmarshalerDecoder
 	}
 	if !d.root && reflect.PointerTo(t).Implements(reflect.TypeOf((*json.Unmarshaler)(nil)).Elem()) {
-		if _, ok := unionVariants[t]; !ok {
+		if _, ok := unionVariants[t]; !ok && !isRecursiveGeneratedType(t) {
 			return indirectUnmarshalerDecoder
 		}
 	}

--- a/internal/apijson/decoder.go
+++ b/internal/apijson/decoder.go
@@ -259,8 +259,13 @@ func (d *decoderBuilder) newTypeDecoder(t reflect.Type) decoderFunc {
 		return unmarshalerDecoder
 	}
 	if !d.root && reflect.PointerTo(t).Implements(reflect.TypeOf((*json.Unmarshaler)(nil)).Elem()) {
-		if _, ok := unionVariants[t]; !ok && !isRecursiveGeneratedType(t) {
-			return indirectUnmarshalerDecoder
+		if _, ok := unionVariants[t]; !ok {
+			if !isRecursiveGeneratedType(t) {
+				return indirectUnmarshalerDecoder
+			}
+			// Retain the object-shape check from the generated UnmarshalRoot
+			// call without restarting decoding or replacing the parent state.
+			isRoot = true
 		}
 	}
 	d.root = false

--- a/internal/apijson/decoder.go
+++ b/internal/apijson/decoder.go
@@ -263,9 +263,13 @@ func (d *decoderBuilder) newTypeDecoder(t reflect.Type) decoderFunc {
 			if !isRecursiveGeneratedType(t) {
 				return indirectUnmarshalerDecoder
 			}
-			// Retain the object-shape check from the generated UnmarshalRoot
-			// call without restarting decoding or replacing the parent state.
-			isRoot = true
+			// Preserve UnmarshalRoot's object validation and permissive state,
+			// but reuse the parsed node instead of copying and parsing it again.
+			rootBuilder := decoderBuilder{root: true}
+			decode := rootBuilder.typeDecoder(t)
+			return func(node gjson.Result, value reflect.Value, _ *decoderState) error {
+				return decode(node, value, &decoderState{strict: false, exactness: exact})
+			}
 		}
 	}
 	d.root = false

--- a/internal/apijson/recursive_decoder_test.go
+++ b/internal/apijson/recursive_decoder_test.go
@@ -1,0 +1,63 @@
+package apijson
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/openai/openai-go/v3/packages/respjson"
+)
+
+var recursiveNodeUnmarshalCalls int
+
+type recursiveNode struct {
+	Children []recursiveNode `json:"children"`
+	Value    string          `json:"value"`
+	JSON     struct {
+		Children respjson.Field
+		Value    respjson.Field
+		raw      string
+	} `json:"-"`
+}
+
+func (r *recursiveNode) UnmarshalJSON(data []byte) error {
+	recursiveNodeUnmarshalCalls++
+	return UnmarshalRoot(data, r)
+}
+
+func TestRecursiveGeneratedTypeRetainsDecoderState(t *testing.T) {
+	const depth = 1000
+	recursiveNodeUnmarshalCalls = 0
+
+	var payload strings.Builder
+	for range depth {
+		payload.WriteString(`{"children":[`)
+	}
+	payload.WriteString(`{"value":"leaf"}`)
+	for range depth {
+		payload.WriteString(`]}`)
+	}
+
+	var got struct {
+		Root recursiveNode `json:"root"`
+	}
+	if err := Unmarshal([]byte(`{"root":`+payload.String()+`}`), &got); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if recursiveNodeUnmarshalCalls != 0 {
+		t.Fatalf("recursive UnmarshalJSON calls = %d, want 0", recursiveNodeUnmarshalCalls)
+	}
+
+	node := &got.Root
+	for level := 0; level < depth; level++ {
+		if node.JSON.raw == "" {
+			t.Fatalf("level %d did not retain raw JSON metadata", level)
+		}
+		if len(node.Children) != 1 {
+			t.Fatalf("level %d children = %d, want 1", level, len(node.Children))
+		}
+		node = &node.Children[0]
+	}
+	if node.Value != "leaf" {
+		t.Fatalf("leaf value = %q, want leaf", node.Value)
+	}
+}

--- a/recursive_filter_decode_test.go
+++ b/recursive_filter_decode_test.go
@@ -79,3 +79,20 @@ func TestCompoundFilterRetainsInvalidNestedObjectMetadata(t *testing.T) {
 		})
 	}
 }
+
+func TestCompoundFilterRetainsNestedFieldMetadata(t *testing.T) {
+	var filter shared.CompoundFilter
+	if err := json.Unmarshal([]byte(`{"type":"and","filters":[{"type":42,"filters":[]}]}`), &filter); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if len(filter.Filters) != 1 {
+		t.Fatalf("filters = %d, want 1", len(filter.Filters))
+	}
+	child := filter.Filters[0].OfCompoundFilter
+	if child.Type != "42" || !child.JSON.Type.Valid() {
+		t.Fatalf("nested type = %q, valid = %v; want 42 and valid", child.Type, child.JSON.Type.Valid())
+	}
+	if got := filter.Filters[0].AsCompoundFilter(); got.Type != child.Type || got.JSON.Type.Valid() != child.JSON.Type.Valid() {
+		t.Fatal("nested field metadata differs from AsCompoundFilter")
+	}
+}

--- a/recursive_filter_decode_test.go
+++ b/recursive_filter_decode_test.go
@@ -2,6 +2,7 @@ package openai_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +12,7 @@ import (
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/option"
 	"github.com/openai/openai-go/v3/responses"
+	"github.com/openai/openai-go/v3/shared"
 )
 
 func TestResponsesNewDecodesDeepRecursiveFilter(t *testing.T) {
@@ -54,5 +56,26 @@ func TestResponsesNewDecodesDeepRecursiveFilter(t *testing.T) {
 			return
 		}
 		filters = filters[0].OfCompoundFilter.Filters
+	}
+}
+
+func TestCompoundFilterRetainsInvalidNestedObjectMetadata(t *testing.T) {
+	for _, raw := range []string{`42`, `[]`, `"filter"`, `true`} {
+		t.Run(raw, func(t *testing.T) {
+			var filter shared.CompoundFilter
+			if err := json.Unmarshal([]byte(`{"type":"and","filters":[`+raw+`]}`), &filter); err != nil {
+				t.Fatalf("Unmarshal() error = %v", err)
+			}
+			if len(filter.Filters) != 1 {
+				t.Fatalf("filters = %d, want 1", len(filter.Filters))
+			}
+			child := filter.Filters[0]
+			if child.JSON.OfCompoundFilter.Valid() {
+				t.Fatal("non-object filter was marked as a valid compound filter")
+			}
+			if got := child.RawJSON(); got != raw {
+				t.Fatalf("filter raw JSON = %q, want %q", got, raw)
+			}
+		})
 	}
 }

--- a/recursive_filter_decode_test.go
+++ b/recursive_filter_decode_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/option"
+	"github.com/openai/openai-go/v3/packages/pagination"
 	"github.com/openai/openai-go/v3/responses"
 	"github.com/openai/openai-go/v3/shared"
 )
@@ -94,5 +95,25 @@ func TestCompoundFilterRetainsNestedFieldMetadata(t *testing.T) {
 	}
 	if got := filter.Filters[0].AsCompoundFilter(); got.Type != child.Type || got.JSON.Type.Valid() != child.JSON.Type.Valid() {
 		t.Fatal("nested field metadata differs from AsCompoundFilter")
+	}
+}
+
+type customRecursiveFilter struct {
+	shared.CompoundFilter
+	Children []customRecursiveFilter `json:"children"`
+}
+
+func (f *customRecursiveFilter) UnmarshalJSON(_ []byte) error {
+	f.Type = "custom"
+	return nil
+}
+
+func TestPageRetainsCustomRecursiveUnmarshaler(t *testing.T) {
+	var page pagination.Page[customRecursiveFilter]
+	if err := json.Unmarshal([]byte(`{"data":[{"type":"and","children":[]}]}`), &page); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if len(page.Data) != 1 || page.Data[0].Type != "custom" {
+		t.Fatalf("page data = %+v, want custom unmarshaler output", page.Data)
 	}
 }

--- a/recursive_filter_decode_test.go
+++ b/recursive_filter_decode_test.go
@@ -1,0 +1,58 @@
+package openai_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+	"github.com/openai/openai-go/v3/responses"
+)
+
+func TestResponsesNewDecodesDeepRecursiveFilter(t *testing.T) {
+	const depth = 1000
+	var filter strings.Builder
+	for range depth {
+		filter.WriteString(`{"type":"and","filters":[`)
+	}
+	filter.WriteString(`{"type":"eq","key":"category","value":"reference"}`)
+	for range depth {
+		filter.WriteString(`]}`)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"tools":[{"type":"file_search","filters":%s}]}`, filter.String())
+	}))
+	t.Cleanup(server.Close)
+
+	client := openai.NewClient(
+		option.WithAPIKey("test-api-key"),
+		option.WithBaseURL(server.URL),
+	)
+	response, err := client.Responses.New(context.Background(), responses.ResponseNewParams{
+		Input: responses.ResponseNewParamsInputUnion{OfString: openai.String("test")},
+		Model: "gpt-4o",
+	})
+	if err != nil {
+		t.Fatalf("Responses.New() error = %v", err)
+	}
+
+	filters := response.Tools[0].Filters.Filters
+	for level := 0; level < depth; level++ {
+		if len(filters) != 1 {
+			t.Fatalf("level %d filters = %d, want 1", level, len(filters))
+		}
+		if level == depth-1 {
+			if got := filters[0].Key; got != "category" {
+				t.Fatalf("comparison key = %q, want category", got)
+			}
+			return
+		}
+		filters = filters[0].OfCompoundFilter.Filters
+	}
+}


### PR DESCRIPTION
### Motivation

Reduce repeated subtree allocation and copying by avoiding generated `UnmarshalJSON` restarts when decoding recursive SDK response types. This is a partial resource-use improvement: existing GJSON subtree scans remain, and linear CPU scaling is not established.

### Description

- Cache recursive SDK-type detection and reuse the existing compiled decoder with the parsed JSON node.
- Preserve root object validation and the fresh permissive decoding state used by generated methods, including field validity, raw JSON, nulls, and coercion behavior.
- Keep consumer-defined custom unmarshaling intact when custom recursive types embed SDK response metadata.
- Cover deep decoding through the public Responses client, invalid recursive object shapes, nested field metadata, and custom hooks through a generic pagination response.

### Testing

- Focused regressions, race checks, vet, and repository lint pass.
- Full root, examples, and external-consumer suites pass on Go 1.25.14 and Go 1.26.8 using the repository-pinned Steady mock server.
- Targeted regressions fail on their pre-repair revisions and pass with the repairs; deep decoding retains raw metadata without repeated generated method calls.
- Bounded manual security review completed. The standalone Codex Security scanner was unavailable locally; hosted scanning is checked on the published exact head.
- Two consecutive clean rounds of two independent reviewers inspected the complete final diff and exact linked worktree after supported compatibility findings were repaired.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_i_6a9cc14547c0832189a66cd828f5c730)
