### PR TITLE
fix(param): validate nested marshaler JSON

### DIFF
--- a/packages/param/encoder.go
+++ b/packages/param/encoder.go
@@ -66,7 +66,7 @@ func MarshalWithExtras[T ParamStruct, R any](f T, underlying any, extras map[str
 	} else if ovr, ok := f.Overrides(); ok {
 		return shimjson.Marshal(ovr)
 	} else {
-		return shimjson.Marshal(underlying, shimjson.WithSkipCompaction(true))
+		return shimjson.Marshal(underlying)
 	}
 }
 
@@ -96,7 +96,7 @@ func MarshalUnion[T ParamStruct](metadata T, variants ...any) ([]byte, error) {
 			Err:  fmt.Errorf("expected union to have only one present variant, got %d", nPresent),
 		}
 	}
-	return shimjson.Marshal(variants[presentIdx], shimjson.WithSkipCompaction(true))
+	return shimjson.Marshal(variants[presentIdx])
 }
 
 // typeFor is shimmed from Go 1.23 "reflect" package

--- a/packages/param/encoder_test.go
+++ b/packages/param/encoder_test.go
@@ -459,9 +459,6 @@ func TestAppendCompactBroken(t *testing.T) {
 		"red/raw-message-parameter-injection": {
 			RawMessageParent{Strict: true, Schema: json.RawMessage(`{},"strict":false`)},
 		},
-		"red/raw-message-union-injection": {
-			RawMessageUnion{OfSchema: json.RawMessage(`{},"strict":false`)},
-		},
 	}
 
 	for name, test := range tests {
@@ -471,6 +468,15 @@ func TestAppendCompactBroken(t *testing.T) {
 				t.Fatal("expected error got", v)
 			}
 		})
+	}
+}
+
+func TestMarshalUnionRejectsInvalidJSON(t *testing.T) {
+	value := RawMessageUnion{OfSchema: json.RawMessage(`{},"strict":false`)}
+	// Exercise the SDK marshaler directly: json.Marshal would independently
+	// reject this output even if MarshalUnion skipped validation.
+	if data, err := value.MarshalJSON(); err == nil {
+		t.Fatalf("expected invalid union JSON to be rejected, got %s", data)
 	}
 }
 

--- a/packages/param/encoder_test.go
+++ b/packages/param/encoder_test.go
@@ -403,6 +403,28 @@ type NonCompacted struct {
 	param.APIObject
 }
 
+type RawMessageParent struct {
+	Strict bool            `json:"strict"`
+	Schema json.RawMessage `json:"schema"`
+
+	param.APIObject
+}
+
+type RawMessageUnion struct {
+	OfSchema json.RawMessage
+
+	param.APIObject
+}
+
+func (r RawMessageParent) MarshalJSON() ([]byte, error) {
+	type shadow RawMessageParent
+	return param.MarshalObject(r, (*shadow)(&r))
+}
+
+func (r RawMessageUnion) MarshalJSON() ([]byte, error) {
+	return param.MarshalUnion(r, r.OfSchema)
+}
+
 func (a NonCompactedDoubleParent) MarshalJSON() ([]byte, error) {
 	type shadow NonCompactedDoubleParent
 	return param.MarshalObject(a, (*shadow)(&a))
@@ -434,6 +456,12 @@ func TestAppendCompactBroken(t *testing.T) {
 				Raw: `{ "broken": "json" `,
 			}},
 		},
+		"red/raw-message-parameter-injection": {
+			RawMessageParent{Strict: true, Schema: json.RawMessage(`{},"strict":false`)},
+		},
+		"red/raw-message-union-injection": {
+			RawMessageUnion{OfSchema: json.RawMessage(`{},"strict":false`)},
+		},
 	}
 
 	for name, test := range tests {
@@ -446,12 +474,8 @@ func TestAppendCompactBroken(t *testing.T) {
 	}
 }
 
-// TestAppendCompact validates an optimization for internal SDK types to
-// avoid O(keys^2) iteration over each JSON object.
-//
-// It's possible to intentionally trigger this behavior as both a user and
-// SDK developer. However, the edge case is quite pathological and requires
-// calling [json.Marshaler.MarshalJSON] rather than [json.Marshal].
+// TestAppendCompact validates that nested marshaler output is compacted and
+// checked as a complete JSON value before it is added to an enclosing value.
 func TestAppendCompact(t *testing.T) {
 
 	tests := map[string]struct {
@@ -461,8 +485,8 @@ func TestAppendCompact(t *testing.T) {
 		//
 		// Non-compacted cases
 		//
-		// Note this is how to exploit the compacter to fail, you must call [json.Marshaler.MarshalJSON] rather than [json.Marshal].
-		// The type must also embed [param.APIObject] and return non-compacted JSON.
+		// A top-level call to MarshalJSON can return non-compacted JSON, while
+		// enclosing SDK parameter types compact nested marshaler output.
 		//
 
 		"no-compact/fails-compaction": {
@@ -473,13 +497,13 @@ func TestAppendCompact(t *testing.T) {
 			NonCompactedParent{BadChild: NonCompacted{
 				Raw: nonCompactedRaw,
 			}},
-			`{"bad_child":` + nonCompactedRaw + `}`,
+			`{"bad_child":{"foo":"bar"}}`,
 		},
 		"no-compact/double-nested-with-bad-child": {
 			NonCompactedDoubleParent{Prop: "1", Parent: NonCompactedParent{BadChild: NonCompacted{
 				Raw: nonCompactedRaw,
 			}}},
-			`{"prop":"1","parent":{"bad_child":` + nonCompactedRaw + `}}`,
+			`{"prop":"1","parent":{"bad_child":{"foo":"bar"}}}`,
 		},
 
 		//
@@ -546,8 +570,12 @@ func TestAppendCompact(t *testing.T) {
 			if err != nil {
 				t.Fatalf("didn't expect error %v, expected %s", err, test.expected)
 			}
-			if string(b) != test.expected {
-				t.Logf("expected %s (%s), received %s", test.expected, reflect.TypeOf(test.value), string(b))
+			var compactedExpected bytes.Buffer
+			if err := json.Compact(&compactedExpected, []byte(test.expected)); err != nil {
+				t.Fatalf("didn't expect error %v, expected %s", err, test.expected)
+			}
+			if string(b) != compactedExpected.String() {
+				t.Fatalf("expected %s (%s), received %s", compactedExpected.String(), reflect.TypeOf(test.value), string(b))
 			}
 		})
 	}


### PR DESCRIPTION
### Motivation

- A recent compaction optimization bypassed per-marshaler validation, allowing `json.Marshaler` output (including `json.RawMessage`) to be appended unchecked and potentially inject sibling or parent request parameters. 
- Restore per-marshaler validation/compaction so unvalidated raw bytes cannot escape their JSON-value boundary and affect surrounding request structure.

### Description

- Stop using the fast-skip path and restore normal marshaling in `param.MarshalWithExtras` by calling `shimjson.Marshal(underlying)` instead of passing `WithSkipCompaction(true)`, ensuring nested outputs are validated and compacted. 
- Apply the same change for unions by removing `WithSkipCompaction(true)` from `param.MarshalUnion` so union variants are validated before being incorporated. 
- Add regression tests that exercise injection via `json.RawMessage` in both ordinary object fields and union variants by introducing `RawMessageParent` and `RawMessageUnion` test cases and updating compaction expectations in `packages/param/encoder_test.go`. 
- Modified files: `packages/param/encoder.go` and `packages/param/encoder_test.go`.

### Testing

- Focused parameter/JSON tests, parameter race tests, and vet pass.
- Full root, examples, and external-consumer suites pass on Go 1.25.14 and Go 1.26.8 using the repository-pinned Steady mock server.
- Repository lint passes for all configured modules/platforms (six zero-issue results).
- The direct union regression fails against the old runtime and passes with the fix.
- Custom-code tooling tests pass (50 passed, one optional Castiron compiler contract test skipped).
- Bounded manual security review and two consecutive rounds of two independent full-diff reviewers completed without unresolved in-scope findings. The standalone Codex Security scanner was unavailable locally; the hosted exact-head scan is checked after publication.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_i_6a9cc40741a08321b7470642de747ab0)