### PR TITLE
fix(param): emit extra fields in sorted key order

### DIFF
--- a/packages/param/encoder.go
+++ b/packages/param/encoder.go
@@ -3,7 +3,9 @@ package param
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"reflect"
+	"slices"
 	"strings"
 	"time"
 
@@ -48,7 +50,14 @@ func MarshalWithExtras[T ParamStruct, R any](f T, underlying any, extras map[str
 		if err != nil {
 			return nil, err
 		}
-		for k, v := range extras {
+		// Sorted rather than map order. Each key is applied with sjson on top of
+		// the already-encoded struct, so iteration order ends up as byte order in
+		// the output, and the same value marshals to a different byte string on
+		// every call. That breaks anything hashing or diffing request bodies,
+		// prefix-based prompt caching most visibly. encoding/json has always
+		// emitted map keys in sorted order, so this matches it.
+		for _, k := range slices.Sorted(maps.Keys(extras)) {
+			v := extras[k]
 			var a any = v
 			if a == Omit {
 				// Errors when handling ForceOmitted are ignored.

--- a/packages/param/encoder_test.go
+++ b/packages/param/encoder_test.go
@@ -200,6 +200,30 @@ func TestExtraFields(t *testing.T) {
 	}
 }
 
+// Extra fields are applied one at a time with sjson, so map iteration order
+// would otherwise show up as byte order in the output. Two or more keys are
+// needed to observe it: a single key cannot permute.
+func TestExtraFieldsSorted(t *testing.T) {
+	const expected = `{"a":"hello","b":123,"c":"third","d":true,"m":["second"],"z":1}`
+
+	for range 100 {
+		v := Struct{A: "hello", B: 123}
+		v.SetExtraFields(map[string]any{
+			"z": 1,
+			"c": "third",
+			"m": []string{"second"},
+			"d": true,
+		})
+		bytes, err := json.Marshal(v)
+		if err != nil {
+			t.Fatalf("failed to marshal: %v", err)
+		}
+		if string(bytes) != expected {
+			t.Fatalf("failed to marshal: got %v", string(bytes))
+		}
+	}
+}
+
 func TestExtraFieldsForceOmitted(t *testing.T) {
 	v := Struct{
 		// Testing with the zero value.


### PR DESCRIPTION
## Summary

`param.MarshalWithExtras` applies extra fields to the encoded struct one key at a time with sjson, iterating the map directly. Go randomizes map iteration order, so that order becomes byte order in the request body: the same value serializes to a different byte string on every call, always of the same length.

Anything that hashes or diffs a request body loses here, but the way it surfaced for us was prompt caching. Hit rate on a long chat session fell from ~99% to near zero inside a single tool loop, with nothing happening to the conversation other than appending. The cause was one assistant message carrying both `reasoning_content` and `reasoning_details`: it re-permuted itself every turn and invalidated the provider's cached prefix from that message onward. 200 marshals of that single message produced four distinct 308-byte encodings.

The constant length is what makes this expensive to track down. Token counts, message sizes and payload byte counts are all blind to it, so nothing in the usual metrics moves and only a per-message fingerprint shows anything at all.

## Changes

- Iterate `extras` in sorted key order in `MarshalWithExtras`.
- Add `TestExtraFieldsSorted`. Two or more extra fields are required to observe the permutation, since a single key cannot reorder.

Sorted order also lines up with `encoding/json`, which has always emitted map keys sorted, so structs with extras now behave the way callers expect from the standard library. Structs without extras are unaffected, and there was no stable order to depend on before, so nothing that worked previously changes.

Reproduced on v3.39.0, still present on main (52e95a9).
